### PR TITLE
Update mailjet.js

### DIFF
--- a/computeengine/mailjet.js
+++ b/computeengine/mailjet.js
@@ -18,7 +18,8 @@ var mailer = require('nodemailer');
 var smtp = require('nodemailer-smtp-transport');
 
 var transport = mailer.createTransport(smtp({
-  service: 'Mailjet',
+  host: "in.mailjet.com",
+  port: 2525,
   auth: {
     user: process.env.MAILJET_API_KEY || '<your-mailjet-api-key',
     pass: process.env.MAILJET_API_SECRET || '<your-mailjet-api-secret>'

--- a/computeengine/mailjet.js
+++ b/computeengine/mailjet.js
@@ -18,7 +18,7 @@ var mailer = require('nodemailer');
 var smtp = require('nodemailer-smtp-transport');
 
 var transport = mailer.createTransport(smtp({
-  host: "in.mailjet.com",
+  host: 'in.mailjet.com',
   port: 2525,
   auth: {
     user: process.env.MAILJET_API_KEY || '<your-mailjet-api-key',


### PR DESCRIPTION
configuring this with the nodemailer   {service: "mailjet"} sets the port to 587, which is blocked by the google.  This setup configuration works.