### PR TITLE
GCLOUD_PROJECT -> GOOGLE_CLOUD_PROJECT

### DIFF
--- a/.kokoro/build-with-appengine.sh
+++ b/.kokoro/build-with-appengine.sh
@@ -16,7 +16,7 @@
 
 set -e;
 
-export GCLOUD_PROJECT=nodejs-docs-samples-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-docs-samples-tests
 
 # Update gcloud
 gcloud components update --quiet
@@ -24,7 +24,7 @@ gcloud components update --quiet
 # Configure gcloud
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 export NODE_ENV=development
 
@@ -48,7 +48,7 @@ cd github/nodejs-docs-samples/${PROJECT}
 # Configure gcloud
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 
 # Deploy the app

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
       
-export GCLOUD_PROJECT=nodejs-docs-samples-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-docs-samples-tests
 export GCF_REGION=us-central1
 export NODE_ENV=development
 
 export FUNCTIONS_TOPIC=integration-tests-instance
-export FUNCTIONS_BUCKET=$GCLOUD_PROJECT
-export BASE_URL="http://localhost:8010/${GCLOUD_PROJECT}/${GCF_REGION}"
+export FUNCTIONS_BUCKET=$GOOGLE_CLOUD_PROJECT
+export BASE_URL="http://localhost:8010/${GOOGLE_CLOUD_PROJECT}/${GCF_REGION}"
 
 cd github/nodejs-docs-samples/${PROJECT}
 
