### PR TITLE
Add Monitoring Tests

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -6,47 +6,39 @@ Monitoring API to retrieve API data.
 `create_custom_metric.js` demonstrates how to create a custom metric, write a timeseries value to it,
 and read it back.
 
-
 # Run locally
 
 Create local credentials by running the following command and following the oauth2 flow:
 
     gcloud beta auth application-default login
 
-Then to run: 
+Then to run:
 
     npm install
     node list_resources.js <YOUR-PROJECT-ID>
     node create_custom_metric.js <YOUR-PROJECT-ID>
-
 
 ## Running on GCE, GAE, or other environments
 
 On Google App Engine, the credentials should be found automatically.
 
 On Google Compute Engine, the credentials should be found automatically, but require that
-you create the instance with the correct scopes. 
+you create the instance with the correct scopes.
 
     gcloud compute instances create --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/compute.readonly" test-instance
 
-If you did not create the instance with the right scopes, you can still upload a JSON service 
+If you did not create the instance with the right scopes, you can still upload a JSON service
 account and set GOOGLE_APPLICATION_CREDENTIALS as described below.
-
 
 ## Using a Service Account
 
 In non-Google Cloud environments, GCE instances created without the correct scopes, or local
-workstations if the `gcloud beta auth application-default login` command fails, use a Service 
+workstations if the `gcloud beta auth application-default login` command fails, use a Service
 Account by doing the following:
 
 * Go to API Manager -> Credentials
-* Click 'New Credentials', and create a Service Account or [click  here](https://console.cloud.google
-.com/project/_/apiui/credential/serviceaccount)
- Download the JSON for this service account, and set the `GOOGLE_APPLICATION_CREDENTIALS`
- environment variable to point to the file containing the JSON credentials.
-
+* Click 'New Credentials', and create a Service Account or [click  here](https://console.cloud.google.com/project/_/apiui/credential/serviceaccount)
+* Download the JSON for this service account, and set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to point to the file containing the JSON credentials.
 
     export GOOGLE_APPLICATION_CREDENTIALS=~/Downloads/<project-id>-0123456789abcdef.json
-
-
-

--- a/test/monitoring/create_custom_metric.test.js
+++ b/test/monitoring/create_custom_metric.test.js
@@ -1,0 +1,44 @@
+// Copyright 2015-2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var assert = require('assert');
+var customMetricsExample = require('../../monitoring/create_custom_metric');
+
+/** Refactored out to keep lines shorter */
+function getPointValue(timeSeries) {
+  return timeSeries.timeSeries[0].points[0].value.int64Value;
+}
+
+it('should create and read back a custom metric', function (done) {
+  this.timeout(20000);
+  customMetricsExample.main(
+    process.env.GCLOUD_PROJECT,
+    Math.random().toString(36).substring(7),
+    function (err, results) {
+      assert.ifError(err);
+      assert.equal(results.length, 4);
+      // Result of creating metric
+      assert.ok(typeof results[0].name === 'string');
+      // Result of writing time series
+      assert.deepEqual(results[1], {});
+      // Result of reading time series
+      assert.ok(typeof getPointValue(results[2]) === 'string');
+      assert.ok(!isNaN(parseInt(getPointValue(results[2]), 10)));
+      // Result of deleting metric
+      assert.deepEqual(results[3], {});
+      done();
+    }
+  );
+});

--- a/test/monitoring/list_resources.test.js
+++ b/test/monitoring/list_resources.test.js
@@ -1,0 +1,35 @@
+// Copyright 2015-2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var assert = require('assert');
+var listResourcesExample = require('../../monitoring/list_resources');
+
+it('should list a bunch of stuff', function (done) {
+  this.timeout(20000);
+  listResourcesExample.main(
+    process.env.GCLOUD_PROJECT,
+    function (err, results) {
+      assert.ifError(err);
+      assert.equal(results.length, 3);
+      // Monitored resources
+      assert.ok(Array.isArray(results[0].resourceDescriptors));
+      // Metric descriptors
+      assert.ok(Array.isArray(results[1].metricDescriptors));
+      // Time series
+      assert.ok(Array.isArray(results[2].timeSeries));
+      done();
+    }
+  );
+});


### PR DESCRIPTION
@JustinBeckwith @jonparrott 

Unfortunately we have to code freeze these samples until GCP Next is over next week, but feel free to  review at your convenience. 

Had to refactor the main code a bit, since for my custom metric tests, I generate a new custom metric and write one value for it. I made CustomMetrics a class so I could attach the metric name to its state. Not sure if this the most idiomatic way to do it for this repo so let me know.

The tests aren't going to work until the API no longer requires a whitelist. That might be now or very soon (I'll double check), otherwise we can add your test project as an owner of mine.

