### PR TITLE
Add missing lint dependency

### DIFF
--- a/appengine/analytics/package.json
+++ b/appengine/analytics/package.json
@@ -24,7 +24,8 @@
     "got": "8.2.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "2.2.1"
+    "@google-cloud/nodejs-repo-tools": "2.2.1",
+    "semistandard": "^12.0.1"
   },
   "cloud-repo-tools": {
     "test": {

--- a/appengine/datastore/package.json
+++ b/appengine/datastore/package.json
@@ -24,7 +24,8 @@
     "express": "4.16.2"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "2.2.1"
+    "@google-cloud/nodejs-repo-tools": "2.2.1",
+    "semistandard": "^12.0.1"
   },
   "cloud-repo-tools": {
     "test": {


### PR DESCRIPTION
`npm test`, which runs the linter, needs this dependency explicitly. 

We install `semistandard` manually on CircleCi. But since it's required in a sample's `run test`, it should be in the `package.json`. 