### PR TITLE
More GAE lintfixes + prefer function expressions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,3 +25,7 @@ rules:
   promise/prefer-await-to-then: warn
   promise/no-nesting: warn
   prefer-destructuring: warn
+  func-style:
+    - 1
+    - expression
+    - allowArrowFunctions: true

--- a/appengine/analytics/app.js
+++ b/appengine/analytics/app.js
@@ -26,7 +26,7 @@ app.enable('trust proxy');
 // Engine, but will need to be set manually when running locally. See README.md.
 const {GA_TRACKING_ID} = process.env;
 
-function trackEvent(category, action, label, value) {
+const trackEvent = (category, action, label, value) => {
   const data = {
     // API Version.
     v: '1',
@@ -48,7 +48,7 @@ function trackEvent(category, action, label, value) {
   };
 
   return got.post('http://www.google-analytics.com/collect', data);
-}
+};
 
 app.get('/', async (req, res, next) => {
   // Event value must be numeric.

--- a/appengine/cloudsql/createTables.js
+++ b/appengine/cloudsql/createTables.js
@@ -24,7 +24,7 @@ const FIELDS = ['user', 'password', 'database'];
 prompt.start();
 
 // Prompt the user for connection details
-prompt.get(FIELDS, (err, config) => {
+prompt.get(FIELDS, async (err, config) => {
   if (err) {
     console.error(err);
     return;
@@ -34,21 +34,20 @@ prompt.get(FIELDS, (err, config) => {
   const knex = Knex({client: 'mysql', connection: config});
 
   // Create the "visits" table
-  knex.schema
-    .createTable('visits', table => {
+  try {
+    await knex.schema.createTable('visits', table => {
       table.increments();
       table.timestamp('timestamp');
       table.string('userIp');
-    })
-    .then(() => {
-      console.log(`Successfully created 'visits' table.`);
-      return knex.destroy();
-    })
-    .catch(err => {
-      console.error(`Failed to create 'visits' table:`, err);
-      if (knex) {
-        knex.destroy();
-      }
     });
+
+    console.log(`Successfully created 'visits' table.`);
+  } catch (err) {
+    console.error(`Failed to create 'visits' table:`, err);
+  } finally {
+    if (knex) {
+      knex.destroy();
+    }
+  }
 });
 // [END gae_flex_mysql_create_tables]

--- a/appengine/cloudsql/server.js
+++ b/appengine/cloudsql/server.js
@@ -26,9 +26,7 @@ const crypto = require('crypto');
 const app = express();
 app.enable('trust proxy');
 
-const knex = connect();
-
-function connect() {
+const connect = () => {
   // [START gae_flex_mysql_connect]
   const config = {
     user: process.env.SQL_USER,
@@ -51,7 +49,9 @@ function connect() {
   // [END gae_flex_mysql_connect]
 
   return knex;
-}
+};
+
+const knex = connect();
 
 /**
  * Insert a visit record into the database.
@@ -60,9 +60,9 @@ function connect() {
  * @param {object} visit The visit record to insert.
  * @returns {Promise}
  */
-function insertVisit(knex, visit) {
+const insertVisit = (knex, visit) => {
   return knex('visits').insert(visit);
-}
+};
 
 /**
  * Retrieve the latest 10 visit records from the database.
@@ -70,20 +70,19 @@ function insertVisit(knex, visit) {
  * @param {object} knex The Knex connection object.
  * @returns {Promise}
  */
-function getVisits(knex) {
-  return knex
+const getVisits = async knex => {
+  const results = await knex
     .select('timestamp', 'userIp')
     .from('visits')
     .orderBy('timestamp', 'desc')
-    .limit(10)
-    .then(results => {
-      return results.map(
-        visit => `Time: ${visit.timestamp}, AddrHash: ${visit.userIp}`
-      );
-    });
-}
+    .limit(10);
 
-app.get('/', (req, res, next) => {
+  return results.map(
+    visit => `Time: ${visit.timestamp}, AddrHash: ${visit.userIp}`
+  );
+};
+
+app.get('/', async (req, res, next) => {
   // Create a visit record to be stored in the database
   const visit = {
     timestamp: new Date(),
@@ -95,19 +94,19 @@ app.get('/', (req, res, next) => {
       .substr(0, 7),
   };
 
-  insertVisit(knex, visit)
+  try {
+    await insertVisit(knex, visit);
+
     // Query the last 10 visits from the database.
-    .then(() => getVisits(knex))
-    .then(visits => {
-      res
-        .status(200)
-        .set('Content-Type', 'text/plain')
-        .send(`Last 10 visits:\n${visits.join('\n')}`)
-        .end();
-    })
-    .catch(err => {
-      next(err);
-    });
+    const visits = await getVisits(knex);
+    res
+      .status(200)
+      .set('Content-Type', 'text/plain')
+      .send(`Last 10 visits:\n${visits.join('\n')}`)
+      .end();
+  } catch (err) {
+    next(err);
+  }
 });
 
 const PORT = process.env.PORT || 8080;

--- a/appengine/cloudsql/test/createTables.test.js
+++ b/appengine/cloudsql/test/createTables.test.js
@@ -25,7 +25,7 @@ const SAMPLE_PATH = path.join(__dirname, '../createTables.js');
 
 const exampleConfig = ['user', 'password', 'database'];
 
-function getSample() {
+const getSample = () => {
   const configMock = exampleConfig;
   const promptMock = {
     start: sinon.stub(),
@@ -56,7 +56,7 @@ function getSample() {
       prompt: promptMock,
     },
   };
-}
+};
 
 beforeEach(tools.stubConsole);
 afterEach(tools.restoreConsole);
@@ -70,15 +70,15 @@ it('should create a table', async () => {
     prompt: sample.mocks.prompt,
   });
 
-  assert.strictEqual(sample.mocks.prompt.start.calledOnce, true);
-  assert.strictEqual(sample.mocks.prompt.get.calledOnce, true);
+  assert.ok(sample.mocks.prompt.start.calledOnce);
+  assert.ok(sample.mocks.prompt.get.calledOnce);
   assert.deepStrictEqual(
     sample.mocks.prompt.get.firstCall.args[0],
     exampleConfig
   );
 
   await new Promise(r => setTimeout(r, 10));
-  assert.strictEqual(sample.mocks.Knex.calledOnce, true);
+  assert.ok(sample.mocks.Knex.calledOnce);
   assert.deepStrictEqual(sample.mocks.Knex.firstCall.args, [
     {
       client: 'mysql',
@@ -86,14 +86,14 @@ it('should create a table', async () => {
     },
   ]);
 
-  assert.strictEqual(sample.mocks.knex.schema.createTable.calledOnce, true);
+  assert.ok(sample.mocks.knex.schema.createTable.calledOnce);
   assert.strictEqual(
     sample.mocks.knex.schema.createTable.firstCall.args[0],
     'visits'
   );
 
-  assert.strictEqual(console.log.calledWith(expectedResult), true);
-  assert.strictEqual(sample.mocks.knex.destroy.calledOnce, true);
+  assert.ok(console.log.calledWith(expectedResult));
+  assert.ok(sample.mocks.knex.destroy.calledOnce);
 });
 
 it('should handle prompt error', async () => {
@@ -107,9 +107,9 @@ it('should handle prompt error', async () => {
   });
 
   await new Promise(r => setTimeout(r, 10));
-  assert.strictEqual(console.error.calledOnce, true);
-  assert.strictEqual(console.error.calledWith(error), true);
-  assert.strictEqual(sample.mocks.Knex.notCalled, true);
+  assert.ok(console.error.calledOnce);
+  assert.ok(console.error.calledWith(error));
+  assert.ok(sample.mocks.Knex.notCalled);
 });
 
 it('should handle knex creation error', async () => {
@@ -124,10 +124,9 @@ it('should handle knex creation error', async () => {
     prompt: sample.mocks.prompt,
   });
   await new Promise(r => setTimeout(r, 10));
-  assert.strictEqual(console.error.calledOnce, true);
-  assert.strictEqual(
-    console.error.calledWith(`Failed to create 'visits' table:`, error),
-    true
+  assert.ok(console.error.calledOnce);
+  assert.ok(
+    console.error.calledWith(`Failed to create 'visits' table:`, error)
   );
-  assert.strictEqual(sample.mocks.knex.destroy.calledOnce, true);
+  assert.ok(sample.mocks.knex.destroy.calledOnce);
 });

--- a/appengine/cloudsql/test/server.test.js
+++ b/appengine/cloudsql/test/server.test.js
@@ -25,7 +25,7 @@ const tools = require('@google-cloud/nodejs-repo-tools');
 
 const SAMPLE_PATH = path.join(__dirname, '../server.js');
 
-function getSample() {
+const getSample = () => {
   const testApp = express();
   sinon.stub(testApp, 'listen').yields();
   const expressMock = sinon.stub().returns(testApp);
@@ -72,7 +72,7 @@ function getSample() {
       process: processMock,
     },
   };
-}
+};
 
 beforeEach(tools.stubConsole);
 afterEach(tools.restoreConsole);
@@ -80,8 +80,8 @@ afterEach(tools.restoreConsole);
 it('should set up sample in Postgres', () => {
   const sample = getSample();
 
-  assert.strictEqual(sample.mocks.express.calledOnce, true);
-  assert.strictEqual(sample.mocks.Knex.calledOnce, true);
+  assert.ok(sample.mocks.express.calledOnce);
+  assert.ok(sample.mocks.Knex.calledOnce);
   assert.deepStrictEqual(sample.mocks.Knex.firstCall.args, [
     {
       client: 'mysql',
@@ -116,7 +116,7 @@ it('should handle insert error', async () => {
     .get('/')
     .expect(500)
     .expect(response => {
-      assert.strictEqual(response.text.includes(expectedResult), true);
+      assert.ok(response.text.includes(expectedResult));
     });
 });
 
@@ -130,6 +130,6 @@ it('should handle read error', async () => {
     .get('/')
     .expect(500)
     .expect(response => {
-      assert.strictEqual(response.text.includes(expectedResult), true);
+      assert.ok(response.text.includes(expectedResult));
     });
 });

--- a/appengine/cloudsql_postgresql/createTables.js
+++ b/appengine/cloudsql_postgresql/createTables.js
@@ -24,7 +24,7 @@ const FIELDS = ['user', 'password', 'database'];
 prompt.start();
 
 // Prompt the user for connection details
-prompt.get(FIELDS, (err, config) => {
+prompt.get(FIELDS, async (err, config) => {
   if (err) {
     console.error(err);
     return;
@@ -34,21 +34,20 @@ prompt.get(FIELDS, (err, config) => {
   const knex = Knex({client: 'pg', connection: config});
 
   // Create the "visits" table
-  knex.schema
-    .createTable('visits', table => {
+  try {
+    await knex.schema.createTable('visits', table => {
       table.increments();
       table.timestamp('timestamp');
       table.string('userIp');
-    })
-    .then(() => {
-      console.log(`Successfully created 'visits' table.`);
-      return knex.destroy();
-    })
-    .catch(err => {
-      console.error(`Failed to create 'visits' table:`, err);
-      if (knex) {
-        knex.destroy();
-      }
     });
+
+    console.log(`Successfully created 'visits' table.`);
+    return knex.destroy();
+  } catch (err) {
+    console.error(`Failed to create 'visits' table:`, err);
+    if (knex) {
+      knex.destroy();
+    }
+  }
 });
 // [END gae_flex_postgres_create_tables]

--- a/appengine/cloudsql_postgresql/test/createTables.test.js
+++ b/appengine/cloudsql_postgresql/test/createTables.test.js
@@ -25,7 +25,7 @@ const SAMPLE_PATH = path.join(__dirname, '../createTables.js');
 
 const exampleConfig = ['user', 'password', 'database'];
 
-function getSample() {
+const getSample = () => {
   const configMock = exampleConfig;
   const promptMock = {
     start: sinon.stub(),
@@ -56,7 +56,7 @@ function getSample() {
       prompt: promptMock,
     },
   };
-}
+};
 
 beforeEach(tools.stubConsole);
 afterEach(tools.restoreConsole);
@@ -70,15 +70,15 @@ it('should create a table', async () => {
     prompt: sample.mocks.prompt,
   });
 
-  assert.strictEqual(sample.mocks.prompt.start.calledOnce, true);
-  assert.strictEqual(sample.mocks.prompt.get.calledOnce, true);
+  assert.ok(sample.mocks.prompt.start.calledOnce);
+  assert.ok(sample.mocks.prompt.get.calledOnce);
   assert.deepStrictEqual(
     sample.mocks.prompt.get.firstCall.args[0],
     exampleConfig
   );
 
   await new Promise(r => setTimeout(r, 10));
-  assert.strictEqual(sample.mocks.Knex.calledOnce, true);
+  assert.ok(sample.mocks.Knex.calledOnce);
   assert.deepStrictEqual(sample.mocks.Knex.firstCall.args, [
     {
       client: 'pg',
@@ -86,14 +86,14 @@ it('should create a table', async () => {
     },
   ]);
 
-  assert.strictEqual(sample.mocks.knex.schema.createTable.calledOnce, true);
+  assert.ok(sample.mocks.knex.schema.createTable.calledOnce);
   assert.strictEqual(
     sample.mocks.knex.schema.createTable.firstCall.args[0],
     'visits'
   );
 
-  assert.strictEqual(console.log.calledWith(expectedResult), true);
-  assert.strictEqual(sample.mocks.knex.destroy.calledOnce, true);
+  assert.ok(console.log.calledWith(expectedResult));
+  assert.ok(sample.mocks.knex.destroy.calledOnce);
 });
 
 it('should handle prompt error', async () => {
@@ -107,9 +107,9 @@ it('should handle prompt error', async () => {
   });
 
   await new Promise(r => setTimeout(r, 10));
-  assert.strictEqual(console.error.calledOnce, true);
-  assert.strictEqual(console.error.calledWith(error), true);
-  assert.strictEqual(sample.mocks.Knex.notCalled, true);
+  assert.ok(console.error.calledOnce);
+  assert.ok(console.error.calledWith(error));
+  assert.ok(sample.mocks.Knex.notCalled);
 });
 
 it('should handle knex creation error', async () => {
@@ -125,10 +125,9 @@ it('should handle knex creation error', async () => {
   });
 
   await new Promise(r => setTimeout(r, 10));
-  assert.strictEqual(console.error.calledOnce, true);
-  assert.strictEqual(
-    console.error.calledWith(`Failed to create 'visits' table:`, error),
-    true
+  assert.ok(console.error.calledOnce);
+  assert.ok(
+    console.error.calledWith(`Failed to create 'visits' table:`, error)
   );
-  assert.strictEqual(sample.mocks.knex.destroy.calledOnce, true);
+  assert.ok(sample.mocks.knex.destroy.calledOnce);
 });

--- a/appengine/cloudsql_postgresql/test/server.test.js
+++ b/appengine/cloudsql_postgresql/test/server.test.js
@@ -25,7 +25,7 @@ const tools = require('@google-cloud/nodejs-repo-tools');
 
 const SAMPLE_PATH = path.join(__dirname, '../server.js');
 
-function getSample() {
+const getSample = () => {
   const testApp = express();
   sinon.stub(testApp, 'listen').yields();
   const expressMock = sinon.stub().returns(testApp);
@@ -72,7 +72,7 @@ function getSample() {
       process: processMock,
     },
   };
-}
+};
 
 beforeEach(tools.stubConsole);
 afterEach(tools.restoreConsole);

--- a/appengine/datastore/app.js
+++ b/appengine/datastore/app.js
@@ -37,24 +37,24 @@ const datastore = new Datastore();
  *
  * @param {object} visit The visit record to insert.
  */
-function insertVisit(visit) {
+const insertVisit = visit => {
   return datastore.save({
     key: datastore.key('visit'),
     data: visit,
   });
-}
+};
 
 /**
  * Retrieve the latest 10 visit records from the database.
  */
-function getVisits() {
+const getVisits = () => {
   const query = datastore
     .createQuery('visit')
     .order('timestamp', {descending: true})
     .limit(10);
 
   return datastore.runQuery(query);
-}
+};
 
 app.get('/', async (req, res, next) => {
   // Create a visit record to be stored in the database
@@ -70,8 +70,7 @@ app.get('/', async (req, res, next) => {
 
   try {
     await insertVisit(visit);
-    const results = await getVisits();
-    const entities = results[0];
+    const [entities] = await getVisits();
     const visits = entities.map(
       entity => `Time: ${entity.timestamp}, AddrHash: ${entity.userIp}`
     );

--- a/appengine/endpoints/app.js
+++ b/appengine/endpoints/app.js
@@ -26,14 +26,14 @@ app.post('/echo', (req, res) => {
   res.status(200).json({message: req.body.message});
 });
 
-function authInfoHandler(req, res) {
+const authInfoHandler = (req, res) => {
   let authUser = {id: 'anonymous'};
   const encodedInfo = req.get('X-Endpoint-API-UserInfo');
   if (encodedInfo) {
     authUser = JSON.parse(Buffer.from(encodedInfo, 'base64'));
   }
   res.status(200).json(authUser);
-}
+};
 
 app.get('/auth/info/googlejwt', authInfoHandler);
 app.get('/auth/info/googleidtoken', authInfoHandler);

--- a/appengine/endpoints/test/app.test.js
+++ b/appengine/endpoints/test/app.test.js
@@ -26,7 +26,7 @@ const tools = require('@google-cloud/nodejs-repo-tools');
 
 const SAMPLE_PATH = path.join(__dirname, '../app.js');
 
-function getSample() {
+const getSample = () => {
   const testApp = express();
   const expressMock = sinon.stub().returns(testApp);
   const app = proxyquire(SAMPLE_PATH, {
@@ -39,7 +39,7 @@ function getSample() {
       express: expressMock,
     },
   };
-}
+};
 
 beforeEach(tools.stubConsole);
 afterEach(tools.restoreConsole);

--- a/appengine/mailjet/app.js
+++ b/appengine/mailjet/app.js
@@ -41,7 +41,7 @@ app.get('/', (req, res) => {
 });
 
 // [START gae_flex_mailjet_send_message]
-app.post('/hello', (req, res, next) => {
+app.post('/hello', async (req, res, next) => {
   const options = {
     Messages: [
       {
@@ -61,19 +61,18 @@ app.post('/hello', (req, res, next) => {
     ],
   };
 
-  const request = Mailjet.post('send', {version: 'v3.1'}).request(options);
-
-  request
-    .then((response, body) => {
-      console.log(response.statusCode, body);
-      // Render the index route on success
-      return res.render('index', {
-        sent: true,
-      });
-    })
-    .catch(err => {
-      return next(err);
+  try {
+    const [response, body] = await Mailjet.post('send', {
+      version: 'v3.1',
+    }).request(options);
+    console.log(response.statusCode, body);
+    // Render the index route on success
+    return res.render('index', {
+      sent: true,
     });
+  } catch (err) {
+    return next(err);
+  }
 });
 // [END gae_flex_mailjet_send_message]
 

--- a/appengine/metadata/standard/server.js
+++ b/appengine/metadata/standard/server.js
@@ -24,7 +24,7 @@ app.enable('trust proxy');
 const METADATA_PROJECT_ID_URL =
   'http://metadata.google.internal/computeMetadata/v1/project/project-id';
 
-function getProjectId() {
+const getProjectId = () => {
   const options = {
     headers: {
       'Metadata-Flavor': 'Google',
@@ -32,7 +32,7 @@ function getProjectId() {
   };
 
   return request(METADATA_PROJECT_ID_URL, options);
-}
+};
 
 app.get('/', async (req, res, next) => {
   try {

--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -103,7 +103,7 @@ app.post('/pubsub/authenticated-push', jsonBodyParser, async (req, res) => {
   try {
     // Get the Cloud Pub/Sub-generated JWT in the "Authorization" header.
     const bearer = req.header('Authorization');
-    const token = bearer.match(/Bearer (.*)/)[1];
+    const [, token] = bearer.match(/Bearer (.*)/);
     tokens.push(token);
 
     // Verify and decode the JWT.

--- a/appengine/pubsub/test/app.test.js
+++ b/appengine/pubsub/test/app.test.js
@@ -38,7 +38,7 @@ const publicCert = fs.readFileSync(path.join(fixtures, 'public_cert.pem'));
 
 const sandbox = sinon.createSandbox();
 
-function createFakeToken() {
+const createFakeToken = () => {
   const now = Date.now() / 1000;
 
   const payload = {
@@ -58,7 +58,7 @@ function createFakeToken() {
   };
 
   return jwt.sign(payload, privateKey, options);
-}
+};
 
 afterEach(() => {
   sandbox.restore();

--- a/appengine/twilio/test/app.test.js
+++ b/appengine/twilio/test/app.test.js
@@ -45,7 +45,7 @@ const getSample = () => {
   };
 };
 
-it('should send an SMS message', async () => {
+it('should send an SMS message', () => {
   const {supertest} = getSample();
 
   return supertest
@@ -57,7 +57,7 @@ it('should send an SMS message', async () => {
     });
 });
 
-it('should receive an SMS message', async () => {
+it('should receive an SMS message', () => {
   const {supertest, mocks} = getSample();
 
   return supertest
@@ -70,7 +70,7 @@ it('should receive an SMS message', async () => {
     });
 });
 
-it('should receive a call', async () => {
+it('should receive a call', () => {
   const {supertest, mocks} = getSample();
 
   return supertest


### PR DESCRIPTION
**Note:** this change adds a rule preferring function expressions (as a `warning`).

(As an example: `func baz(quux) { ... }` --> `const baz = (quux) => { ... }`)