### PR TITLE
Clean up package.json in root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,31 +5,23 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
-  "main": "src/index.js",
   "private": true,
   "scripts": {
     "lint": "eslint '**/*.js'",
-    "pretest": "npm run lint",
-    "unit-cover": "nyc --cache npm test && nyc report --reporter=html",
-    "system-cover": "nyc --cache npm run system-test && nyc report --reporter=html",
-    "test": "npm run unit-test && npm run system-test",
-    "cover": "nyc --cache npm run test && nyc report --reporter=html"
+    "test": "echo 'Please run tests in each sample directory.' && exit 1"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.2.0",
-    "@google-cloud/storage": "2.4.3",
-    "ava": "0.25.0",
     "eslint": "^5.9.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "nyc": "^13.3.0",
     "prettier": "^1.15.2"
   }
 }


### PR DESCRIPTION
Tests are run in individual subfolders, but we have a global
lint job.
Follow up PR that deletes the coverage output, as it's at 55% and not tracking correctly 😞 