### PR TITLE
Force mocha to exit after running all tests

### DIFF
--- a/appengine/building-an-app/update/package.json
+++ b/appengine/building-an-app/update/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "deploy": "gcloud app deploy",
-    "test": "mocha test/*.test.js --timeout=20000"
+    "test": "mocha test/*.test.js --exit --timeout=20000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
mocha v4 no longer ends itself when all the tests are finished; with HTTP samples continuing to listen at 8080 the tests will run forever.