### PR TITLE
Use supertest instead of repo-tools test app

### DIFF
--- a/appengine/hello-world/standard/app.js
+++ b/appengine/hello-world/standard/app.js
@@ -34,3 +34,5 @@ app.listen(PORT, () => {
   console.log('Press Ctrl+C to quit.');
 });
 // [END gae_node_request_example]
+
+module.exports = app;

--- a/appengine/hello-world/standard/package.json
+++ b/appengine/hello-world/standard/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "system-test": "repo-tools test app",
+    "system-test": "mocha --exit test/*.test.js",
     "test": "npm run system-test",
     "e2e-test": "repo-tools test deploy"
   },
@@ -23,7 +23,9 @@
     "express": "^4.16.3"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.3.0"
+    "@google-cloud/nodejs-repo-tools": "^3.3.0",
+    "mocha": "^6.1.4",
+    "supertest": "^4.0.2"
   },
   "cloud-repo-tools": {
     "test": {

--- a/appengine/hello-world/standard/test/app.test.js
+++ b/appengine/hello-world/standard/test/app.test.js
@@ -1,0 +1,16 @@
+const app = require('../app');
+
+const request = require('supertest');
+
+describe('GET /', () => {
+  it('should get 200', done => {
+    request(app)
+      .get('/')
+      .expect(200, done);
+  }),
+    it('should get Hello World', done => {
+      request(app)
+        .get('/')
+        .expect('Hello, world!', done);
+    });
+});


### PR DESCRIPTION
Trying to remove `repo-tools`. Will send a follow up PR that removes `repo-tools test deploy`. 

Ref: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/issues/1247