### PR TITLE
Move description from docs into code sample

### DIFF
--- a/functions/helloworld/index.js
+++ b/functions/helloworld/index.js
@@ -56,6 +56,8 @@ exports.helloBackground = (event, callback) => {
 // [START functions_helloworld_pubsub]
 /**
  * Background Cloud Function to be triggered by Pub/Sub.
+ * This function is exported by index.js, and executed when
+ * the trigger topic receives a message.
  *
  * @param {object} event The Cloud Functions event.
  * @param {function} callback The callback function.


### PR DESCRIPTION
As part of making the GCF docs language-agnostic, we are removing language-specific comments from the text and putting them into the code samples instead as code comments.