### PR TITLE
(fix) Multer options

### DIFF
--- a/appengine/storage/app.js
+++ b/appengine/storage/app.js
@@ -38,7 +38,9 @@ app.set('view engine', 'pug');
 // req.files.
 const multer = Multer({
   storage: Multer.memoryStorage(),
-  fileSize: 5 * 1024 * 1024 // no larger than 5mb, you can change as needed.
+  limits: {
+    fileSize: 5 * 1024 * 1024 // no larger than 5mb, you can change as needed.
+  }
 });
 
 // A bucket is a container for objects (files).


### PR DESCRIPTION
There is no `fileSize` option for multer. (https://github.com/expressjs/multer#multeropts)
`fileSize` option is member of `limits`. (https://github.com/expressjs/multer#limits)