### PR TITLE
Removed deprecated flag from app.yaml

### DIFF
--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -12,10 +12,10 @@
 # limitations under the License.
 
 runtime: nodejs
-vm: true
+env: flex
 
 endpoints_api_service:
   # The following values are to be replaced by information from the output of
   # 'gcloud service-management deploy openapi.yaml' command.
-  name: ENDPOINTS SERVICE-NAME
-  config_id: ENDPOINTS CONFIG-ID
+  name: ENDPOINTS-SERVICE-NAME
+  config_id: ENDPOINTS-CONFIG-ID


### PR DESCRIPTION
vm: true is no longer accepted. It is now env: flex