### PR TITLE
Fixing non working example with publish

### DIFF
--- a/pubsub/topics.js
+++ b/pubsub/topics.js
@@ -83,13 +83,19 @@ function publishMessage (topicName, data) {
 
   // References an existing topic, e.g. "my-topic"
   const topic = pubsub.topic(topicName);
-
+  
+  // Creates a new Topic Publisher
+  const publisher = topic.publisher()
+  
+  // Creates a new Buffer from data
+  let dataBuffer = new Buffer.from(data)
+  
   // Publishes the message, e.g. "Hello, world!" or { amount: 599.00, status: 'pending' }
-  return topic.publish(data)
+  return publisher.publish(dataBuffer)
     .then((results) => {
-      const messageIds = results[0];
+      const messageIds = results.shift(); // Or results[0] since it returns [ 'ID' ]
 
-      console.log(`Message ${messageIds[0]} published.`);
+      console.log(`Message ${messageIds} published.`);
 
       return messageIds;
     });


### PR DESCRIPTION
Publish example was not working, so I updated it to the new API (because I needed to read the source code to understand this part), so it's easier for us to use the docs.

Here's my code as an example:

> publisher.js
```js
const PubSub = require('@google-cloud/pubsub')
const chalk = require('chalk')

function run () {
  console.log(chalk.bold.cyan('Publishing Message...'))
  return PubSub().topic('my-topic').publisher().publish(new Buffer.from(process.argv.pop()))
    .then((results) => {
      console.log(`Message ${chalk.bold.green(results.shift())} published`)
      return results
    })
    .catch(console.error)
}

run()
```

Use it like `node publisher.js <mydata>`