### PR TITLE
Proper setup for local testing of hello world

### DIFF
--- a/functions/helloworld/README.md
+++ b/functions/helloworld/README.md
@@ -18,9 +18,22 @@ See the [Cloud Functions Hello World tutorial][tutorial].
 
 1. Read and follow the [prerequisites](../../../../#prerequisites).
 
+1. Install [Google Cloud Functions Emulator][https://github.com/GoogleCloudPlatform/cloud-functions-emulator] globally, and then run it
+
+        npm install -g @google-cloud/functions-emulator
+        functions start
+
 1. Install dependencies:
 
         npm install
+
+1. Set the following environment variables, note GCF_REGION is the default for the Cloud Functions Emulator.
+
+        GCLOUD_PROJECT
+        GCF_REGION=us-central1
+        FUNCTIONS_TOPIC
+        FUNCTIONS_BUCKET
+        GOOGLE_APPLICATION_CREDENTIALS
 
 1. Run the tests:
 

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -24,7 +24,6 @@
     "safe-buffer": "5.1.1"
   },
   "devDependencies": {
-    "@google-cloud/functions-emulator": "^1.0.0-beta.5",
     "@google-cloud/nodejs-repo-tools": "^2.2.5",
     "@google-cloud/pubsub": "^0.17.0",
     "@google-cloud/storage": "^1.5.0",
@@ -42,9 +41,10 @@
     "requiresProjectId": true,
     "requiredEnvVars": [
       "BASE_URL",
+      "GCLOUD_PROJECT",
       "GCF_REGION",
-      "TOPIC",
-      "BUCKET",
+      "FUNCTIONS_TOPIC",
+      "FUNCTIONS_BUCKET",
       "FUNCTIONS_CMD"
     ]
   }


### PR DESCRIPTION
There are a few changes required for this project to properly test on a local machine. The big one was to remove the dev dependency for `@google-cloud/functions-emulator` because it should be installed globally.

Tested with 6.14.4.