### PR TITLE
Keeping user costs low

### DIFF
--- a/appengine/hello-world/app.yaml
+++ b/appengine/hello-world/app.yaml
@@ -14,4 +14,16 @@
 # [START app_yaml]
 runtime: nodejs
 env: flex
+
+# This sample incurs costs to run on the App Engine flexible environment. 
+# The settings below are to reduce costs during testing and are not appropriate
+# for production use. For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 10
+
 # [END app_yaml]


### PR DESCRIPTION
We've gotten reports of unexpected costs from users that left the hello world running and had two standard instances running for a month. This keeps the costs to a minimum to kick the tires.