### PR TITLE
refactor(appengine-headless-chrome):ava to mocha

### DIFF
--- a/appengine/headless-chrome/package.json
+++ b/appengine/headless-chrome/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node app.js",
     "system-test": "repo-tools test app",
-    "unit-test": "ava --verbose test/*.test.js",
+    "unit-test": "mocha test/*.test.js --timeout=30000",
     "test": "npm run unit-test && npm run system-test"
   },
   "repository": {
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "^0.25.0"
+    "mocha": "^5.2.0"
   },
   "cloud-repo-tools": {
     "test": {

--- a/appengine/headless-chrome/test/app.test.js
+++ b/appengine/headless-chrome/test/app.test.js
@@ -13,22 +13,21 @@
 
 'use strict';
 
-const test = require(`ava`);
-const path = require(`path`);
-const utils = require(`@google-cloud/nodejs-repo-tools`);
+const assert = require('assert');
+const path = require('path');
+const utils = require('@google-cloud/nodejs-repo-tools');
 
-const cwd = path.join(__dirname, `../`);
+const cwd = path.join(__dirname, '../');
 const requestObj = utils.getRequest({cwd: cwd});
 
-test.serial.cb(`should return a screenshot`, t => {
-  requestObj
-    .get(`/?url=https://example.com`)
+it('should return a screenshot', async () => {
+  await requestObj
+    .get('/?url=https://example.com')
     .send()
     .expect(200)
     .expect(response => {
-      t.is(response.type, `image/png`);
-      t.true(response.body instanceof Buffer);
-      t.true(response.body.length > 0);
-    })
-    .end(t.end);
+      assert.strictEqual(response.type, 'image/png');
+      assert.strictEqual(response.body instanceof Buffer, true);
+      assert.strictEqual(response.body.length > 0, true);
+    });
 });


### PR DESCRIPTION
Tracking issue: Convert tests from ava to mocha [#1080](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/issues/1080) (it's a good idea to open an issue first for discussion)