### PR TITLE
OCR sample: add cross-version support

### DIFF
--- a/functions/ocr/app/index.js
+++ b/functions/ocr/app/index.js
@@ -108,11 +108,11 @@ function renameImageForSave (filename, lang) {
  * a file is uploaded to the Cloud Storage bucket you created
  * for uploading images.
  *
- * @param {object} event The Cloud Functions event.
- * @param {object} event.data A Google Cloud Storage File object.
+ * @param {object} event.data (Node 6) A Google Cloud Storage File object.
+ * @param {object} event (Node 8+) A Google Cloud Storage File object.
  */
 exports.processImage = (event) => {
-  let file = event.data;
+  let file = event.data || event;
 
   return Promise.resolve()
     .then(() => {
@@ -143,14 +143,14 @@ exports.processImage = (event) => {
  * by the TRANSLATE_TOPIC value in the config.json file. The
  * function translates text using the Google Translate API.
  *
- * @param {object} event The Cloud Functions event.
- * @param {object} event.data The Cloud Pub/Sub Message object.
- * @param {string} event.data.data The "data" property of the Cloud Pub/Sub
+ * @param {object} event.data (Node 6) The Cloud Pub/Sub Message object.
+ * @param {object} event (Node 8+) The Cloud Pub/Sub Message object.
+ * @param {string} {messageObject}.data The "data" property of the Cloud Pub/Sub
  * Message. This property will be a base64-encoded string that you must decode.
  */
 exports.translateText = (event) => {
-  const pubsubMessage = event.data;
-  const jsonStr = Buffer.from(pubsubMessage.data, 'base64').toString();
+  const pubsubData = event.data.data || event.data;
+  const jsonStr = Buffer.from(pubsubData, 'base64').toString();
   const payload = JSON.parse(jsonStr);
 
   return Promise.resolve()
@@ -195,14 +195,14 @@ exports.translateText = (event) => {
  * by the RESULT_TOPIC value in the config.json file. The
  * function saves the data packet to a file in GCS.
  *
- * @param {object} event The Cloud Functions event.
- * @param {object} event.data The Cloud Pub/Sub Message object.
- * @param {string} event.data.data The "data" property of the Cloud Pub/Sub
+ * @param {object} event.data (Node 6) The Cloud Pub/Sub Message object.
+ * @param {object} event (Node 8+) The Cloud Pub/Sub Message object.
+ * @param {string} {messageObject}.data The "data" property of the Cloud Pub/Sub
  * Message. This property will be a base64-encoded string that you must decode.
  */
 exports.saveResult = (event) => {
-  const pubsubMessage = event.data;
-  const jsonStr = Buffer.from(pubsubMessage.data, 'base64').toString();
+  const pubsubData = event.data.data || event.data;
+  const jsonStr = Buffer.from(pubsubData, 'base64').toString();
   const payload = JSON.parse(jsonStr);
 
   return Promise.resolve()

--- a/functions/ocr/app/package.json
+++ b/functions/ocr/app/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "samples lint",
+    "lint": "repo-tools lint",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },


### PR DESCRIPTION
**Question to reviewers:** this is a pretty complex sample, and the `event.data.data` vs `event.data` logic may be confusing to some readers. _Does this PR address this issue adequately?_

~~**TODO:** add comments to the sample calling out the Node 6-vs-8+ difference.~~