### PR TITLE
Fix busboy sample not working on GCF

### DIFF
--- a/functions/http/index.js
+++ b/functions/http/index.js
@@ -182,7 +182,7 @@ exports.uploadFile = (req, res) => {
       res.send();
     });
 
-    req.pipe(busboy);
+    busboy.end(req.rawBody);
   } else {
     // Return a "method not allowed" error
     res.status(405).end();


### PR DESCRIPTION
**Note:** this change breaks the `uploadFile` sample in the Emulator (where `req.pipe(busboy)` is correct). @jmdobry can you investigate?

**Do not merge** until we've resolved this issue in both GCF itself and the Emulator.