### PR TITLE
Update sample to include an example of gRPC HTTP/JSON transcoding setup.

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -35,14 +35,18 @@ To update `gcloud`, use the `gcloud components update` command.
 
 1. Compile the proto file using protoc.
 ```
-$ protoc --include_imports --include_source_info protos/helloworld.proto --descriptor_set_out out.pb
+$ protoc \
+    --include_imports \
+    --include_source_info \
+    protos/helloworld.proto \
+    --descriptor_set_out api.pb
 ```
 
 1. In `api_config.yaml`, replace `MY_PROJECT_ID` and `SERVICE-ACCOUNT-ID` with your Project ID and your service account's email address respectively.
 
 1. Deploy your service's configuration to Endpoints. Take note of your service's config ID and name once the deployment completes.
 ```
-$ gcloud service-management deploy out.pb api_config.yaml
+$ gcloud service-management deploy api.pb api_config.yaml
 ...
 Service Configuration [SERVICE_CONFIG_ID] uploaded for service [SERVICE_NAME]
 ```
@@ -68,18 +72,20 @@ $ sudo apt-get install docker.io
 
 1. Using the SSH connection to your instance, initialize the required Docker images in the order specified below. Replace `[YOUR_GCLOUD_PROJECT]`, `[YOUR_SERVICE_NAME]` and `[YOUR_SERVICE_CONFIG_ID]` with your GCloud Project ID, your service's name and your service's config ID respectively.
 ```
-$ sudo docker run -d --name=helloworld gcr.io/[YOUR_GCLOUD_PROJECT]/endpoints-example:1.0
+$ sudo docker run --detach --name=helloworld gcr.io/[YOUR_GCLOUD_PROJECT]/endpoints-example:1.0
 ```
 
 ```
-$ sudo docker run --detach --name=esp \
-    -p 80:9000 \
+$ sudo docker run \
+    --detach \
+    --name=esp \
+    --publish=80:9000 \
     --link=helloworld:helloworld \
     gcr.io/endpoints-release/endpoints-runtime:1 \
-    -s [YOUR_SERVICE_NAME] \
-    -v [YOUR_SERVICE_CONFIG_ID] \
-    -P 9000 \
-    -a grpc://helloworld:50051
+    --service=[YOUR_SERVICE_NAME] \
+    --version=[YOUR_SERVICE_CONFIG_ID] \
+    --http2_port=9000 \
+    --backend=grpc://helloworld:50051
 ```
 
 1. On your local machine, use the client to test your Endpoints deployment. Replace `[YOUR_INSTANCE_IP_ADDRESS]` with your instance's external IP address, and `[YOUR_API_KEY]` with a [valid Google Cloud Platform API key][gcp_api_key].
@@ -134,6 +140,52 @@ You can use the included client to test your Endpoints deployment.
     $ node client.js -h [YOUR_CLUSTER_IP_ADDRESS]:80 -j [YOUR_JWT_AUTHTOKEN]
     ```
 
+## gRPC HTTP/JSON Transcoding
+
+In order to enable HTTP/JSON transcoding, use the `protos/http_helloworld.proto` definition and the `http_deployment.yaml` Kubernetes deployment.
+
+1. In order to compile the gRPC definition with HTTP annotations, you need a copy of the [googleapis][googleapis] proto definitions.
+
+```
+$ GOOGLEAPIS=...
+$ git clone https://github.com/googleapis/googleapis $GOOGLEAPIS
+```
+
+1. Compile the gRPC definition with HTTP annotations:
+
+```
+$ protoc \
+    --proto_path=protos \
+    --proto_path=$GOOGLEAPIS \
+    --include_imports \
+    --include_source_info \
+    --descriptor_set_out api.pb \
+    helloworld.proto
+```
+
+1. Deploy the API definition with HTTP annotations:
+
+```
+$ gcloud endpoints services deploy api.pb api_config.yaml
+
+Service Configuration [SERVICE_CONFIG_ID] uploaded for service [SERVICE_NAME]
+```
+
+1. Deploy the Endpoints Proxy (ESP) with the HTTP 1.1 port enabled.
+Make sure to update the content of `http_deployment.yaml` and replace the placeholder `[SERVICE_NAME]`, `[SERVICE_CONFIG_ID]` and `[GCLOUD_PROJECT]`.
+```
+$ kubectl apply -f http_deployment.yaml
+```
+
+1. Test the HTTP 1.1 Transcoding interface
+
+```
+$ curl "http://[SERVICE_IP_ADDRESS]/v1/sayHello?key=${API_KEY}&name=World"
+
+{"message":"Hello World"}
+```
+
+
 ## Cleanup
 If you do not intend to use the resources you created for this tutorial in the future, delete your [VM instances][console_gce_instances] and/or [container clusters][console_gke_instances] to prevent additional charges.
 
@@ -151,6 +203,7 @@ If those suggestions don't solve your problem, please [let us know][github_issue
 [gcp_api_key]: https://support.google.com/cloud/answer/6158862?hl=en
 [github_issues]: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/issues
 [github_pulls]: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pulls
+[googleapis]: https://github.com/googleapis/googleapis
 [console_gce_instances]: https://console.cloud.google.com/compute/instances
 [console_gce_create]: https://console.cloud.google.com/compute/instancesAdd
 [console_gke_instances]: https://console.cloud.google.com/kubernetes/list

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -46,7 +46,7 @@ $ protoc \
 
 1. Deploy your service's configuration to Endpoints. Take note of your service's config ID and name once the deployment completes.
 ```
-$ gcloud service-management deploy api.pb api_config.yaml
+$ gcloud endpoints services deploy api.pb api_config.yaml
 ...
 Service Configuration [SERVICE_CONFIG_ID] uploaded for service [SERVICE_NAME]
 ```

--- a/endpoints/getting-started-grpc/http_deployment.yaml
+++ b/endpoints/getting-started-grpc/http_deployment.yaml
@@ -19,9 +19,13 @@ metadata:
 spec:
   ports:
   - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http1
+  - port: 443
     targetPort: 9000
     protocol: TCP
-    name: http
+    name: grpc
   selector:
     app: grpc-hello
   type: LoadBalancer
@@ -41,12 +45,14 @@ spec:
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
+          "--http_port=8080",
           "--http2_port=9000",
           "--backend=grpc://127.0.0.1:50051",
           "--service=SERVICE_NAME",
           "--version=SERVICE_CONFIG_ID",
         ]
         ports:
+          - containerPort: 8080
           - containerPort: 9000
       - name: node-grpc-hello
         image: gcr.io/GCLOUD_PROJECT/endpoints-example:1.0

--- a/endpoints/getting-started-grpc/protos/http_helloworld.proto
+++ b/endpoints/getting-started-grpc/protos/http_helloworld.proto
@@ -1,0 +1,59 @@
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+import "google/api/annotations.proto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/sayHello"
+    };
+  }
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
 - Add `http_helloworld.proto` gRPC definition with HTTP transcoding.
 - Add `http_deployment.yaml` kubernetes deployment with HTTP1.1 port
   enabled for transcoding.
 - Update README accordingly.
 - Update README with long-flags everywhere.