### PR TITLE
Allow minor and patch updates

### DIFF
--- a/appengine/analytics/package.json
+++ b/appengine/analytics/package.json
@@ -18,7 +18,7 @@
     "test": "npm run system-test"
   },
   "dependencies": {
-    "express": "4.16.4",
+    "express": "^4.16.4",
     "got": "^9.6.0"
   },
   "devDependencies": {

--- a/appengine/building-an-app/build/package.json
+++ b/appengine/building-an-app/build/package.json
@@ -22,8 +22,8 @@
     "express": "^4.16.3"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "3.2.0",
-    "ava": "0.25.0"
+    "@google-cloud/nodejs-repo-tools": "^3.2.0",
+    "ava": "^0.25.0"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": false,

--- a/appengine/building-an-app/update/package.json
+++ b/appengine/building-an-app/update/package.json
@@ -23,7 +23,7 @@
     "express": "^4.16.3"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "3.2.0",
+    "@google-cloud/nodejs-repo-tools": "^3.2.0",
     "mocha": "^6.0.0"
   }
 }

--- a/appengine/cloudsql/package.json
+++ b/appengine/cloudsql/package.json
@@ -21,10 +21,10 @@
     "test": "repo-tools test run --cmd npm -- run all-test"
   },
   "dependencies": {
-    "express": "4.16.4",
-    "knex": "0.16.3",
-    "mysql": "2.16.0",
-    "prompt": "1.0.0"
+    "express": "^4.16.4",
+    "knex": "^0.16.3",
+    "mysql": "^2.16.0",
+    "prompt": "^1.0.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",

--- a/appengine/cloudsql_postgresql/package.json
+++ b/appengine/cloudsql_postgresql/package.json
@@ -21,10 +21,10 @@
     "test": "repo-tools test run --cmd npm -- run all-test"
   },
   "dependencies": {
-    "express": "4.16.4",
-    "knex": "0.16.3",
+    "express": "^4.16.4",
+    "knex": "^0.16.3",
     "pg": "^7.8.0",
-    "prompt": "1.0.0"
+    "prompt": "^1.0.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",

--- a/appengine/datastore/package.json
+++ b/appengine/datastore/package.json
@@ -18,8 +18,8 @@
     "test": "npm run system-test"
   },
   "dependencies": {
-    "@google-cloud/datastore": "2.0.0",
-    "express": "4.16.4"
+    "@google-cloud/datastore": "^2.0.0",
+    "express": "^4.16.4"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/endpoints/package.json
+++ b/appengine/endpoints/package.json
@@ -22,13 +22,13 @@
     "e2e-test": "repo-tools test deploy"
   },
   "dependencies": {
-    "body-parser": "1.18.3",
-    "express": "4.16.4",
-    "safe-buffer": "5.1.2"
+    "body-parser": "^1.18.3",
+    "express": "^4.16.4",
+    "safe-buffer": "^5.1.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "0.25.0",
+    "ava": "^0.25.0",
     "proxyquire": "^2.1.0",
     "sinon": "^7.1.1",
     "supertest": "^3.3.0"

--- a/appengine/loopback/package.json
+++ b/appengine/loopback/package.json
@@ -14,15 +14,15 @@
     "test": "repo-tools test app -- ."
   },
   "dependencies": {
-    "compression": "1.7.3",
-    "cors": "2.8.5",
-    "helmet": "3.16.0",
-    "loopback-boot": "2.27.1",
-    "loopback-component-explorer": "5.4.0",
-    "serve-favicon": "2.5.0",
-    "strong-error-handler": "3.2.0",
+    "compression": "^1.7.3",
+    "cors": "^2.8.5",
+    "helmet": "^3.16.0",
+    "loopback-boot": "^2.27.1",
+    "loopback-component-explorer": "^5.4.0",
+    "serve-favicon": "^2.5.0",
+    "strong-error-handler": "^3.2.0",
     "loopback-datasource-juggler": "^4.5.3",
-    "loopback": "3.25.0"
+    "loopback": "^3.25.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/mailjet/package.json
+++ b/appengine/mailjet/package.json
@@ -18,10 +18,10 @@
     "test": "npm run system-test"
   },
   "dependencies": {
-    "body-parser": "1.18.3",
-    "express": "4.16.4",
-    "jade": "1.11.0",
-    "node-mailjet": "3.3.1"
+    "body-parser": "^1.18.3",
+    "express": "^4.16.4",
+    "jade": "^1.11.0",
+    "node-mailjet": "^3.3.1"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/memcached/package.json
+++ b/appengine/memcached/package.json
@@ -12,7 +12,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "4.16.4",
+    "express": "^4.16.4",
     "memjs": "^1.2.0"
   }
 }

