### PR TITLE
Use native Buffer.from()

### DIFF
--- a/appengine/endpoints/app.js
+++ b/appengine/endpoints/app.js
@@ -17,7 +17,6 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const {Buffer} = require('safe-buffer');
 
 const app = express();
 app.use(bodyParser.json());

--- a/appengine/endpoints/package.json
+++ b/appengine/endpoints/package.json
@@ -23,8 +23,7 @@
   },
   "dependencies": {
     "body-parser": "^1.18.3",
-    "express": "^4.16.4",
-    "safe-buffer": "^5.1.2"
+    "express": "^4.16.4"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/appengine/endpoints/test/app.test.js
+++ b/appengine/endpoints/test/app.test.js
@@ -15,7 +15,6 @@
 
 'use strict';
 
-const {Buffer} = require('safe-buffer');
 const express = require('express');
 const path = require('path');
 const proxyquire = require('proxyquire').noCallThru();

--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -19,7 +19,6 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const {OAuth2Client} = require('google-auth-library');
 const path = require('path');
-const {Buffer} = require('safe-buffer');
 const process = require('process'); // Required for mocking environment variables
 
 // By default, the client will authenticate using the service account file

--- a/appengine/pubsub/package.json
+++ b/appengine/pubsub/package.json
@@ -17,8 +17,7 @@
     "body-parser": "^1.18.3",
     "express": "^4.16.3",
     "google-auth-library": "^5.0.0",
-    "pug": "^2.0.1",
-    "safe-buffer": "^5.1.2"
+    "pug": "^2.0.1"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/endpoints/getting-started/app.js
+++ b/endpoints/getting-started/app.js
@@ -19,7 +19,6 @@
 // [START setup]
 const express = require('express');
 const bodyParser = require('body-parser');
-const {Buffer} = require('safe-buffer');
 
 const app = express();
 

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "body-parser": "^1.18.3",
-    "express": "^4.16.4",
-    "safe-buffer": "^5.1.2"
+    "express": "^4.16.4"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/endpoints/getting-started/test/app.test.js
+++ b/endpoints/getting-started/test/app.test.js
@@ -15,7 +15,6 @@
 
 'use strict';
 
-const {Buffer} = require('safe-buffer');
 const express = require('express');
 const path = require('path');
 const proxyquire = require('proxyquire').noPreserveCache();

--- a/functions/helloworld/index.js
+++ b/functions/helloworld/index.js
@@ -15,8 +15,6 @@
 
 'use strict';
 
-const {Buffer} = require('safe-buffer');
-
 // [START functions_helloworld_http]
 const escapeHtml = require('escape-html');
 

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "@google-cloud/debug-agent": "^4.0.0",
     "escape-html": "^1.0.3",
-    "pug": "^2.0.3",
-    "safe-buffer": "^5.1.2"
+    "pug": "^2.0.3"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/functions/helloworld/test/index.test.js
+++ b/functions/helloworld/test/index.test.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-const {Buffer} = require('safe-buffer');
 const path = require('path');
 const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');

--- a/functions/http/package.json
+++ b/functions/http/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@google-cloud/storage": "^3.0.0",
     "busboy": "^0.3.0",
-    "escape-html": "^1.0.3",
-    "safe-buffer": "^5.1.2"
+    "escape-html": "^1.0.3"
   },
   "cloud-repo-tools": {
     "requiresKeyFile": true,

--- a/functions/http/test/index.test.js
+++ b/functions/http/test/index.test.js
@@ -15,7 +15,6 @@
 
 'use strict';
 
-const {Buffer} = require('safe-buffer');
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const assert = require('assert');

--- a/functions/ocr/app/index.js
+++ b/functions/ocr/app/index.js
@@ -38,7 +38,6 @@ const vision = new Vision.ImageAnnotatorClient();
 const {Translate} = require('@google-cloud/translate');
 const translate = new Translate();
 
-const {Buffer} = require('safe-buffer');
 // [END functions_ocr_setup]
 
 // [START functions_ocr_publish]

--- a/functions/ocr/app/package.json
+++ b/functions/ocr/app/package.json
@@ -19,8 +19,7 @@
     "@google-cloud/storage": "^3.0.0",
     "@google-cloud/translate": "^4.0.0",
     "@google-cloud/vision": "^1.0.0",
-    "nconf": "^0.10.0",
-    "safe-buffer": "^5.1.2"
+    "nconf": "^0.10.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/functions/ocr/app/test/index.test.js
+++ b/functions/ocr/app/test/index.test.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const assert = require('assert');
-const {Buffer} = require('safe-buffer');
 
 const {Storage} = require('@google-cloud/storage');
 const storage = new Storage();

--- a/functions/pubsub/index.js
+++ b/functions/pubsub/index.js
@@ -22,8 +22,6 @@ const {PubSub} = require('@google-cloud/pubsub');
 const pubsub = new PubSub();
 // [END functions_pubsub_setup]
 
-const {Buffer} = require('safe-buffer');
-
 // [START functions_pubsub_publish]
 /**
  * Publishes a message to a Cloud Pub/Sub Topic.

--- a/functions/pubsub/package.json
+++ b/functions/pubsub/package.json
@@ -15,8 +15,7 @@
     "test": "mocha test/*.test.js --timeout=20000"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^0.28.1",
-    "safe-buffer": "^5.2.0"
+    "@google-cloud/pubsub": "^0.28.1"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/functions/pubsub/test/index.test.js
+++ b/functions/pubsub/test/index.test.js
@@ -17,7 +17,6 @@
 
 const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
-const {Buffer} = require('safe-buffer');
 const path = require('path');
 
 const execPromise = require('child-process-promise').exec;

--- a/functions/scheduleinstance/index.js
+++ b/functions/scheduleinstance/index.js
@@ -15,7 +15,6 @@
 
 // [START functions_start_instance_pubsub]
 // [START functions_stop_instance_pubsub]
-const {Buffer} = require('safe-buffer');
 const Compute = require('@google-cloud/compute');
 const compute = new Compute();
 // [END functions_stop_instance_pubsub]

--- a/functions/scheduleinstance/package.json
+++ b/functions/scheduleinstance/package.json
@@ -21,7 +21,6 @@
     "sinon": "^7.0.0"
   },
   "dependencies": {
-    "@google-cloud/compute": "^1.0.0",
-    "safe-buffer": "^5.1.2"
+    "@google-cloud/compute": "^1.0.0"
   }
 }

--- a/functions/scheduleinstance/test/index.test.js
+++ b/functions/scheduleinstance/test/index.test.js
@@ -15,7 +15,6 @@
 
 'use strict';
 
-const {Buffer} = require('safe-buffer');
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const assert = require('assert');

--- a/functions/sendgrid/index.js
+++ b/functions/sendgrid/index.js
@@ -16,7 +16,6 @@
 'use strict';
 
 // [START functions_sendgrid_setup]
-const {Buffer} = require('safe-buffer');
 const sendgrid = require('sendgrid');
 const config = require('./config.json');
 const uuid = require('uuid');

--- a/functions/sendgrid/package.json
+++ b/functions/sendgrid/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@google-cloud/bigquery": "^4.0.0",
     "@google-cloud/storage": "^3.0.0",
-    "safe-buffer": "^5.1.2",
     "sendgrid": "^5.2.3",
     "uuid": "^3.3.2"
   },

--- a/functions/tips/package.json
+++ b/functions/tips/package.json
@@ -15,8 +15,7 @@
     "test": "mocha test/*.test.js --timeout=60000 --exit"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^0.28.0",
-    "safe-buffer": "^5.1.2"
+    "@google-cloud/pubsub": "^0.28.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/jobs/v3/package.json
+++ b/jobs/v3/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "googleapis": "^42.0.0",
-    "safe-buffer": "^5.1.2",
     "uuid": "^3.3.2",
     "yargs": "^13.2.2"
   },


### PR DESCRIPTION
`safe-buffer` is not needed in Node 8 anymore, we can safely use native
Buffer.from(). See
https://nodejs.org/fr/docs/guides/buffer-constructor-deprecation/