### PR TITLE
Update app.yaml to use instance connection name

### DIFF
--- a/appengine/cloudsql/app.yaml
+++ b/appengine/cloudsql/app.yaml
@@ -21,13 +21,14 @@ env_variables:
   MYSQL_PASSWORD: YOUR_PASSWORD
   MYSQL_DATABASE: YOUR_DATABASE
   # e.g. my-awesome-project:us-central1:my-cloud-sql-instance
-  INSTANCE_CONNECTION_NAME: YOUR_PROJECT_ID:YOUR_REGION:YOUR_INSTANCE_NAME
+  INSTANCE_CONNECTION_NAME: YOUR_INSTANCE_CONNECTION_NAME
 # [END env]
 
 # [START cloudsql_settings]
 beta_settings:
-  # The connection name of your instance on its Overview page in the Google
-  # Cloud Platform Console, or use `YOUR_PROJECT_ID:YOUR_REGION:YOUR_INSTANCE_NAME`
-  cloud_sql_instances: YOUR_PROJECT_ID:YOUR_REGION:YOUR_INSTANCE_NAME
+  # The connection name of your instance, available by using
+  'gcloud beta sql instances describe [INSTANCE_NAME]' or from
+  the Instance details page in the Google Cloud Platform Console.
+  cloud_sql_instances: YOUR_INSTANCE_CONNECTION_NAME
 # [END cloudsql_settings]
 # [END app_yaml]

--- a/appengine/cloudsql/app.yaml
+++ b/appengine/cloudsql/app.yaml
@@ -27,8 +27,8 @@ env_variables:
 # [START cloudsql_settings]
 beta_settings:
   # The connection name of your instance, available by using
-  'gcloud beta sql instances describe [INSTANCE_NAME]' or from
-  the Instance details page in the Google Cloud Platform Console.
+  # 'gcloud beta sql instances describe [INSTANCE_NAME]' or from
+  # the Instance details page in the Google Cloud Platform Console.
   cloud_sql_instances: YOUR_INSTANCE_CONNECTION_NAME
 # [END cloudsql_settings]
 # [END app_yaml]


### PR DESCRIPTION
We're moving towards using instance connection name everywhere. It's also available from gcloud now.