### PR TITLE
functions/tips: add run region tags

### DIFF
--- a/functions/tips/index.js
+++ b/functions/tips/index.js
@@ -30,6 +30,7 @@ const functionSpecificComputation = heavyComputation;
 const fileWideComputation = lightComputation;
 
 // [START functions_tips_scopes]
+// [START run_tips_global_scope]
 // Global (instance-wide) scope
 // This computation runs at instance cold-start
 const instanceVar = heavyComputation();
@@ -47,9 +48,11 @@ exports.scopeDemo = (req, res) => {
 
   res.send(`Per instance: ${instanceVar}, per function: ${functionVar}`);
 };
+// [END run_tips_global_scope]
 // [END functions_tips_scopes]
 
 // [START functions_tips_lazy_globals]
+// [START run_tips_global_lazy]
 // Always initialized (at cold-start)
 const nonLazyGlobal = fileWideComputation();
 
@@ -68,6 +71,7 @@ exports.lazyGlobals = (req, res) => {
 
   res.send(`Lazy global: ${lazyGlobal}, non-lazy global: ${nonLazyGlobal}`);
 };
+// [END run_tips_global_lazy]
 // [END functions_tips_lazy_globals]
 
 // [START functions_tips_connection_pooling]


### PR DESCRIPTION
These two snippets are reused in Cloud Run. Adding dedicated region tags for separate tracking.

x-ref: https://github.com/GoogleCloudPlatform/golang-samples/pull/831