### PR TITLE
Add Prediction API sample.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
     "coveralls": "cat ./coverage/lcov.info | node_modules/.bin/coveralls",
     "deps_datastore": "cd datastore && npm i && cd ../..",
     "deps_storage": "cd storage && npm i && cd ../..",
+    "deps_prediction": "cd prediction && npm i && cd ../..",
     "deps_express": "cd appengine/express && npm i && cd ../..",
     "deps_sendgrid": "cd appengine/sendgrid && npm i && cd ../.. && cd computeengine/sendgrid && npm i && cd ../..",
     "deps_memcached": "cd appengine/express-memcached-session && npm i && cd ../..",
     "pretest_geddy": "cd appengine/geddy && npm i geddy; GEDDY_SECRET=config/secrets.json; [[ -f $GEDDY_SECRET ]] || echo '{}' > $GEDDY_SECRET && node node_modules/.bin/geddy gen secret; cd ../..;",
-    "pretest": "npm run deps_datastore && npm run deps_storage && npm run deps_memcached && npm run deps_express && npm run deps_sendgrid && npm run pretest_geddy",
+    "pretest": "npm run deps_datastore && npm run deps_storage && npm run deps_prediction && npm run deps_memcached && npm run deps_express && npm run deps_sendgrid && npm run pretest_geddy",
     "test": "npm run jshint && npm run cover"
   },
   "devDependencies": {

--- a/prediction/hostedmodels.js
+++ b/prediction/hostedmodels.js
@@ -1,0 +1,70 @@
+// Copyright 2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// [START predict]
+var google = require('googleapis');
+var hostedmodels = google.prediction('v1.6').hostedmodels;
+
+function auth (callback) {
+  google.auth.getApplicationDefault(function(err, authClient) {
+    if (err) {
+      return callback(err);
+    }
+    // The createScopedRequired method returns true when running on GAE or a
+    // local developer machine. In that case, the desired scopes must be passed
+    // in manually. When the code is  running in GCE or a Managed VM, the scopes
+    // are pulled from the GCE metadata server.
+    // See https://cloud.google.com/compute/docs/authentication for more
+    // information. 
+    if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+      // Scopes can be specified either as an array or as a single,
+      // space-delimited string. 
+      authClient = authClient.createScoped([
+        'https://www.googleapis.com/auth/prediction'
+      ]);
+    }
+    callback(null, authClient);
+  });
+}
+
+function predict(callback) {
+  auth(function(err, authClient) {
+    if (err) {
+      return callback(err);
+    }
+    // Predict the sentiment for the word "hello". 
+    hostedmodels.predict({
+      auth: authClient,
+      // Project id used for this sample
+      project: '414649711441',
+      hostedModelName: 'sample.sentiment',
+      resource: {
+        input: {
+          // Predict sentiment of the word "hello"
+          csvInstance: ['hello']
+        }
+      }
+    }, callback);
+  });
+}
+// [END predict]
+
+exports.predict = predict;
+
+if (module === require.main) {
+  predict(function (err, result) {
+    console.log(err, result);
+  });
+}

--- a/prediction/package.json
+++ b/prediction/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nodejs-docs-samples-prediction",
+  "description": "Node.js samples for Google Cloud Prediction API.",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache Version 2.0",
+  "scripts": {
+    "hostedmodels": "node hostedmodels.js"
+  },
+  "dependencies": {
+    "googleapis": "^2.1.7"
+  }
+}

--- a/test/prediction/hostedmodels.test.js
+++ b/test/prediction/hostedmodels.test.js
@@ -1,0 +1,42 @@
+// Copyright 2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var assert = require('assert');
+var hostedmodels = require('../../prediction/hostedmodels');
+
+var EXPECTED_RESULT = {
+  kind: 'prediction#output',
+  id: 'sample.sentiment',
+  selfLink: 'https://www.googleapis.com/prediction/v1.6/projects/414649711441' +
+    '/hostedmodels/sample.sentiment/predict',
+  outputLabel: 'positive',
+  outputMulti: [
+    { label: 'positive', score: '0.784671' },
+    { label: 'negative', score: '0.186649' },
+    { label: 'neutral', score: '0.028680' }
+  ]
+};
+
+describe('prediction/hostedmodels', function () {
+  it('should predict', function (done) {
+    hostedmodels.predict(function (err, result) {
+      if (err) {
+        return done(err);
+      }
+      assert.deepEqual(result, EXPECTED_RESULT);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Adding missing Node.js sample for these docs: https://cloud.google.com/prediction/docs/developer-guide#predictionfromappengine