### PR TITLE
Auto-update minor and patch for some dependencies

### DIFF
--- a/appengine/analytics/package.json
+++ b/appengine/analytics/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "express": "4.16.4",
-    "got": "9.6.0"
+    "got": "^9.6.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/cloudsql_postgresql/package.json
+++ b/appengine/cloudsql_postgresql/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "express": "4.16.4",
     "knex": "0.16.3",
-    "pg": "7.8.0",
+    "pg": "^7.8.0",
     "prompt": "1.0.0"
   },
   "devDependencies": {

--- a/appengine/loopback/package.json
+++ b/appengine/loopback/package.json
@@ -21,7 +21,7 @@
     "loopback-component-explorer": "5.4.0",
     "serve-favicon": "2.5.0",
     "strong-error-handler": "3.2.0",
-    "loopback-datasource-juggler": "4.5.3",
+    "loopback-datasource-juggler": "^4.5.3",
     "loopback": "3.24.0"
   },
   "devDependencies": {

--- a/appengine/metadata/flexible/package.json
+++ b/appengine/metadata/flexible/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "express": "4.16.4",
-    "got": "9.6.0"
+    "got": "^9.6.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/metadata/standard/package.json
+++ b/appengine/metadata/standard/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "express": "4.16.4",
-    "got": "9.6.0"
+    "got": "^9.6.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/mongodb/package.json
+++ b/appengine/mongodb/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "mongodb": "3.1.13",
+    "mongodb": "^3.1.13",
     "nconf": "0.10.0"
   },
   "devDependencies": {

--- a/appengine/twilio/package.json
+++ b/appengine/twilio/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "body-parser": "1.18.3",
     "express": "4.16.4",
-    "twilio": "3.27.1"
+    "twilio": "^3.27.1"
   }
 }

--- a/endpoints/getting-started-grpc/package.json
+++ b/endpoints/getting-started-grpc/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "google-auth-library": "^3.0.0",
-    "grpc": "1.18.0",
+    "grpc": "^1.18.0",
     "jsonwebtoken": "^8.2.0",
     "yargs": "12.0.5"
   },

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -26,6 +26,6 @@
     "ava": "0.25.0",
     "proxyquire": "2.1.0",
     "sinon": "7.2.3",
-    "supertest": "3.4.2"
+    "supertest": "^3.4.2"
   }
 }

--- a/storage-transfer/package.json
+++ b/storage-transfer/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "googleapis": "37.1.0",
-    "moment": "2.24.0",
+    "moment": "^2.24.0",
     "yargs": "12.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Changing a few hand-picke dependencies where we trust the minor and
patch updates. If dependency versions are fixed, we are drowning in
RenovateBot PRs.