### PR TITLE
Add Kokoro config for appengine-datastore

### DIFF
--- a/.kokoro/appengine-datastore.cfg
+++ b/.kokoro/appengine-datastore.cfg
@@ -1,0 +1,10 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/nodejs-docs-samples"
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/nodejs-docs-samples/.kokoro/appengine-datastore.sh"
+}

--- a/.kokoro/appengine-datastore.sh
+++ b/.kokoro/appengine-datastore.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export GCLOUD_PROJECT=nodejs-docs-samples-tests
+STAGE_BUCKET=$GCLOUD_PROJECT
+GCP_REGION=us-central1
+
+export NODE_ENV=development
+export GAE_VERSION=appengine-datastore-flexible
+
+# Register post-test cleanup
+function cleanup {
+  CODE=$?
+
+  gcloud app versions delete $GAE_VERSION --quiet
+  if [ -e "worker.yaml" ]; then
+    gcloud app versions delete ${GAE_VERSION}-worker --quiet
+  fi
+}
+trap cleanup EXIT
+set -e;
+
+cd github/nodejs-docs-samples/appengine/datastore
+
+# Install dependencies
+npm install
+
+# Configure gcloud
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
+gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+gcloud config set project $GCLOUD_PROJECT
+
+
+# Deploy the app
+gcloud app deploy app.flexible.yaml --version $GAE_VERSION --no-promote --quiet
+if [ -e "worker.yaml" ]; then
+  gcloud app deploy worker.yaml --version ${GAE_VERSION} --no-promote --quiet
+fi
+
+
+# Test the deployed app
+npm test
+
+# Exit on error
+if [[ $CODE -ne 0 ]]; then
+  exit $CODE
+fi


### PR DESCRIPTION
First config for Kokoro. Once everything works I'll make it configurable so the build file can be used for all AppEngine tests.