### PR TITLE
Correcting function name to match README.md

### DIFF
--- a/functions/uuid/index.js
+++ b/functions/uuid/index.js
@@ -19,7 +19,7 @@
 const uuid = require('uuid');
 
 // Return a newly generated UUID in the HTTP response.
-exports.getUuid = (req, res) => {
+exports.uuid = (req, res) => {
   res.send(uuid.v4());
 };
 // [END functions_uuid]


### PR DESCRIPTION
README.md invokes a function named `uuid` bug the function in index.js has getUuid which is wrong.