### PR TITLE
Remove engine.node in Standard Hello World

### DIFF
--- a/appengine/hello-world/standard/package.json
+++ b/appengine/hello-world/standard/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
-  "engines": {
-    "node": "8.x.x"
-  },
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",


### PR DESCRIPTION
No need to pin to a Node version for a Hello World.
This will make the sample forward compatible with Node 10