### PR TITLE
refactor: Remove duplicate CORS header

### DIFF
--- a/functions/http/index.js
+++ b/functions/http/index.js
@@ -253,8 +253,6 @@ exports.corsEnabledFunction = (req, res) => {
     res.set('Access-Control-Max-Age', '3600');
     res.status(204).send('');
   } else {
-    // Set CORS headers for the main request
-    res.set('Access-Control-Allow-Origin', '*');
     res.send('Hello World!');
   }
 };


### PR DESCRIPTION
The following line is duplicate in the sample. The response header is already set on [line 247](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/compare/master...grant-functions-cors?quick_pull=1#diff-cb29a8c8153c2a5c55203eccfa98361cR247).
```js
res.set('Access-Control-Allow-Origin', '*');
```

Like the other sample, it should not be in the
```js
if (req.method === 'OPTIONS') {
```
conditional block.

Doc: https://cloud.google.com/functions/docs/writing/http#handling_cors_requests