--- a/appengine/metadata/flexible/package.json
+++ b/appengine/metadata/flexible/package.json
@@ -17,7 +17,7 @@
     "test": "npm run system-test"
   },
   "dependencies": {
-    "express": "4.16.4",
+    "express": "^4.16.4",
     "got": "^9.6.0"
   },
   "devDependencies": {

--- a/appengine/metadata/standard/package.json
+++ b/appengine/metadata/standard/package.json
@@ -17,7 +17,7 @@
     "test": "npm run system-test"
   },
   "dependencies": {
-    "express": "4.16.4",
+    "express": "^4.16.4",
     "got": "^9.6.0"
   },
   "devDependencies": {

--- a/appengine/mongodb/package.json
+++ b/appengine/mongodb/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "mongodb": "^3.1.13",
-    "nconf": "0.10.0"
+    "nconf": "^0.10.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/pubsub/package.json
+++ b/appengine/pubsub/package.json
@@ -14,15 +14,15 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^0.22.0",
-    "body-parser": "1.18.3",
+    "body-parser": "^1.18.3",
     "express": "^4.16.3",
     "pug": "^2.0.1",
-    "safe-buffer": "5.1.2"
+    "safe-buffer": "^5.1.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "0.25.0",
-    "uuid": "3.3.2"
+    "ava": "^0.25.0",
+    "uuid": "^3.3.2"
   },
   "cloud-repo-tools": {
     "requiresProjectId": true,

--- a/appengine/redis/package.json
+++ b/appengine/redis/package.json
@@ -28,8 +28,8 @@
     }
   },
   "dependencies": {
-    "nconf": "0.10.0",
-    "redis": "2.8.0"
+    "nconf": "^0.10.0",
+    "redis": "^2.8.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/sendgrid/package.json
+++ b/appengine/sendgrid/package.json
@@ -12,9 +12,9 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "body-parser": "1.18.3",
-    "express": "4.16.4",
-    "pug": "2.0.3",
-    "sendgrid": "5.2.3"
+    "body-parser": "^1.18.3",
+    "express": "^4.16.4",
+    "pug": "^2.0.3",
+    "sendgrid": "^5.2.3"
   }
 }

--- a/appengine/static-files/package.json
+++ b/appengine/static-files/package.json
@@ -21,8 +21,8 @@
     }
   },
   "dependencies": {
-    "express": "4.16.4",
-    "pug": "2.0.3"
+    "express": "^4.16.4",
+    "pug": "^2.0.3"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0"

--- a/appengine/twilio/package.json
+++ b/appengine/twilio/package.json
@@ -12,8 +12,8 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "body-parser": "1.18.3",
-    "express": "4.16.4",
+    "body-parser": "^1.18.3",
+    "express": "^4.16.4",
     "twilio": "^3.28.0"
   }
 }

