### PR TITLE
fix: use a node version compatible with App Engine

### DIFF
--- a/appengine/analytics/package.json
+++ b/appengine/analytics/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/building-an-app/build/package.json
+++ b/appengine/building-an-app/build/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "author": "Google Inc.",
   "license": "Apache-2.0",

--- a/appengine/building-an-app/update/package.json
+++ b/appengine/building-an-app/update/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "author": "Google Inc.",
   "license": "Apache-2.0",

--- a/appengine/cloudsql/package.json
+++ b/appengine/cloudsql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "unit-test": "mocha test/*.test.js --timeout=60000",

--- a/appengine/cloudsql_postgresql/package.json
+++ b/appengine/cloudsql_postgresql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "unit-test": "mocha test/*.test.js --timeout=30000",

--- a/appengine/datastore/package.json
+++ b/appengine/datastore/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/endpoints/package.json
+++ b/appengine/endpoints/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "deploy": "gcloud app deploy",

--- a/appengine/headless-chrome/package.json
+++ b/appengine/headless-chrome/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headless-chrome-sample",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "version": "1.0.0",
   "description": "An example of taking screenshot with Puppeteer (Headless Chrome) in Node.js on Google App Engine.",

--- a/appengine/hello-world/flexible/package.json
+++ b/appengine/hello-world/flexible/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "deploy": "gcloud app deploy",

--- a/appengine/hello-world/standard/package.json
+++ b/appengine/hello-world/standard/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "deploy": "gcloud app deploy",

--- a/appengine/mailjet/package.json
+++ b/appengine/mailjet/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/memcached/package.json
+++ b/appengine/memcached/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/metadata/flexible/package.json
+++ b/appengine/metadata/flexible/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "system-test": "repo-tools test app -- server.js",

--- a/appengine/metadata/standard/package.json
+++ b/appengine/metadata/standard/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "system-test": "repo-tools test app -- ./server.js",

--- a/appengine/pubsub/package.json
+++ b/appengine/pubsub/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/redis/package.json
+++ b/appengine/redis/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node server.js",

--- a/appengine/sendgrid/package.json
+++ b/appengine/sendgrid/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/static-files/package.json
+++ b/appengine/static-files/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/storage/flexible/package.json
+++ b/appengine/storage/flexible/package.json
@@ -6,7 +6,7 @@
     "test": "mocha system-test/*.test.js --timeout=30000"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "@google-cloud/storage": "^2.3.3",

--- a/appengine/storage/standard/package.json
+++ b/appengine/storage/standard/package.json
@@ -6,7 +6,7 @@
     "test": "mocha system-test/*.test.js --timeout=30000"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "@google-cloud/storage": "^2.3.3",

--- a/appengine/twilio/package.json
+++ b/appengine/twilio/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/typescript/package.json
+++ b/appengine/typescript/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "prepare": "npm run gcp-build",

--- a/appengine/websockets/package.json
+++ b/appengine/websockets/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "deploy": "gcloud app deploy",

--- a/auth/package.json
+++ b/auth/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run system-test",

--- a/cloud-sql/mysql/mysql/package.json
+++ b/cloud-sql/mysql/mysql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "system-test": "mocha test/*.test.js --timeout=60000 --exit",

--- a/cloud-sql/postgres/knex/package.json
+++ b/cloud-sql/postgres/knex/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "unit-test": "mocha test/*.test.js --timeout=60000 --exit",

--- a/containerengine/hello-world/package.json
+++ b/containerengine/hello-world/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node server.js",

--- a/endpoints/getting-started-grpc/package.json
+++ b/endpoints/getting-started-grpc/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node server.js",

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/functions/background/package.json
+++ b/functions/background/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -4,7 +4,7 @@
   "description": "Examples of integrating Cloud Functions with billing",
   "main": "index.js",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/composer-storage-trigger/package.json
