### PR TITLE
Env vars are parsed from app.yaml on local run. Added SERVER_URL to app.yaml

### DIFF
--- a/appengine/parse-server/README.md
+++ b/appengine/parse-server/README.md
@@ -11,19 +11,22 @@ app to [Google App Engine Managed VMs](https://cloud.google.com/appengine).
 1. Setup a MongoDB server. Here are two possible options:
   1. Create a Google Compute Engine virtual machine with [MongoDB pre-installed](https://cloud.google.com/launcher/?q=mongodb).
   1. Use [MongoLab](https://mongolab.com/google/) to create a free MongoDB deployment on Google Cloud Platform.
-
-## Running locally
+  
+## Downloading Files
 
 1. `git clone https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git`
 1. `cd appengine/parse-server`
+
+## Running locally
+
 1. `npm install`
-1. Set the necessary [environment variables](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/appengine/parse-server/server.js#L23).
+1. Set the necessary [environment variables](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/appengine/parse-server/config.json).
 1. `npm start`
 
 ## Deploy
 
-1. Modify `app.yaml` as needed.
-1. `gcloud preview app deploy`
+1. Set the necessary [environment variables](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/appengine/parse-server/config.json).
+1. `npm run deploy`
 
 Refer to the [appengine/README.md](../README.md) file for more instructions on
 running and deploying.

--- a/appengine/parse-server/app.yaml
+++ b/appengine/parse-server/app.yaml
@@ -15,22 +15,6 @@
 runtime: nodejs
 vm: true
 
-env_variables:
-  # Your MongoDB URI, e.g. mongodb://user:password@123.456.78.901:27017/db
-  DATABASE_URI: mongodb://localhost:27017/dev
-  # Absolute path to your cloud code main.js file
-  # CLOUD_PATH: <your-cloud-path>
-  # App id
-  # REQUIRED
-  APP_ID: <your-app-id>
-  # master key
-  # REQUIRED
-  MASTER_KEY: <your-master-key>
-  # file key
-  FILE_KEY: <your-file-key>
-  # Mount path for Parse API
-  PARSE_MOUNT_PATH: /parse
-
 skip_files:
   # Don't deploy node_modules folder
   - ^(.*/)?.*/node_modules/.*$

--- a/appengine/parse-server/config.json
+++ b/appengine/parse-server/config.json
@@ -1,0 +1,9 @@
+{
+  "DATABASE_URI": "mongodb://localhost:27017/dev",
+  "CLOUD_PATH": "./cloud/main.js",
+  "APP_ID": "<your-app-id>",
+  "MASTER_KEY": "<your-master-key>",
+  "FILE_KEY": "<your-file-key>",
+  "PARSE_MOUNT_PATH": "/parse",
+  "SERVER_URL": "<your-server-url>"
+}

--- a/appengine/parse-server/package.json
+++ b/appengine/parse-server/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "express": "^4.13.4",
-    "parse-server": "^2.1.3"
+    "parse-server": "^2.1.3",
+    "nconf": "0.8.4"
   }
 }

--- a/appengine/parse-server/server.js
+++ b/appengine/parse-server/server.js
@@ -16,17 +16,20 @@
 
 // [START app]
 var express = require('express');
+var nconf = require('nconf');
 var ParseServer = require('parse-server').ParseServer;
+
+nconf.argv().env().file({ file: 'config.json' });
 
 var app = express();
 
 var parseServer = new ParseServer({
-  databaseURI: process.env.DATABASE_URI || 'mongodb://localhost:27017/dev',
-  cloud: process.env.CLOUD_PATH || __dirname + '/cloud/main.js',
-  appId: process.env.APP_ID,
-  masterKey: process.env.MASTER_KEY,
-  fileKey: process.env.FILE_KEY,
-  serverURL: process.env.SERVER_URL
+  databaseURI: nconf.get('DATABASE_URI') || 'mongodb://localhost:27017/dev',
+  cloud: nconf.get('CLOUD_PATH') || __dirname + '/cloud/main.js',
+  appId: nconf.get('APP_ID'),
+  masterKey: nconf.get('MASTER_KEY'),
+  fileKey: nconf.get('FILE_KEY'),
+  serverURL: nconf.get('SERVER_URL')
 });
 
 // Mount the Parse API server middleware to /parse


### PR DESCRIPTION
I am at a event and a lot of people want to run Parse Server on App Engine. The env variables are very confusing when running locally. This patch makes it so the variables set in the app.yaml are applied to the local config as well.

It might make sense to have a "LOCAL_DATABASE_URI" as well in app.yaml, so you can run a local database.