### PR TITLE
kokoro/run: fallback from PR # to commit in service name

### DIFF
--- a/.kokoro/build-with-run.sh
+++ b/.kokoro/build-with-run.sh
@@ -33,7 +33,9 @@ gcloud config set project $GOOGLE_CLOUD_PROJECT
 # to run them concurrently.
 export SAMPLE_VERSION="${KOKORO_GIT_COMMIT:-latest}"
 export SAMPLE_NAME="$(basename $(pwd))"
-export SERVICE_NAME="${SAMPLE_NAME}-${KOKORO_GITHUB_PULL_REQUEST_NUMBER}"
+# Builds not triggered by a PR will fall back to the commit hash then "latest".
+SUFFIX=${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-${SAMPLE_VERSION:0:12}}
+export SERVICE_NAME="${SAMPLE_NAME}-${SUFFIX}"
 export CONTAINER_IMAGE="gcr.io/${GOOGLE_CLOUD_PROJECT}/run-${SAMPLE_NAME}:${SAMPLE_VERSION}"
 
 # Register post-test cleanup.


### PR DESCRIPTION
## Problem

Cloud Run release testing does not rely on a PR. The `.kokoro/build-with-run.sh` script names a service with a hard dependency on a PR-specific environment variable. As a result, end-to-end tests attempt to deploy with an invalid name (e.g., `sample-name-`).

## Solution

This PR adjusts the construction of the service name to fall back to the first 12 characters of the commit hash of the change if the PR environment variable is not available.