+++ b/functions/composer-storage-trigger/package.json
@@ -6,7 +6,7 @@
     "node-fetch": "^2.2.0"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "private": true,
   "license": "Apache-2.0",

--- a/functions/concepts/package.json
+++ b/functions/concepts/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "request": "^2.85.0"

--- a/functions/datastore/package.json
+++ b/functions/datastore/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" mocha test/*.test.js --timeout=60000",

--- a/functions/env_vars/package.json
+++ b/functions/env_vars/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/firebase/package.json
+++ b/functions/firebase/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "ava -T 30s test/*.test.js"

--- a/functions/headless-chrome/package.json
+++ b/functions/headless-chrome/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "e2e-test": "export FUNCTIONS_CMD='gcloud beta functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCF_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" && npm run test",

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "e2e-test": "export FUNCTIONS_CMD='gcloud functions' && sh test/updateFunctions.sh && BASE_URL=\"https://$GCP_REGION-$GCLOUD_PROJECT.cloudfunctions.net/\" mocha test/*.test.js --timeout=60000 --exit",

--- a/functions/http/package.json
+++ b/functions/http/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=60000"

--- a/functions/imagemagick/package.json
+++ b/functions/imagemagick/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/log/package.json
+++ b/functions/log/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/node8/package.json
+++ b/functions/node8/package.json
@@ -6,7 +6,7 @@
     "test": "mocha test/*.test.js --timeout=20000"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/functions/ocr/app/package.json
+++ b/functions/ocr/app/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/pubsub/package.json
+++ b/functions/pubsub/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/scheduleinstance/package.json
+++ b/functions/scheduleinstance/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/sendgrid/package.json
+++ b/functions/sendgrid/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/spanner/package.json
+++ b/functions/spanner/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/functions/speech-to-speech/functions/package.json
+++ b/functions/speech-to-speech/functions/package.json
@@ -7,7 +7,7 @@
   "author": "Google LLC",
   "private": true,
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/functions/sql/package.json
+++ b/functions/sql/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start-proxy-mysql": "cloud_sql_proxy -instances=$INSTANCE_CONNECTION_NAME-mysql=tcp:3306 &",

--- a/functions/tips/package.json
+++ b/functions/tips/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=60000 --exit"

--- a/functions/uuid/package.json
+++ b/functions/uuid/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha test/*.test.js --timeout=20000"

--- a/healthcare/datasets/package.json
+++ b/healthcare/datasets/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha system-test/*.test.js --timeout=60000"

--- a/healthcare/dicom/package.json
+++ b/healthcare/dicom/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha system-test/*.test.js --timeout=60000"

--- a/healthcare/fhir/package.json
+++ b/healthcare/fhir/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha system-test/*.test.js --timeout=60000"

--- a/healthcare/hl7v2/package.json
+++ b/healthcare/hl7v2/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha system-test/*.test.js --timeout=60000"

--- a/iot/beta-features/gateway/package.json
+++ b/iot/beta-features/gateway/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run unit-test",

--- a/iot/http_example/package.json
+++ b/iot/http_example/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run system-test",

--- a/iot/manager/package.json
+++ b/iot/manager/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run system-test",

--- a/iot/mqtt_example/package.json
+++ b/iot/mqtt_example/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run system-test",

--- a/jobs/v2/package.json
+++ b/jobs/v2/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run system-test",

--- a/jobs/v3/package.json
+++ b/jobs/v3/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "repo-tools test install --cmd=npm -- run system-test",

--- a/memorystore/redis/package.json
+++ b/memorystore/redis/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "redis": "^2.8.0"

--- a/opencensus/package.json
+++ b/opencensus/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "start": "node metrics-quickstart.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/storage-transfer/package.json
+++ b/storage-transfer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "unit-test": "mocha test/*.test.js --timeout=10000",


### PR DESCRIPTION
Apologies for the churn here.  Just kicking all these back to `8.0.0` to avoid the ire of GAE. 