--- a/appengine/websockets/package.json
+++ b/appengine/websockets/package.json
@@ -17,12 +17,12 @@
     "e2e-test": "samples test deploy"
   },
   "dependencies": {
-    "express": "4.15.4",
-    "pug": "2.0.3",
-    "socket.io": "2.2.0"
+    "express": "^4.15.4",
+    "pug": "^2.0.3",
+    "socket.io": "^2.2.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "3.2.0",
+    "@google-cloud/nodejs-repo-tools": "^3.2.0",
     "puppeteer": "^1.11.0"
   },
   "cloud-repo-tools": {

--- a/auth/package.json
+++ b/auth/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^2.0.3",
-    "yargs": "13.2.2"
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",

--- a/cloud-sql/mysql/mysql/package.json
+++ b/cloud-sql/mysql/mysql/package.json
@@ -21,13 +21,13 @@
     "body-parser": "1.18.3",
     "express": "4.16.2",
     "promise-mysql": "^3.3.1",
-    "prompt": "1.0.0",
-    "pug": "2.0.3",
+    "prompt": "^1.0.0",
+    "pug": "^2.0.3",
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "3.2.0",
-    "ava": "0.25.0",
+    "@google-cloud/nodejs-repo-tools": "^3.2.0",
+    "ava": "^0.25.0",
     "proxyquire": "^2.1.0",
     "supertest": "^3.3.0",
     "sinon": "^7.1.1"

--- a/cloud-sql/postgres/knex/package.json
+++ b/cloud-sql/postgres/knex/package.json
@@ -21,17 +21,17 @@
     "test": "repo-tools test run --cmd npm -- run all-test"
   },
   "dependencies": {
-    "body-parser": "1.18.3",
-    "express": "4.16.2",
-    "knex": "0.16.3",
-    "prompt": "1.0.0",
-    "pug": "2.0.3",
+    "body-parser": "^1.18.3",
+    "express": "^4.16.2",
+    "knex": "^0.16.3",
+    "prompt": "^1.0.0",
+    "pug": "^2.0.3",
     "@google-cloud/logging-winston": "^0.11.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "3.2.0",
-    "ava": "0.25.0",
+    "@google-cloud/nodejs-repo-tools": "^3.2.0",
+    "ava": "^0.25.0",
     "proxyquire": "^2.1.0",
     "supertest": "^3.3.0",
     "sinon": "^7.1.1"

--- a/endpoints/getting-started-grpc/package.json
+++ b/endpoints/getting-started-grpc/package.json
@@ -20,11 +20,11 @@
     "google-auth-library": "^3.0.0",
     "grpc": "^1.18.0",
     "jsonwebtoken": "^8.2.0",
-    "yargs": "13.2.2"
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "0.25.0"
+    "ava": "^0.25.0"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": true,

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -17,15 +17,15 @@
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose test/*.test.js"
   },
   "dependencies": {
-    "body-parser": "1.18.3",
-    "express": "4.16.4",
-    "safe-buffer": "5.1.2"
+    "body-parser": "^1.18.3",
+    "express": "^4.16.4",
+    "safe-buffer": "^5.1.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "0.25.0",
-    "proxyquire": "2.1.0",
-    "sinon": "7.2.7",
+    "ava": "^0.25.0",
+    "proxyquire": "^2.1.0",
+    "sinon": "^7.2.7",
     "supertest": "^3.4.2"
   }
 }

--- a/iot/beta-features/gateway/package.json
+++ b/iot/beta-features/gateway/package.json
@@ -19,14 +19,14 @@
   "dependencies": {
     "googleapis": "^37.0.0",
     "jsonwebtoken": "^8.3.0",
-    "mqtt": "2.18.8",
-    "yargs": "13.2.2"
+    "mqtt": "^2.18.8",
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "mocha": "^6.0.0",
-    "@google-cloud/pubsub": "0.22.2",
-    "uuid": "3.1.0"
+    "@google-cloud/pubsub": "^0.22.2",
+    "uuid": "^3.1.0"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": true,

--- a/iot/http_example/package.json
+++ b/iot/http_example/package.json
@@ -17,15 +17,15 @@
     "system-test": "mocha system-test/*.test.js --timeout=60000"
   },
   "dependencies": {
-    "jsonwebtoken": "8.5.0",
-    "retry-request": "3.3.2",
-    "yargs": "13.2.2"
+    "jsonwebtoken": "^8.5.0",
+    "retry-request": "^3.3.2",
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "googleapis": "^37.0.0",
-    "@google-cloud/pubsub": "0.22.2",
+    "@google-cloud/pubsub": "^0.22.2",
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "mocha": "^6.0.0",
-    "uuid": "3.3.2"
+    "uuid": "^3.3.2"
   }
 }

--- a/iot/manager/package.json
+++ b/iot/manager/package.json
@@ -18,14 +18,14 @@
   },
   "dependencies": {
     "@google-cloud/iot": "^0.2.0",
-    "@google-cloud/pubsub": "0.22.2",
+    "@google-cloud/pubsub": "^0.22.2",
     "googleapis": "^37.0.0",
-    "yargs": "13.2.2"
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "mocha": "^6.0.0",
-    "uuid": "3.3.2"
+    "uuid": "^3.3.2"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": true,

--- a/iot/mqtt_example/package.json
+++ b/iot/mqtt_example/package.json
@@ -18,14 +18,14 @@
   },
   "dependencies": {
     "@google-cloud/iot": "^0.2.0",
-    "jsonwebtoken": "8.5.0",
-    "mqtt": "2.18.8",
-    "yargs": "13.2.2"
+    "jsonwebtoken": "^8.5.0",
+    "mqtt": "^2.18.8",
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.2.0",
-    "@google-cloud/pubsub": "0.22.2",
+    "@google-cloud/pubsub": "^0.22.2",
     "mocha": "^6.0.0",
-    "uuid": "3.3.2"
+    "uuid": "^3.3.2"
   }
 }

--- a/iot/scripts/package.json
+++ b/iot/scripts/package.json
@@ -5,6 +5,6 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/pubsub": "0.22.2"
+    "@google-cloud/pubsub": "^0.22.2"
   }
 }

--- a/jobs/v3/package.json
+++ b/jobs/v3/package.json
@@ -16,10 +16,10 @@
     "system-test": "mocha system-test/*.test.js --timeout=40000"
   },
   "dependencies": {
-    "googleapis": "37.2.0",
-    "safe-buffer": "5.1.2",
-    "uuid": "3.3.2",
-    "yargs": "13.2.2"
+    "googleapis": "^37.2.0",
+    "safe-buffer": "^5.1.2",
+    "uuid": "^3.3.2",
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",

--- a/memorystore/redis/package.json
+++ b/memorystore/redis/package.json
@@ -9,7 +9,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "redis": "2.8.0"
+    "redis": "^2.8.0"
   }
 }
 

--- a/opencensus/package.json
+++ b/opencensus/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "0.25.0"
+    "ava": "^0.25.0"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": true,

--- a/storage-transfer/package.json
+++ b/storage-transfer/package.json
@@ -17,17 +17,17 @@
     "test": "npm run unit-test && npm run system-test"
   },
   "dependencies": {
-    "googleapis": "37.2.0",
+    "googleapis": "^37.2.0",
     "moment": "^2.24.0",
-    "yargs": "13.2.2"
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "0.25.0",
-    "proxyquire": "2.1.0",
-    "sinon": "7.2.7",
+    "ava": "^0.25.0",
+    "proxyquire": "^2.1.0",
+    "sinon": "^7.2.7",
     "@google-cloud/storage": "^2.3.3",
-    "uuid": "3.3.2"
+    "uuid": "^3.3.2"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": true,


### PR DESCRIPTION
Reduce some of the churn caused by renovate bot by making dependency
versions more flexible.