@@ -30,7 +30,7 @@ npm install
 # Configure gcloud
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 # Start functions emulator, if appropriate
 if [[ $PROJECT == functions/* ]]; then

--- a/.kokoro/lint.sh
+++ b/.kokoro/lint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
       
-export GCLOUD_PROJECT=nodejs-docs-samples-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-docs-samples-tests
 export NODE_ENV=development
 
 cd github/nodejs-docs-samples/

--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ on Google Cloud Platform.
 
         cd nodejs-docs-samples
 
-1. Set the `GCLOUD_PROJECT` environment variable:
+1. Set the `GOOGLE_CLOUD_PROJECT` environment variable:
 
     Linux:
 
-        export GCLOUD_PROJECT=your-project-id
+        export GOOGLE_CLOUD_PROJECT=your-project-id
 
     Windows:
 
-        set GCLOUD_PROJECT=your-project-id
+        set GOOGLE_CLOUD_PROJECT=your-project-id
 
     Windows (PowerShell):
 
-        $env:GCLOUD_PROJECT="your-project-id"
+        $env:GOOGLE_CLOUD_PROJECT="your-project-id"
 
 1. Obtain authentication credentials.
 

--- a/debugger/README.md
+++ b/debugger/README.md
@@ -15,19 +15,19 @@ appropriate, replace `YOUR_PROJECT_ID` with the ID of your Cloud project):
 1.  Refer to the [appengine/README.md][readme] file for instructions on
     running and deploying.
 
-1. Set the `GCLOUD_PROJECT` environment variable:
+1. Set the `GOOGLE_CLOUD_PROJECT` environment variable:
 
     Linux:
 
-        export GCLOUD_PROJECT=your-project-id
+        export GOOGLE_CLOUD_PROJECT=your-project-id
 
     Windows:
 
-        set GCLOUD_PROJECT=your-project-id
+        set GOOGLE_CLOUD_PROJECT=your-project-id
 
     Windows (PowerShell):
 
-        $env:GCLOUD_PROJECT="your-project-id"
+        $env:GOOGLE_CLOUD_PROJECT="your-project-id"
 
 1.  Acquire local credentials for authenticating with Google Cloud Platform APIs:
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -72,9 +72,9 @@ $ sudo apt-get update
 $ sudo apt-get install docker.io
 ```
 
-1. Using the SSH connection to your instance, initialize the required Docker images in the order specified below. Replace `[YOUR_GCLOUD_PROJECT]` and `[YOUR_SERVICE_NAME]` with your GCloud Project ID and your service's name respectively.
+1. Using the SSH connection to your instance, initialize the required Docker images in the order specified below. Replace `[YOUR_GOOGLE_CLOUD_PROJECT]` and `[YOUR_SERVICE_NAME]` with your GCloud Project ID and your service's name respectively.
 ```
-$ sudo docker run --detach --name=helloworld gcr.io/[YOUR_GCLOUD_PROJECT]/endpoints-example:1.0
+$ sudo docker run --detach --name=helloworld gcr.io/[YOUR_GOOGLE_CLOUD_PROJECT]/endpoints-example:1.0
 ```
 
 ```
@@ -109,7 +109,7 @@ $ gcloud components install kubectl
 $ gcloud container clusters get-credentials [YOUR_CLUSTER_NAME] --zone [YOUR_CLUSTER_ZONE]
 ```
 
-1. Edit the `container_engine.yaml` file, and replace `GCLOUD_PROJECT` and `SERVICE_NAME` with your GCloud Project ID and your service's name.
+1. Edit the `container_engine.yaml` file, and replace `GOOGLE_CLOUD_PROJECT` and `SERVICE_NAME` with your GCloud Project ID and your service's name.
 
 1. Add a [Kubernetes service][docs_k8s_services] to the cluster you created. Note that Kubernetes services should not be confused with [Endpoints services][docs_endpoints_services].
 ```
@@ -173,7 +173,7 @@ $ gcloud endpoints services deploy api.pb api_config.yaml
 ```
 
 1. Deploy the Endpoints Proxy (ESP) with the HTTP 1.1 port enabled.
-Make sure to update the content of `http_deployment.yaml` and replace the placeholder `[SERVICE_NAME]` and `[GCLOUD_PROJECT]`.
+Make sure to update the content of `http_deployment.yaml` and replace the placeholder `[SERVICE_NAME]` and `[GOOGLE_CLOUD_PROJECT]`.
 ```
 $ kubectl apply -f http_deployment.yaml
 ```

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -49,6 +49,6 @@ spec:
         ports:
           - containerPort: 9000
       - name: node-grpc-hello
-        image: gcr.io/GCLOUD_PROJECT/endpoints-example:1.0
+        image: gcr.io/GOOGLE_CLOUD_PROJECT/endpoints-example:1.0
         ports:
           - containerPort: 50051

--- a/endpoints/getting-started-grpc/http_deployment.yaml
+++ b/endpoints/getting-started-grpc/http_deployment.yaml
@@ -55,6 +55,6 @@ spec:
           - containerPort: 8080
           - containerPort: 9000
       - name: node-grpc-hello
-        image: gcr.io/GCLOUD_PROJECT/endpoints-example:1.0
+        image: gcr.io/GOOGLE_CLOUD_PROJECT/endpoints-example:1.0
         ports:
           - containerPort: 50051

--- a/functions/datastore/package.json
+++ b/functions/datastore/package.json
@@ -12,8 +12,8 @@
     "node": ">=8"
   },
   "scripts": {
-    "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
-    "system-test": "export FUNCTIONS_CMD='functions' && sh test/updateFunctions.sh && BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" ava -T 20s --verbose test/*.test.js",
+    "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GOOGLE_CLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
+    "system-test": "export FUNCTIONS_CMD='functions' && sh test/updateFunctions.sh && BASE_URL=\"http://localhost:8010/$GOOGLE_CLOUD_PROJECT/$GCF_REGION\" ava -T 20s --verbose test/*.test.js",
     "test": "npm run system-test"
   },
   "dependencies": {

--- a/functions/headless-chrome/package.json
+++ b/functions/headless-chrome/package.json
@@ -12,7 +12,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "e2e-test": "export FUNCTIONS_CMD='gcloud beta functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js"
+    "e2e-test": "export FUNCTIONS_CMD='gcloud beta functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GOOGLE_CLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js"
   },
   "dependencies": {
     "puppeteer": "^1.6.2"

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -12,9 +12,9 @@
     "node": ">=8"
   },
   "scripts": {
-    "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCP_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
-    "test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose -c 1 test/index.test.js",
-    "system-test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GCLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose test/*.test.js"
+    "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCP_REGION-$GOOGLE_CLOUD_PROJECT.cloudfunctions.net/\" ava -T 20s --verbose test/*.test.js",
+    "test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GOOGLE_CLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose -c 1 test/index.test.js",
+    "system-test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunctions.sh && export BASE_URL=\"http://localhost:8010/$GOOGLE_CLOUD_PROJECT/$GCF_REGION\" && ava -T 20s --verbose test/*.test.js"
   },
   "dependencies": {
     "@google-cloud/debug-agent": "^3.0.0",
@@ -39,7 +39,7 @@
     "requiresProjectId": true,
     "requiredEnvVars": [
       "BASE_URL",
-      "GCLOUD_PROJECT",
+      "GOOGLE_CLOUD_PROJECT",
       "GCF_REGION",
       "FUNCTIONS_TOPIC",
       "FUNCTIONS_BUCKET",

--- a/functions/log/index.js
+++ b/functions/log/index.js
@@ -26,7 +26,7 @@ exports.helloWorld = (req, res) => {
 // [START functions_log_retrieve]
 // By default, the client will authenticate using the service account file
 // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
-// the project specified by the GCLOUD_PROJECT environment variable. See
+// the project specified by the GOOGLE_CLOUD_PROJECT environment variable. See
 // https://googlecloudplatform.github.io/gcloud-node/#/docs/google-cloud/latest/guides/authentication
 const Logging = require('@google-cloud/logging');
 
@@ -52,7 +52,7 @@ function getLogEntries() {
 // [START functions_log_get_metrics]
 // By default, the client will authenticate using the service account file
 // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
-// the project specified by the GCLOUD_PROJECT environment variable. See
+// the project specified by the GOOGLE_CLOUD_PROJECT environment variable. See
 // https://googlecloudplatform.github.io/gcloud-node/#/docs/google-cloud/latest/guides/authentication
 const Monitoring = require('@google-cloud/monitoring');
 
@@ -65,7 +65,7 @@ function getMetrics(callback) {
   oneWeekAgo.setHours(oneWeekAgo.getHours() - 7 * 24);
 
   const options = {
-    name: monitoring.projectPath(process.env.GCLOUD_PROJECT),
+    name: monitoring.projectPath(process.env.GOOGLE_CLOUD_PROJECT),
     // There is also: cloudfunctions.googleapis.com/function/execution_count
     filter:
       'metric.type="cloudfunctions.googleapis.com/function/execution_times"',

--- a/healthcare/datasets/README.md
+++ b/healthcare/datasets/README.md
@@ -28,7 +28,7 @@ Run the following command to install the library dependencies for Node.js:
                                the value of API_KEY environment variable.
                                                                    [string]
         --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-        --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+        --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                                 environment variables.                                    [string]
         --serviceAccount, -s  The path to your service credentials JSON.
                                              [string]

--- a/healthcare/datasets/datasets.js
+++ b/healthcare/datasets/datasets.js
@@ -216,10 +216,10 @@ require(`yargs`)  // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
         'The Project ID to use. Defaults to the value of the ' +
-        'GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/datasets/package.json
+++ b/healthcare/datasets/package.json
@@ -27,7 +27,7 @@
       "build": {
         "requiredEnvVars": [
           "API_KEY",
-          "GCLOUD_PROJECT"
+          "GOOGLE_CLOUD_PROJECT"
         ]
       }
     }

--- a/healthcare/dicom/README.md
+++ b/healthcare/dicom/README.md
@@ -35,7 +35,7 @@ Run the following command to install the library dependencies for Node.js:
     --apiKey, -a          The API key used for discovering the API.
                                                                                                                   [string]
     --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-    --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.                                                                  [string]
     --serviceAccount, -s  The path to your service credentials JSON.
                                                                                                                   [string]
@@ -59,7 +59,7 @@ Run the following command to install the library dependencies for Node.js:
     Options:
     --version             Show version number                                                                    [boolean]
     --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-    --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.                                                                  [string]
     --serviceAccount, -s  The path to your service credentials JSON.
                                                                                                                   [string]

--- a/healthcare/dicom/dicom_stores.js
+++ b/healthcare/dicom/dicom_stores.js
@@ -292,9 +292,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/dicom/dicomweb.js
+++ b/healthcare/dicom/dicomweb.js
@@ -206,9 +206,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/dicom/package.json
+++ b/healthcare/dicom/package.json
@@ -30,7 +30,7 @@
       "build": {
         "requiredEnvVars": [
           "API_KEY",
-          "GCLOUD_PROJECT"
+          "GOOGLE_CLOUD_PROJECT"
         ]
       }
     }

--- a/healthcare/fhir/README.md
+++ b/healthcare/fhir/README.md
@@ -32,7 +32,7 @@ Run the following command to install the library dependencies for Node.js:
     --apiKey, -a          The API key used for discovering the API.
                                                                                                                   [string]
     --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-    --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.                                                                  [string]
     --serviceAccount, -s  The path to your service credentials JSON.
                                                                                                                   [string]
@@ -62,7 +62,7 @@ Run the following command to install the library dependencies for Node.js:
     Options:
     --version             Show version number                                                                    [boolean]
     --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-    --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.                                                                  [string]
     --serviceAccount, -s  The path to your service credentials JSON.
                                                                                                                   [string]

--- a/healthcare/fhir/fhir_resources.js
+++ b/healthcare/fhir/fhir_resources.js
@@ -388,9 +388,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/fhir/fhir_stores.js
+++ b/healthcare/fhir/fhir_stores.js
@@ -230,9 +230,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/fhir/package.json
+++ b/healthcare/fhir/package.json
@@ -30,7 +30,7 @@
       "build": {
         "requiredEnvVars": [
           "API_KEY",
-          "GCLOUD_PROJECT"
+          "GOOGLE_CLOUD_PROJECT"
         ]
       }
     }

--- a/healthcare/hl7v2/README.md
+++ b/healthcare/hl7v2/README.md
@@ -31,7 +31,7 @@ Run the following command to install the library dependencies for Node.js:
     --apiKey, -a          The API key used for discovering the API.
                                                                                                                   [string]
     --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-    --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.                                                                  [string]
     --serviceAccount, -s  The path to your service credentials JSON.
                                                                                                                   [string]
@@ -62,7 +62,7 @@ Run the following command to install the library dependencies for Node.js:
     --apiKey, -a          The API key used for discovering the API.
                                                                                                                   [string]
     --cloudRegion, -c                                                                    [string] [default: "us-central1"]
-    --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.                                                                  [string]
     --serviceAccount, -s  The path to your service credentials JSON.
                                                                                                                   [string]

--- a/healthcare/hl7v2/hl7v2_messages.js
+++ b/healthcare/hl7v2/hl7v2_messages.js
@@ -269,9 +269,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/hl7v2/hl7v2_stores.js
+++ b/healthcare/hl7v2/hl7v2_stores.js
@@ -212,9 +212,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/healthcare/hl7v2/package.json
+++ b/healthcare/hl7v2/package.json
@@ -27,7 +27,7 @@
       "build": {
         "requiredEnvVars": [
           "API_KEY",
-          "GCLOUD_PROJECT"
+          "GOOGLE_CLOUD_PROJECT"
         ]
       }
     }

--- a/iot/beta-features/gateway/README.md
+++ b/iot/beta-features/gateway/README.md
@@ -23,7 +23,7 @@ Run the following command to install the library dependencies for NodeJS:
       relayData <deviceId> <registryId> <privateKeyFile>  Sends data on behalf of a device.
 
     Options:
-      --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+      --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                             environment variables.                                                                  [string]
       --serviceAccount, -s  The path to your service credentials JSON.                                              [string]
       --cloudRegion, -c                                                                    [string] [default: "us-central1"]

--- a/iot/beta-features/gateway/gateway.js
+++ b/iot/beta-features/gateway/gateway.js
@@ -796,9 +796,9 @@ let argv = require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/iot/http_example/cloudiot_http_example.js
+++ b/iot/http_example/cloudiot_http_example.js
@@ -24,9 +24,9 @@ console.log('Google Cloud IoT Core HTTP example.');
 var argv = require(`yargs`)
   .options({
     projectId: {
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/iot/manager/README.md
+++ b/iot/manager/README.md
@@ -33,7 +33,7 @@ Run the following command to install the library dependencies for NodeJS:
       setConfig <deviceId> <registryId> <configuration> <version>  Sets a devices configuration to the specified data.
 
     Options:
-      --projectId, -p       The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+      --projectId, -p       The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                             environment variables.                                                                  [string]
       --serviceAccount, -s  The path to your service credentials JSON.                                              [string]
       --help                Show help                                                                              [boolean]

--- a/iot/manager/manager.js
+++ b/iot/manager/manager.js
@@ -898,9 +898,9 @@ require(`yargs`) // eslint-disable-line
     },
     projectId: {
       alias: 'p',
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/iot/mqtt_example/README.md
+++ b/iot/mqtt_example/README.md
@@ -24,7 +24,7 @@ The following command summarizes the sample usage:
 
   Options:
 
-    --projectId           The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    --projectId           The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
                           environment variables.
     --cloudRegion         GCP cloud region.
     --registryId          Cloud IoT registry ID.

--- a/iot/mqtt_example/cloudiot_mqtt_example_nodejs.js
+++ b/iot/mqtt_example/cloudiot_mqtt_example_nodejs.js
@@ -40,9 +40,9 @@ console.log('Google Cloud IoT Core MQTT example.');
 var argv = require(`yargs`)
   .options({
     projectId: {
-      default: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
+      default: process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT,
       description:
-        'The Project ID to use. Defaults to the value of the GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
+        'The Project ID to use. Defaults to the value of the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT environment variables.',
       requiresArg: true,
       type: 'string',
     },

--- a/jobs/v2/README.md
+++ b/jobs/v2/README.md
@@ -25,7 +25,7 @@ staffing agencies to improve job site engagement and candidate conversion.
 
 ## Running the tests
 
-1.  Set the **GCLOUD_PROJECT** and **GOOGLE_APPLICATION_CREDENTIALS** environment variables.
+1.  Set the **GOOGLE_CLOUD_PROJECT** and **GOOGLE_APPLICATION_CREDENTIALS** environment variables.
 
 1.  Run the tests:
 

--- a/jobs/v3/README.md
+++ b/jobs/v3/README.md
@@ -25,7 +25,7 @@ staffing agencies to improve job site engagement and candidate conversion.
 
 ## Running the tests
 
-1.  Set the **GCLOUD_PROJECT** and **GOOGLE_APPLICATION_CREDENTIALS** environment variables.
+1.  Set the **GOOGLE_CLOUD_PROJECT** and **GOOGLE_APPLICATION_CREDENTIALS** environment variables.
 
 1.  Run all tests:
 

--- a/language/slackbot/README.md
+++ b/language/slackbot/README.md
@@ -143,10 +143,10 @@ this, first run:
 npm install
 ```
 
-Then, set GCLOUD_PROJECT to your project id:
+Then, set GOOGLE_CLOUD_PROJECT to your project id:
 
 ```bash
-export GCLOUD_PROJECT=my-cloud-project-id
+export GOOGLE_CLOUD_PROJECT=my-cloud-project-id
 ```
 
 Then, create a file containing your Slack token, and point `SLACK_TOKEN_PATH` to that file when you run the script

--- a/language/slackbot/generate-dep.sh
+++ b/language/slackbot/generate-dep.sh
@@ -70,7 +70,7 @@ spec:
         env:
         - name: SLACK_TOKEN_PATH
           value: /etc/slack-token/slack-token
-        - name: GCLOUD_PROJECT
+        - name: GOOGLE_CLOUD_PROJECT
           value: ${cloud_project}
       volumes:
       - name: slack-token

--- a/language/slackbot/generate-rc.sh
+++ b/language/slackbot/generate-rc.sh
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SLACK_TOKEN_PATH
           value: /etc/slack-token/slack-token
-        - name: GCLOUD_PROJECT
+        - name: GOOGLE_CLOUD_PROJECT
           value: ${cloud_project}
       volumes:
       - name: slack-token

--- a/storage-transfer/README.md
+++ b/storage-transfer/README.md
@@ -50,7 +50,7 @@ For more information, see https://cloud.google.com/storage/transfer
 
 ## Running the tests
 
-1.  Set the **GCLOUD_PROJECT** and **GOOGLE_APPLICATION_CREDENTIALS** environment variables.
+1.  Set the **GOOGLE_CLOUD_PROJECT** and **GOOGLE_APPLICATION_CREDENTIALS** environment variables.
 
 1.  Run the tests:
 

--- a/storage-transfer/test/transfer.test.js
+++ b/storage-transfer/test/transfer.test.js
@@ -163,7 +163,7 @@ test.serial(`should get a transfer job`, t => {
     [
       {
         auth: {},
-        projectId: process.env.GCLOUD_PROJECT,
+        projectId: process.env.GOOGLE_CLOUD_PROJECT,
         jobName: jobName,
       },
     ]
@@ -220,7 +220,7 @@ test.serial(`should update a transfer job`, t => {
         auth: {},
         jobName: jobName,
         resource: {
-          projectId: process.env.GCLOUD_PROJECT,
+          projectId: process.env.GOOGLE_CLOUD_PROJECT,
           transferJob: {
             name: jobName,
             status: options.value,
@@ -254,7 +254,7 @@ test.serial(`should update a transfer job`, t => {
         auth: {},
         jobName: jobName,
         resource: {
-          projectId: process.env.GCLOUD_PROJECT,
+          projectId: process.env.GOOGLE_CLOUD_PROJECT,
           transferJob: {
             name: jobName,
             description: options.value,
@@ -285,7 +285,7 @@ test.serial(`should update a transfer job`, t => {
         auth: {},
         jobName: jobName,
         resource: {
-          projectId: process.env.GCLOUD_PROJECT,
+          projectId: process.env.GOOGLE_CLOUD_PROJECT,
           transferJob: {
             name: jobName,
             transferSpec: JSON.parse(options.value),
@@ -350,7 +350,7 @@ test.serial(`should list transfer jobs`, t => {
     [
       {
         auth: {},
-        filter: JSON.stringify({project_id: process.env.GCLOUD_PROJECT}),
+        filter: JSON.stringify({project_id: process.env.GOOGLE_CLOUD_PROJECT}),
       },
     ]
   );
@@ -368,7 +368,7 @@ test.serial(`should list transfer jobs`, t => {
     [
       {
         auth: {},
-        filter: JSON.stringify({project_id: process.env.GCLOUD_PROJECT}),
+        filter: JSON.stringify({project_id: process.env.GOOGLE_CLOUD_PROJECT}),
       },
     ]
   );
@@ -418,7 +418,7 @@ test.serial(`should list transfer operations`, t => {
       {
         name: `transferOperations`,
         auth: {},
-        filter: JSON.stringify({project_id: process.env.GCLOUD_PROJECT}),
+        filter: JSON.stringify({project_id: process.env.GOOGLE_CLOUD_PROJECT}),
       },
     ]
   );
@@ -444,7 +444,7 @@ test.serial(`should list transfer operations`, t => {
         name: `transferOperations`,
         auth: {},
         filter: JSON.stringify({
-          project_id: process.env.GCLOUD_PROJECT,
+          project_id: process.env.GOOGLE_CLOUD_PROJECT,
           job_names: [jobName],
         }),
       },
@@ -473,7 +473,7 @@ test.serial(`should list transfer operations`, t => {
         name: `transferOperations`,
         auth: {},
         filter: JSON.stringify({
-          project_id: process.env.GCLOUD_PROJECT,
+          project_id: process.env.GOOGLE_CLOUD_PROJECT,
           job_names: [jobName],
         }),
       },

--- a/storage-transfer/transfer.js
+++ b/storage-transfer/transfer.js
@@ -71,7 +71,7 @@ function createTransferJob(options, callback) {
     }
 
     var transferJob = {
-      projectId: process.env.GCLOUD_PROJECT,
+      projectId: process.env.GOOGLE_CLOUD_PROJECT,
       status: 'ENABLED',
       transferSpec: {
         gcsDataSource: {
@@ -136,7 +136,7 @@ function getTransferJob(jobName, callback) {
     storagetransfer.transferJobs.get(
       {
         auth: authClient,
-        projectId: process.env.GCLOUD_PROJECT,
+        projectId: process.env.GOOGLE_CLOUD_PROJECT,
         jobName: jobName,
       },
       function(err, response) {
@@ -170,7 +170,7 @@ function updateTransferJob(options, callback) {
     }
 
     var patchRequest = {
-      projectId: process.env.GCLOUD_PROJECT,
+      projectId: process.env.GOOGLE_CLOUD_PROJECT,
       transferJob: {
         name: options.job,
       },
@@ -220,7 +220,7 @@ function listTransferJobs(callback) {
     storagetransfer.transferJobs.list(
       {
         auth: authClient,
-        filter: JSON.stringify({project_id: process.env.GCLOUD_PROJECT}),
+        filter: JSON.stringify({project_id: process.env.GOOGLE_CLOUD_PROJECT}),
       },
       function(err, response) {
         if (err) {
@@ -251,7 +251,7 @@ function listTransferOperations(jobName, callback) {
     }
 
     var filter = {
-      project_id: process.env.GCLOUD_PROJECT,
+      project_id: process.env.GOOGLE_CLOUD_PROJECT,
     };
 
     if (jobName) {


### PR DESCRIPTION
We prefer `GOOGLE_CLOUD_PROJECT` over `GCLOUD_PROJECT`. Rename a such.

See various docs and comment threads about this:
- https://cloud.google.com/appengine/docs/flexible/nodejs/runtime#environment_variables
- https://github.com/googleapis/nodejs-common/issues/20#issuecomment-360209232
- https://github.com/googleapis/google-cloud-php/issues/827