### PR TITLE
No need for the --disable-setuid-sandbox flag

### DIFF
--- a/appengine/headless-chrome/app.js
+++ b/appengine/headless-chrome/app.js
@@ -29,7 +29,7 @@ app.use(async (req, res) => {
 
   // [START browser]
   const browser = await puppeteer.launch({
-    args: ['--no-sandbox', '--disable-setuid-sandbox']
+    args: ['--no-sandbox']
   });
   // [END browser]
   const page = await browser.newPage();


### PR DESCRIPTION
It seems the --disable-setuid-sandbox flag is becoming deprecating and is being removed from the Chrome codebase.
I tried running the sample without this flag, and the screenshots are properly generated.

/cc @steren 