### PR TITLE
No need to await for the browser to be closed to send back the screenshot

### DIFF
--- a/appengine/headless-chrome/app.js
+++ b/appengine/headless-chrome/app.js
@@ -35,7 +35,7 @@ app.use(async (req, res) => {
   const page = await browser.newPage();
   await page.goto(url);
   const imageBuffer = await page.screenshot();
-  await browser.close();
+  browser.close();
 
   res.set('Content-Type', 'image/png');
   res.send(imageBuffer);


### PR DESCRIPTION
Awaiting for the headless browser to be closed add a certain amount of time to the duration of the request, although the image is already ready to be sent back to the user.

/cc @steren 