### PR TITLE
[KMS] Generalizing KMS samples for GCS docs

### DIFF
--- a/kms/keys.js
+++ b/kms/keys.js
@@ -747,8 +747,8 @@ function addMemberToCryptoKeyPolicy (projectId, locationId, keyRingId, cryptoKey
   // Your Google Cloud Platform project ID
   // const projectId = 'YOUR_PROJECT_ID';
 
-  // The location of the crypto key's key ring, e.g. "global"
-  // const locationId = 'global';
+  // The location of the crypto key's key ring
+  // const locationId = 'my-key-ring-location';
 
   // The name of the crypto key's key ring, e.g. "my-key-ring"
   // const keyRingId = 'my-key-ring';


### PR DESCRIPTION
Hi, 

I'm removing global location mention to generalize sample for GCS CMEK documentation. The sample is used to show developers how to set an IAM policy on a KMS key, but global location aren't supported so I' want to generalize that part of the sample.

PTAL, thank you!