### PR TITLE
Replace call to repo-tools lint

### DIFF
--- a/appengine/analytics/package.json
+++ b/appengine/analytics/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app",
     "test": "npm run system-test"

--- a/appengine/cloudsql/package.json
+++ b/appengine/cloudsql/package.json
@@ -13,7 +13,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "unit-test": "ava --verbose test/*.test.js",
     "start-proxy": "! pgrep cloud_sql_proxy > /dev/null && cloud_sql_proxy -instances=$INSTANCE_CONNECTION_NAME=tcp:$SQL_PORT &",

--- a/appengine/cloudsql_postgresql/package.json
+++ b/appengine/cloudsql_postgresql/package.json
@@ -13,7 +13,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "unit-test": "ava --verbose test/*.test.js",
     "start-proxy": "! pgrep cloud_sql_proxy > /dev/null && cloud_sql_proxy -instances=$INSTANCE_CONNECTION_NAME=tcp:$SQL_PORT &",

--- a/appengine/datastore/package.json
+++ b/appengine/datastore/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app",
     "test": "npm run system-test"

--- a/appengine/endpoints/package.json
+++ b/appengine/endpoints/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "unit-test": "ava --verbose test/*.test.js",
     "system-test": "repo-tools test app",

--- a/appengine/errorreporting/package.json
+++ b/appengine/errorreporting/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "unit-test": "ava --verbose test/*.test.js",
     "system-test": "repo-tools test app",

--- a/appengine/headless-chrome/package.json
+++ b/appengine/headless-chrome/package.json
@@ -9,7 +9,7 @@
     "start": "node app.js",
     "system-test": "repo-tools test app",
     "unit-test": "ava --verbose test/*.test.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "npm run unit-test && npm run system-test"
   },

--- a/appengine/hello-world/flexible/package.json
+++ b/appengine/hello-world/flexible/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app",
     "test": "npm run system-test",

--- a/appengine/hello-world/standard/package.json
+++ b/appengine/hello-world/standard/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app",
     "test": "npm run system-test",

--- a/appengine/mailjet/package.json
+++ b/appengine/mailjet/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app",
     "test": "npm run system-test"

--- a/appengine/metadata/flexible/package.json
+++ b/appengine/metadata/flexible/package.json
@@ -13,7 +13,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app -- server.js",
     "test": "npm run system-test"

--- a/appengine/metadata/standard/package.json
+++ b/appengine/metadata/standard/package.json
@@ -13,7 +13,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app -- ./server.js",
     "test": "npm run system-test"

--- a/auth/package.json
+++ b/auth/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=6"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js"
   },

--- a/containerengine/hello-world/package.json
+++ b/containerengine/hello-world/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node server.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app -- server.js",
     "test": "npm run system-test"

--- a/debugger/package.json
+++ b/debugger/package.json
@@ -10,12 +10,12 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=6"
   },
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "system-test": "repo-tools test app",
     "test": "npm run system-test",

--- a/endpoints/getting-started-grpc/package.json
+++ b/endpoints/getting-started-grpc/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node server.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 1m --verbose system-test/*.test.js"
   },

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose test/*.test.js"
   },

--- a/error-reporting/package.json
+++ b/error-reporting/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=6"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "error-test": "repo-tools test app --msg \"Something broke!\" --url \"http://localhost:33332/error\" --port 33332  -- snippets.js express",
     "exception-test": "repo-tools test app --code 500 --msg SyntaxError --url \"http://localhost:33333/exception\" --port 33333  -- snippets.js express",

--- a/functions/background/package.json
+++ b/functions/background/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -4,7 +4,7 @@
   "description": "Examples of integrating Cloud Functions with billing",
   "main": "index.js",
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava test/*"
   },

--- a/functions/composer-storage-trigger/package.json
+++ b/functions/composer-storage-trigger/package.json
@@ -23,7 +23,7 @@
     "sinon": "4.4.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "test": "ava -T 20s --verbose test/*.test.js"
   }
 }

--- a/functions/concepts/package.json
+++ b/functions/concepts/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint"
+    "lint": "semistandard '**/*.js'"
   },
   "dependencies": {
     "request": "^2.85.0"

--- a/functions/datastore/package.json
+++ b/functions/datastore/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
     "system-test": "export FUNCTIONS_CMD='functions' && sh test/updateFunctions.sh && BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" ava -T 20s --verbose test/*.test.js",

--- a/functions/env_vars/package.json
+++ b/functions/env_vars/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/firebase/package.json
+++ b/functions/firebase/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "pretest": "repo-tools lint",
+    "pretest": "semistandard '**/*.js'",
     "test": "ava -T 30s test/*.test.js"
   },
   "devDependencies": {

--- a/functions/gcs/package.json
+++ b/functions/gcs/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/headless-chrome/package.json
+++ b/functions/headless-chrome/package.json
@@ -12,7 +12,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "e2e-test": "export FUNCTIONS_CMD='gcloud beta functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCP_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
     "test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose -c 1 test/index.test.js test/*unit*test.js test/*integration*test.js",

--- a/functions/http/package.json
+++ b/functions/http/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/imagemagick/package.json
+++ b/functions/imagemagick/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/log/package.json
+++ b/functions/log/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/ocr/app/package.json
+++ b/functions/ocr/app/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/pubsub/package.json
+++ b/functions/pubsub/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/scheduleinstance/package.json
+++ b/functions/scheduleinstance/package.json
@@ -12,7 +12,7 @@
     "node": ">=6.0"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/sendgrid/package.json
+++ b/functions/sendgrid/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "samples lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/spanner/package.json
+++ b/functions/spanner/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/functions/speech-to-speech/package.json
+++ b/functions/speech-to-speech/package.json
@@ -24,7 +24,7 @@
     "storage"
   ],
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "local-test": "mocha test/index.test.js",
     "system-test": "mocha --timeout 20000 test/sample.integration.http.test.js",
     "pretest": "npm run lint && sh test/updateFunctions.sh",

