### PR TITLE
bigquery-stream-data-nodejs docs - use correct json property to check for errors

### DIFF
--- a/bigquery/tables.js
+++ b/bigquery/tables.js
@@ -415,21 +415,24 @@ function insertRowsAsStream (datasetId, tableId, rows, projectId) {
 
   // Inserts data into a table
   bigquery
-    .dataset(datasetId)
-    .table(tableId)
-    .insert(rows)
-    .then((insertErrors) => {
-      console.log('Inserted:');
+  .dataset(datasetId)
+  .table(tableId)
+  .insert(rows)
+  .then((response) => {
+    const insertErrors = response.insertErrors;
+    if (insertErrors && insertErrors.length > 0) {
+      console.log('start insert errors');
+      insertErrors.forEach((err) => console.error(JSON.stringify(err, null, 2)));
+      console.log('end insert errors');
+    } else {
+      console.log('inserted:');
       rows.forEach((row) => console.log(row));
-
-      if (insertErrors && insertErrors.length > 0) {
-        console.log('Insert errors:');
-        insertErrors.forEach((err) => console.error(err));
-      }
-    })
-    .catch((err) => {
-      console.error('ERROR:', err);
-    });
+      console.log('end inserted');
+    }
+  })
+  .catch((err) => {
+    console.error('Exception:', JSON.stringify(err, null, 2));
+  });
   // [END bigquery_insert_stream]
 }
 


### PR DESCRIPTION
Fix from the documentation here:

https://cloud.google.com/bigquery/streaming-data-into-bigquery#bigquery-stream-data-nodejs

- name json correctly and then use the correct child value to check for errors
- also log in a way that doesn't matter if you read logs top down or bottom up (i.e. firebase function logs vs cmd line)
- use JSON.stringify for more readable output

paired with @ouchadam