### PR TITLE
Missing handler for the app.js

### DIFF
--- a/appengine/hello-world/standard/app.yaml
+++ b/appengine/hello-world/standard/app.yaml
@@ -13,4 +13,7 @@
 
 # [START gae_quickstart_yaml]
 runtime: nodejs8
+handlers:
+- url: /.*
+  script: app.js
 # [END gae_quickstart_yaml]


### PR DESCRIPTION
`gcloud app deploy`
did not run without adding the handler