--- a/functions/sql/package.json
+++ b/functions/sql/package.json
@@ -16,7 +16,7 @@
     "start-proxy-pg": "cloud_sql_proxy -instances=$INSTANCE_CONNECTION_NAME-pg=tcp:5432 &",
     "start-proxy": "! pgrep cloud_sql_proxy > /dev/null && npm run start-proxy-pg && npm run start-proxy-mysql || exit 0",
     "kill-proxy": "killall cloud_sql_proxy",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "ava": "ava -T 20s --verbose test/*.test.js",
     "test": "npm run start-proxy && npm run ava && npm run kill-proxy"

--- a/functions/tips/package.json
+++ b/functions/tips/package.json
@@ -12,7 +12,7 @@
     "node": ">=6.14.0"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint"
   },
   "dependencies": {

--- a/functions/uuid/package.json
+++ b/functions/uuid/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "ava -T 20s --verbose test/*.test.js"
   },

--- a/iot/http_example/package.json
+++ b/iot/http_example/package.json
@@ -6,7 +6,7 @@
   "author": "Google Inc.",
   "main": "cloudiot_http_example_nodejs.js",
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 3m --verbose system-test/*.test.js"
   },

--- a/iot/manager/package.json
+++ b/iot/manager/package.json
@@ -13,7 +13,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 3m --verbose system-test/*.test.js"
   },

--- a/iot/mqtt_example/package.json
+++ b/iot/mqtt_example/package.json
@@ -6,7 +6,7 @@
   "main": "cloudiot_mqtt_example_nodejs.js",
   "name": "nodejs-docs-samples-iot-mqtt-example",
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 3m --verbose system-test/*.test.js"
   },

--- a/jobs/cjd_sample/package.json
+++ b/jobs/cjd_sample/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js"
   },

--- a/kms/package.json
+++ b/kms/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=6"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js"
   },

--- a/language/slackbot/package.json
+++ b/language/slackbot/package.json
@@ -18,7 +18,7 @@
     "node": ">=4.3.2"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "check": "yarn check --strict-semver --integrity",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "generate": "node ./scripts/generate",
     "pretest": "npm run lint && node ./scripts/clean coverage",
     "unit-cover": "nyc --cache npm test && nyc report --reporter=html",

--- a/storage-transfer/package.json
+++ b/storage-transfer/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "unit-test": "repo-tools test run --cmd ava -- -T 20s --verbose test/*.test.js",
     "system-test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js",

--- a/trace/package.json
+++ b/trace/package.json
@@ -10,12 +10,12 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=6"
   },
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "lint": "repo-tools lint",
+    "lint": "semistandard '**/*.js'",
     "pretest": "npm run lint",
     "test": "repo-tools test app",
     "e2e-test": "repo-tools test deploy"


### PR DESCRIPTION
`repo-tools` lint was deleted in 3.0. Use `semistandard`. In a future
CL, we will replace `semistandard` with `eslint` and `prettier`.