### PR TITLE
Endpoints sample: use current endpoints-runtime docker image

### DIFF
--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       # [START esp]
       - name: esp
-        image: b.gcr.io/endpoints/endpoints-runtime:0.3
+        image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
           "-p", "8081",
           "-a", "127.0.0.1:8080",


### PR DESCRIPTION
b.gcr.io has been deprecated and shut down

This sample code is being used at https://cloud.google.com/endpoints/docs/openapi/get-started-container-engine#node