### PR TITLE
Deprecate Node <8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#161 makes this repo dependent on Node 8+ - this PR updates `package.json` to reflect that.