### PR TITLE
Update README.md for functions/

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -32,6 +32,3 @@ environment.
 * [OCR (Optical Character Recognition)](ocr/)
 * [SendGrid](sendgrid/)
 * [Slack](slack/)
-
-## Notes:
-The samples in the `node8` directory are designed for use with Node.js `8.x.x` only. Unless otherwise noted, all other samples are designed for _both_ Node.js `6.x.x` _and_ Node.js `8.x.x`.


### PR DESCRIPTION
Remove list of samples. It doesn't add any value in addition to the directories listed above and it's easily out of date. 

Remove comment about Node 6 as many samples need Node 8 to run now.