### PR TITLE
Fix link for prerequisites

### DIFF
--- a/functions/helloworld/README.md
+++ b/functions/helloworld/README.md
@@ -16,7 +16,7 @@ See the [Cloud Functions Hello World tutorial][tutorial].
 
 ## Run the tests
 
-1. Read and follow the [prerequisites](../../#how-to-run-the-tests).
+1. Read and follow the [prerequisites](../../../../#prerequisites).
 
 1. Install dependencies:
 


### PR DESCRIPTION
This fixes issue https://github.com/GoogleCloudPlatform/nodejs-docs-samples/issues/586