### PR TITLE
Use correct memcache environment variable. Fixes #123

### DIFF
--- a/appengine/express-memcached-session/app.yaml
+++ b/appengine/express-memcached-session/app.yaml
@@ -15,5 +15,5 @@
 runtime: nodejs
 vm: true
 env_variables:
-  MEMCACHE_URL: localhost:11211
+  MEMCACHE_URL: memcache:11211
 # [END app_yaml]


### PR DESCRIPTION
This uses the correct memcache environment variable in the express-memcached-session example.

Please let me know if there's anything else I need to do. 