### PR TITLE
Update ports for endpoints sample.

### DIFF
--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -1,8 +1,13 @@
+# The Google App Engine Flexible Environment base Docker image can
+# also be used on Google Container Engine, or any other Docker host.
+# This image is based on Debian Jessie and includes nodejs and npm
+# installed from nodejs.org. The source is located in
+# https://github.com/GoogleCloudPlatform/nodejs-docker
 FROM gcr.io/google_appengine/nodejs
 
 ADD . /app
 WORKDIR /app
 
 RUN npm install
-ENV PORT=8081
+ENV PORT=8080
 ENTRYPOINT ["npm", "start"]

--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 8081
     protocol: TCP
     name: http
   selector:
@@ -42,15 +42,15 @@ spec:
       - name: esp
         image: b.gcr.io/endpoints/endpoints-runtime:0.3
         args: [
-          "-p", "8080",
-          "-a", "127.0.0.1:8081",
+          "-p", "8081",
+          "-a", "127.0.0.1:8080",
           "-s", "SERVICE_NAME",
           "-v", "SERVICE_VERSION",
         ]
       # [END esp]
         ports:
-          - containerPort: 8080
-      - name: echo
-        image: gcr.io/google-samples/node-echo:1.0
-        ports:
           - containerPort: 8081
+      - name: echo
+        image: gcr.io/google-samples/echo-node:1.0
+        ports:
+          - containerPort: 8080


### PR DESCRIPTION
Switch ports and name on docker image for Endpoints GKE sample to align with other languages.

`gcr.io/google-samples/echo-node:1.0` is updated and pushed.