### PR TITLE
Use SERVICE_CONFIG_ID

### DIFF
--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port", "8081",
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
-          "--version", "SERVICE_VERSION",
+          "--version", "SERVICE_CONFIG_ID",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
To be consistent with the docs and the version of this file in the other language repos, use SERVICE_CONFIG_ID.