### PR TITLE
Fix kokoro config

### DIFF
--- a/.kokoro/appengine/test-deployment/common.cfg
+++ b/.kokoro/appengine/test-deployment/common.cfg
@@ -20,10 +20,3 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-docs-samples/.kokoro/build-with-appengine.sh"
 }
-
-
-# Used in `gcloud app deploy ${APPENGINE_ENVIRONMENT}.yaml
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "app"
-}

--- a/.kokoro/appengine/test-deployment/hello-world-flex.cfg
+++ b/.kokoro/appengine/test-deployment/hello-world-flex.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/hello-world/flexible"
 }
+
+# flexible or standard
+env_vars: {
+    key: "APPENGINE_ENVIRONMENT"
+    value: "flexible"
+}

--- a/.kokoro/appengine/test-deployment/hello-world-standard.cfg
+++ b/.kokoro/appengine/test-deployment/hello-world-standard.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/hello-world/standard"
 }
+
+# flexible or standard
+env_vars: {
+    key: "APPENGINE_ENVIRONMENT"
+    value: "standard"
+}

--- a/.kokoro/appengine/test-deployment/metadata-flex.cfg
+++ b/.kokoro/appengine/test-deployment/metadata-flex.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/metadata/flexible"
 }
+
+# flexible or standard
+env_vars: {
+    key: "APPENGINE_ENVIRONMENT"
+    value: "flexible"
+}

--- a/.kokoro/appengine/test-deployment/metadata-standard.cfg
+++ b/.kokoro/appengine/test-deployment/metadata-standard.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/metadata/standard"
 }
+
+# flexible or standard
+env_vars: {
+    key: "APPENGINE_ENVIRONMENT"
+    value: "standard"
+}

--- a/.kokoro/appengine/test-deployment/storage-flex.cfg
+++ b/.kokoro/appengine/test-deployment/storage-flex.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/storage/flexible"
 }
+
+# flexible or standard
+env_vars: {
+    key: "APPENGINE_ENVIRONMENT"
+    value: "flexible"
+}

--- a/.kokoro/appengine/test-deployment/storage-standard.cfg
+++ b/.kokoro/appengine/test-deployment/storage-standard.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/storage/standard"
 }
+
+# flexible or standard
+env_vars: {
+    key: "APPENGINE_ENVIRONMENT"
+    value: "standard"
+}

--- a/.kokoro/build-with-appengine.sh
+++ b/.kokoro/build-with-appengine.sh
@@ -48,7 +48,7 @@ gcloud config set project $GCLOUD_PROJECT
 
 
 # Deploy the app
-gcloud app deploy ${APPENGINE_ENVIRONMENT}.yaml --version $GAE_VERSION --no-promote --quiet
+gcloud app deploy --version $GAE_VERSION --no-promote --quiet
 if [ -e "worker.yaml" ]; then
   gcloud app deploy worker.yaml --version ${GAE_VERSION} --no-promote --quiet
 fi


### PR DESCRIPTION
Allowed values are standard and flexible. Use them for the version string.

Always deploy app.yaml, so don't specify it.