### PR TITLE
Updated readWriteTransaction to fix bug

### DIFF
--- a/spanner/transaction.js
+++ b/spanner/transaction.js
@@ -100,6 +100,7 @@ function readWriteTransaction (instanceId, databaseId) {
   // at a specific point in time
   let transaction, firstBudget, secondBudget;
   const transferAmount = 200000;
+  const minimumAmountToTransfer = 300000;
 
   database.runTransaction()
     .then((results) => {
@@ -126,8 +127,8 @@ function readWriteTransaction (instanceId, databaseId) {
           console.log(`The second album's marketing budget: ${secondBudget}`);
 
           // Makes sure the second album's budget is sufficient
-          if (secondBudget < 300000) {
-            throw new Error(`The second album's budget (${secondBudget}) is less than the minimum required amount of $300,000.`);
+          if (secondBudget < minimumAmountToTransfer) {
+            throw new Error(`The second album's budget (${secondBudget}) is less than the minimum required amount to transfer.`);
           }
         }),
 

--- a/spanner/transaction.js
+++ b/spanner/transaction.js
@@ -126,8 +126,8 @@ function readWriteTransaction (instanceId, databaseId) {
           console.log(`The second album's marketing budget: ${secondBudget}`);
 
           // Makes sure the second album's budget is sufficient
-          if (secondBudget < transferAmount) {
-            throw new Error(`The second album's budget (${secondBudget}) is less than the transfer amount (${transferAmount}).`);
+          if (secondBudget < 300000) {
+            throw new Error(`The second album's budget (${secondBudget}) is less than the minimum required amount of $300,000.`);
           }
         }),
 


### PR DESCRIPTION
Documentation at https://cloud.google.com/spanner/docs/transactions#rw_transaction_example says that second budget should be at least $300,000 for the transaction to proceed. I'm fixing this for Python / Node. Addresses bug #35360945.