### PR TITLE
iot: update gateway association management samples

### DIFF
--- a/iot/beta-features/gateway/gateway.test.js
+++ b/iot/beta-features/gateway/gateway.test.js
@@ -198,7 +198,7 @@ test(`should list gateways for bound device`, async t => {
   );
 
   // binding a non-existing device should create it
-  const deviceId = `nodejs-test-device-iot-${uuid.v4 ()}`;
+  const deviceId = `nodejs-test-device-iot-${uuid.v4()}`;
   await tools.runAsync(
     `${cmd} bindDeviceToGateway ${registryName} ${gatewayId} ${deviceId}`
   );

--- a/iot/manager/manager.js
+++ b/iot/manager/manager.js
@@ -527,6 +527,7 @@ function clearRegistry(client, registryId, projectId, cloudRegion) {
       let data = res.data;
       console.log('Current devices in registry:', data['devices']);
       let devices = data['devices'];
+
       if (devices) {
         devices.forEach((device, index) => {
           console.log(`${device.id} [${index}/${devices.length}] removed`);


### PR DESCRIPTION
Add 3 functions to gateway management
1. `unbindDeviceFromAllGateways` unbinds a single device from all gateways
2. `unbindAllDevices` unbinds all devices in a given registry (calls the above function on all devices in a registry)
3. `listGatewaysForDevice` lists all the gateways a device is bound to

1 and 2 do not have corresponding region tags since they will not be included in the docs (mostly for debugging purposes), but 3 is and has a corresponding test