### PR TITLE
OpenCensus sample: Add region tags

### DIFF
--- a/opencensus/metrics-quickstart.js
+++ b/opencensus/metrics-quickstart.js
@@ -16,8 +16,10 @@
 // [START monitoring_opencensus_metrics_quickstart]
 'use strict';
 
+// [START monitoring_opencensus_metrics_dependencies]
 const {globalStats, MeasureUnit, AggregationType} = require('@opencensus/core');
 const {StackdriverStatsExporter} = require('@opencensus/exporter-stackdriver');
+// [END monitoring_opencensus_metrics_dependencies]
 
 const EXPORT_INTERVAL = 60;
 const LATENCY_MS = globalStats.createMeasureInt64(


### PR DESCRIPTION
Putting region tags ("monitoring_opencensus_metrics_dependencies") to highlight dependencies section on Stackdriver page (https://cloud-dot-devsite.googleplex.com/monitoring/custom-metrics/open-census) .