### PR TITLE
Use valid format for App Engine version string

### DIFF
--- a/.kokoro/appengine/test-deployment/hello-world-flex.cfg
+++ b/.kokoro/appengine/test-deployment/hello-world-flex.cfg
@@ -5,9 +5,3 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/hello-world/flexible"
 }
-
-# flexible or standard
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "flexible"
-}

--- a/.kokoro/appengine/test-deployment/hello-world-standard.cfg
+++ b/.kokoro/appengine/test-deployment/hello-world-standard.cfg
@@ -5,9 +5,3 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/hello-world/standard"
 }
-
-# flexible or standard
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "standard"
-}

--- a/.kokoro/appengine/test-deployment/metadata-flex.cfg
+++ b/.kokoro/appengine/test-deployment/metadata-flex.cfg
@@ -5,9 +5,3 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/metadata/flexible"
 }
-
-# flexible or standard
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "flexible"
-}

--- a/.kokoro/appengine/test-deployment/metadata-standard.cfg
+++ b/.kokoro/appengine/test-deployment/metadata-standard.cfg
@@ -5,9 +5,3 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/metadata/standard"
 }
-
-# flexible or standard
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "standard"
-}

--- a/.kokoro/appengine/test-deployment/storage-flex.cfg
+++ b/.kokoro/appengine/test-deployment/storage-flex.cfg
@@ -5,9 +5,3 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/storage/flexible"
 }
-
-# flexible or standard
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "flexible"
-}

--- a/.kokoro/appengine/test-deployment/storage-standard.cfg
+++ b/.kokoro/appengine/test-deployment/storage-standard.cfg
@@ -5,9 +5,3 @@ env_vars: {
     key: "PROJECT"
     value: "appengine/storage/standard"
 }
-
-# flexible or standard
-env_vars: {
-    key: "APPENGINE_ENVIRONMENT"
-    value: "standard"
-}

--- a/.kokoro/build-with-appengine.sh
+++ b/.kokoro/build-with-appengine.sh
@@ -24,7 +24,7 @@ gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS
 gcloud config set project $GCLOUD_PROJECT
 
 export NODE_ENV=development
-export GAE_VERSION=doc-sample-${PROJECT}-${APPENGINE_ENVIRONMENT}
+export GAE_VERSION=doc-sample-$(echo $PROJECT | sed 's_/_-_g')
 
 # Register post-test cleanup
 function cleanup {


### PR DESCRIPTION
argument --version/-v: Bad value
[doc-sample-appengine/hello-world/standard-standard]: May only contain
lowercase letters, digits, and hyphens. Must begin and end with a
letter or digit. Must not exceed 63 characters.

I'll delete `APPENGINE_ENVIRONMENT` from the list of allowed environment variables in the matching job configs. 