### PR TITLE
refactor: move createDataset sample to own file

### DIFF
--- a/healthcare/datasets/createDataset.js
+++ b/healthcare/datasets/createDataset.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2019, Google, LLC
+ * Licensed under the Apache License, Version 2.0 (the `License`);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an `AS IS` BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function main(
+  projectId = process.env.GCLOUD_PROJECT,
+  cloudRegion = 'us-central1',
+  datasetId
+) {
+  // [START healthcare_create_dataset]
+  const {google} = require('googleapis');
+  const healthcare = google.healthcare('v1alpha2');
+
+  async function createDataset() {
+    const auth = await google.auth.getClient({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+    google.options({auth});
+
+    // TODO(developer): uncomment these lines before running the sample
+    // const cloudRegion = 'us-central1';
+    // const projectId = 'adjective-noun-123';
+    // const datasetId = 'my-dataset';
+    const parent = `projects/${projectId}/locations/${cloudRegion}`;
+    const request = {parent, datasetId};
+
+    await healthcare.projects.locations.datasets.create(request);
+    console.log(`Created dataset: ${datasetId}`);
+  }
+
+  createDataset();
+  // [END healthcare_create_dataset]
+}
+
+// node createDataset.js <projectId> <cloudRegion> <datasetId>
+main(...process.argv.slice(2));

--- a/healthcare/datasets/datasets.js
+++ b/healthcare/datasets/datasets.js
@@ -17,28 +17,6 @@
 
 const {google} = require('googleapis');
 
-// [START healthcare_create_dataset]
-function createDataset(client, projectId, cloudRegion, datasetId) {
-  // Client retrieved in callback
-  // getClient(serviceAccountJson, function(client) {...});
-  // const cloudRegion = 'us-central1';
-  // const projectId = 'adjective-noun-123';
-  // const datasetId = 'my-dataset';
-  const parentName = `projects/${projectId}/locations/${cloudRegion}`;
-
-  const request = {parent: parentName, datasetId: datasetId};
-
-  client.projects.locations.datasets
-    .create(request)
-    .then(() => {
-      console.log(`Created dataset: ${datasetId}`);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-// [END healthcare_create_dataset]
-
 // [START healthcare_delete_dataset]
 function deleteDataset(client, projectId, cloudRegion, datasetId) {
   // Client retrieved in callback
@@ -258,17 +236,6 @@ require(`yargs`)  // eslint-disable-line
       type: 'string',
     },
   })
-  .command(
-    `createDataset <datasetId>`,
-    `Creates a new health dataset.`,
-    {},
-    opts => {
-      const cb = function(client) {
-        createDataset(client, opts.projectId, opts.cloudRegion, opts.datasetId);
-      };
-      getClient(opts.apiKey, opts.serviceAccount, cb);
-    }
-  )
   .command(
     `deleteDataset <datasetId>`,
     `Deletes the specified health dataset and all data contained

--- a/healthcare/datasets/system-test/datasets.test.js
+++ b/healthcare/datasets/system-test/datasets.test.js
@@ -35,7 +35,10 @@ after(async () => {
 });
 
 it('should create a dataset', async () => {
-  const output = await tools.runAsync(`${cmd} createDataset ${datasetId}`, cwd);
+  const output = await tools.runAsync(
+    `$node createDataset.js ${datasetId}`,
+    cwd
+  );
   assert.strictEqual(output, `Created dataset: ${datasetId}`);
 });
 


### PR DESCRIPTION
Dipping my toes into the water.  This is the first change for moving the healthcare samples over to the v1alpha2 version of the API.  At the same time, I'm trying to convert these to match the new style we want for samples.  Let me know what you think!