### PR TITLE
Change to endpoints managed rollout

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -44,15 +44,18 @@ $ protoc \
 
 1. In `api_config.yaml`, replace `MY_PROJECT_ID` and `SERVICE-ACCOUNT-ID` with your Project ID and your service account's email address respectively.
 
-1. Deploy your service's configuration to Endpoints. 
+1. Deploy your service's configuration to Endpoints. Take note of your service's name once the deployment completes.
 ```
 $ gcloud endpoints services deploy api.pb api_config.yaml
 ...
+
 ```
 
 1. Build a Docker image for later use using the following command. Make sure to replace `[YOUR_PROJECT_ID]` with your Project ID.
 ```
 $ gcloud container builds submit --tag gcr.io/[YOUR_PROJECT_ID]/endpoints-example:1.0 .
+...
+Service Configuration [SERVICE_CONFIG_ID] uploaded for service [SERVICE_NAME]
 ```
 
 ### Running your service
@@ -106,7 +109,7 @@ $ gcloud components install kubectl
 $ gcloud container clusters get-credentials [YOUR_CLUSTER_NAME] --zone [YOUR_CLUSTER_ZONE]
 ```
 
-1. Edit the `container_engine.yaml` file, and replace `GCLOUD_PROJECT` and `SERVICE_NAME` with your Project ID and your Endpoints service's name.
+1. Edit the `container_engine.yaml` file, and replace `GCLOUD_PROJECT` and `SERVICE_NAME` with your GCloud Project ID and your service's name.
 
 1. Add a [Kubernetes service][docs_k8s_services] to the cluster you created. Note that Kubernetes services should not be confused with [Endpoints services][docs_endpoints_services].
 ```

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -44,11 +44,10 @@ $ protoc \
 
 1. In `api_config.yaml`, replace `MY_PROJECT_ID` and `SERVICE-ACCOUNT-ID` with your Project ID and your service account's email address respectively.
 
-1. Deploy your service's configuration to Endpoints. Take note of your service's config ID and name once the deployment completes.
+1. Deploy your service's configuration to Endpoints. 
 ```
 $ gcloud endpoints services deploy api.pb api_config.yaml
 ...
-Service Configuration [SERVICE_CONFIG_ID] uploaded for service [SERVICE_NAME]
 ```
 
 1. Build a Docker image for later use using the following command. Make sure to replace `[YOUR_PROJECT_ID]` with your Project ID.
@@ -70,7 +69,7 @@ $ sudo apt-get update
 $ sudo apt-get install docker.io
 ```
 
-1. Using the SSH connection to your instance, initialize the required Docker images in the order specified below. Replace `[YOUR_GCLOUD_PROJECT]`, `[YOUR_SERVICE_NAME]` and `[YOUR_SERVICE_CONFIG_ID]` with your GCloud Project ID, your service's name and your service's config ID respectively.
+1. Using the SSH connection to your instance, initialize the required Docker images in the order specified below. Replace `[YOUR_GCLOUD_PROJECT]` and `[YOUR_SERVICE_NAME]` with your GCloud Project ID and your service's name respectively.
 ```
 $ sudo docker run --detach --name=helloworld gcr.io/[YOUR_GCLOUD_PROJECT]/endpoints-example:1.0
 ```
@@ -83,7 +82,7 @@ $ sudo docker run \
     --link=helloworld:helloworld \
     gcr.io/endpoints-release/endpoints-runtime:1 \
     --service=[YOUR_SERVICE_NAME] \
-    --version=[YOUR_SERVICE_CONFIG_ID] \
+    --rollout_strategy=managed \
     --http2_port=9000 \
     --backend=grpc://helloworld:50051
 ```
@@ -107,7 +106,7 @@ $ gcloud components install kubectl
 $ gcloud container clusters get-credentials [YOUR_CLUSTER_NAME] --zone [YOUR_CLUSTER_ZONE]
 ```
 
-1. Edit the `container_engine.yaml` file, and replace `GCLOUD_PROJECT`, `SERVICE_NAME`, and `SERVICE_CONFIG` with your Project ID and your Endpoints service's name and config ID respectively.
+1. Edit the `container_engine.yaml` file, and replace `GCLOUD_PROJECT` and `SERVICE_NAME` with your Project ID and your Endpoints service's name.
 
 1. Add a [Kubernetes service][docs_k8s_services] to the cluster you created. Note that Kubernetes services should not be confused with [Endpoints services][docs_endpoints_services].
 ```
@@ -168,11 +167,10 @@ $ protoc \
 ```
 $ gcloud endpoints services deploy api.pb api_config.yaml
 
-Service Configuration [SERVICE_CONFIG_ID] uploaded for service [SERVICE_NAME]
 ```
 
 1. Deploy the Endpoints Proxy (ESP) with the HTTP 1.1 port enabled.
-Make sure to update the content of `http_deployment.yaml` and replace the placeholder `[SERVICE_NAME]`, `[SERVICE_CONFIG_ID]` and `[GCLOUD_PROJECT]`.
+Make sure to update the content of `http_deployment.yaml` and replace the placeholder `[SERVICE_NAME]` and `[GCLOUD_PROJECT]`.
 ```
 $ kubectl apply -f http_deployment.yaml
 ```

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           "--http2_port=9000",
           "--backend=grpc://127.0.0.1:50051",
           "--service=SERVICE_NAME",
-          "--version=SERVICE_CONFIG_ID",
+          "--rollout_strategy=managed",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started-grpc/http_deployment.yaml
+++ b/endpoints/getting-started-grpc/http_deployment.yaml
@@ -49,7 +49,7 @@ spec:
           "--http2_port=9000",
           "--backend=grpc://127.0.0.1:50051",
           "--service=SERVICE_NAME",
-          "--version=SERVICE_CONFIG_ID",
+          "--rollout_strategy=managed",
         ]
         ports:
           - containerPort: 8080

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -19,5 +19,5 @@ endpoints_api_service:
   # The following values are to be replaced by information from the output of
   # 'gcloud endpoints services deploy openapi-appengine.yaml' command.
   name: ENDPOINTS-SERVICE-NAME
-  config_id: ENDPOINTS-CONFIG-ID
+  rollout_strategy: managed
 # [END configuration]

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port", "8081",
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
-          "--version", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**