### PR TITLE
fix: Make functions_http_method consistent with other samples

### DIFF
--- a/functions/http/index.js
+++ b/functions/http/index.js
@@ -55,16 +55,6 @@ exports.helloContent = (req, res) => {
 // [END functions_http_content]
 
 // [START functions_http_method]
-function handleGET(req, res) {
-  // Do something with the GET request
-  res.status(200).send('Hello World!');
-}
-
-function handlePUT(req, res) {
-  // Do something with the PUT request
-  res.status(403).send('Forbidden!');
-}
-
 /**
  * Responds to a GET request with "Hello World!". Forbids a PUT request.
  *
@@ -77,10 +67,10 @@ function handlePUT(req, res) {
 exports.helloHttp = (req, res) => {
   switch (req.method) {
     case 'GET':
-      handleGET(req, res);
+      res.status(200).send('Hello World!');
       break;
     case 'PUT':
-      handlePUT(req, res);
+      res.status(403).send('Forbidden!');
       break;
     default:
       res.status(405).send({error: 'Something blew up!'});


### PR DESCRIPTION
Inline function handlers like in Go and Python. It looks weird (and is unnecessary) having standalone functions.

See:
https://cloud.google.com/functions/docs/writing/http#handling_http_methods