### PR TITLE
Enable auto table creation in Google Cloud Functions SendGrid tutorial

### DIFF
--- a/functions/sendgrid/index.js
+++ b/functions/sendgrid/index.js
@@ -271,10 +271,9 @@ exports.sendgridWebhook = function sendgridWebhook (req, res) {
  */
 function getTable () {
   const dataset = bigquery.dataset(config.DATASET);
-  const options = { autoCreate: true };
 
-  return dataset.get(options)
-    .then(([dataset]) => dataset.table(config.TABLE).get(options));
+  return dataset.get({autoCreate: true})
+    .then(([dataset]) => dataset.table(config.TABLE).get({autoCreate: true}));
 }
 // [END functions_sendgrid_get_table]
 

--- a/functions/sendgrid/index.js
+++ b/functions/sendgrid/index.js
@@ -272,8 +272,8 @@ exports.sendgridWebhook = function sendgridWebhook (req, res) {
 function getTable () {
   const dataset = bigquery.dataset(config.DATASET);
 
-  return dataset.get({autoCreate: true})
-    .then(([dataset]) => dataset.table(config.TABLE).get({autoCreate: true}));
+  return dataset.get({ autoCreate: true })
+    .then(([dataset]) => dataset.table(config.TABLE).get({ autoCreate: true }));
 }
 // [END functions_sendgrid_get_table]
 


### PR DESCRIPTION
`autoCreate` is consumed in `dataset.get` and `table.get` is called with empty option. This behaviour prevents me to create table on the fly.

The log(project/dataset name is masked):

```
E      sendgridLoad     49181714454430  2016-11-25 07:27:35.826  ApiError: Not found: Table the-project-name:the-dataset.events
    at new util.ApiError (/user_code/node_modules/@google-cloud/common/src/util.js:107:10)
    at Object.parseHttpRespBody (/user_code/node_modules/@google-cloud/common/src/util.js:185:30)
    at Object.handleResp (/user_code/node_modules/@google-cloud/common/src/util.js:125:18)
    at /user_code/node_modules/@google-cloud/common/src/util.js:448:12
    at Request.onResponse [as _callback] (/user_code/node_modules/retry-request/index.js:120:7)
    at Request.self.callback (/user_code/node_modules/request/request.js:186:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/user_code/node_modules/request/request.js:1081:10)
    at emitOne (events.js:96:13)
```