### PR TITLE
Fix docs — config.socketPath should be config.host

### DIFF
--- a/functions/sql/index.js
+++ b/functions/sql/index.js
@@ -85,7 +85,7 @@ const pgConfig = {
 };
 
 if (process.env.NODE_ENV === 'production') {
-  pgConfig.socketPath = `/cloudsql/${connectionName}`;
+  pgConfig.host = `/cloudsql/${connectionName}`;
 }
 
 // Connection pools reuse connections between invocations,


### PR DESCRIPTION
It's not well documented, but the correct option for using node-postgres with a Unix socket is `host`, not `socketPath`: https://github.com/brianc/node-postgres/issues/16#issuecomment-327626885