### PR TITLE
Add style section to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,16 @@ accept your pull requests.
 1. The repo owner will respond to your issue promptly.
 1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
 1. Fork the desired repo, develop and test your code changes.
-1. Ensure that your code adheres to the existing style in the sample to which you are contributing. Refer to the
-   [Google Cloud Platform Samples Style Guide](https://github.com/GoogleCloudPlatform/Template/wiki/style.html) for the
-   recommended coding standards for this organization.  You can run `npm run jshint` to match our JavaScript coding standards.
+1. Ensure that your code adheres to the existing style in the sample to which you are contributing.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
 1. Submit a pull request!
+
+## Style
+
+Samples in this repository follow the [JavaScript Semi-Standard
+Style](https://github.com/Flet/semistandard).
+
+You can run `npm run lint` to match our JavaScript coding standards.
 
 ## Sample template
 


### PR DESCRIPTION
I'd like to point https://github.com/GoogleCloudPlatform/Template/wiki/style.html back to the repositories where the samples should go.