### PR TITLE
Bump gcloud requirement to version based on Datastore v1beta3.

### DIFF
--- a/datastore/package.json
+++ b/datastore/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "gcloud": "^0.28.0"
+    "gcloud": "^0.30.3"
   }
 }


### PR DESCRIPTION
Fixes #98.