### PR TITLE
Fix for the bug: pod error ImagePullBackOff

### DIFF
--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       # [START esp]
       - name: esp
-        image: b.gcr.io/endpoints/endpoints-runtime:0.3
+        image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
           "-p", "8081",
           "-a", "127.0.0.1:8080",


### PR DESCRIPTION
The container registry b.gcr.io has been deprecated. In this bug fix, the deprecated
container registry has been updated to the correct container registry.