### PR TITLE
Use gcloud functions beta

### DIFF
--- a/.kokoro/appengine-datastore.sh
+++ b/.kokoro/appengine-datastore.sh
@@ -43,7 +43,7 @@ gcloud config set project $GCLOUD_PROJECT
 # Deploy the app
 gcloud app deploy app.flexible.yaml --version $GAE_VERSION --no-promote --quiet
 if [ -e "worker.yaml" ]; then
-  gcloud app deploy worker.yaml --version ${GAE_VERSION} --no-promote --quiet
+  gcloud app deploy worker.yaml --version ${GAE_VERSION}-worker --no-promote --quiet
 fi
 
 

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "repo-tools lint",
     "pretest": "npm run lint",
-    "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
+    "e2e-test": "export FUNCTIONS_CMD='gcloud beta functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
     "test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose -c 1 test/index.test.js test/*unit*test.js test/*integration*test.js",
     "system-test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose test/*.test.js"
   },


### PR DESCRIPTION
Kokoro CI has the following error:

ERROR: (gcloud) Invalid choice: 'functions'.
This command is available in one or more alternate release tracks.  Try:
  gcloud alpha functions
  gcloud beta functions

Drive-by fix: delete the correct appengine version in cleanup.