### PR TITLE
Rollback to older pubsub

### DIFF
--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -26,7 +26,7 @@ const process = require('process'); // Required for mocking environment variable
 // the project specified by the GOOGLE_CLOUD_PROJECT environment variable. See
 // https://github.com/GoogleCloudPlatform/google-cloud-node/blob/master/docs/authentication.md
 // These environment variables are set automatically on Google App Engine
-const {PubSub} = require('@google-cloud/pubsub');
+const PubSub = require('@google-cloud/pubsub');
 
 // Instantiate a pubsub client
 const pubsub = new PubSub();

--- a/appengine/pubsub/package.json
+++ b/appengine/pubsub/package.json
@@ -13,7 +13,7 @@
     "test": "repo-tools test app && ava -T 30s */*.test.js"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^0.21.0",
+    "@google-cloud/pubsub": "^0.20.1",
     "body-parser": "1.18.3",
     "express": "^4.16.3",
     "pug": "^2.0.1",


### PR DESCRIPTION
`21` throws this error:

Error: google/pubsub/v1/pubsub.proto could not be found in
/tmpfs/.../appengine/pubsub/node_modules/@google-cloud/pubsub/build/protos

cc @kinwa91 