### PR TITLE
functions/imagemagick: fix "callback must be a function" error

### DIFF
--- a/functions/imagemagick/index.js
+++ b/functions/imagemagick/index.js
@@ -103,6 +103,7 @@ const blurImage = async (file, blurredBucketName) => {
   }
 
   // Delete the temporary file.
-  return promisify(fs.unlink(tempLocalPath));
+  const unlink = promisify(fs.unlink);
+  return unlink(tempLocalPath);
 };
 // [END functions_imagemagick_blur]


### PR DESCRIPTION
When I run the index.js code from the Functions imagemagick sample in Cloud Run on a Node 10 container, I get the following error:

```
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function 
     at makeCallback (fs.js:136:11) 
     at Object.unlink (fs.js:943:14) 
     at blurImage (/usr/src/app/image.js:106:23) 
     at process._tickCallback (internal/process/next_tick.js:68:7) 
```

Looking at the current promisify implementation around fs.unlink, it differs from what I've read in trying to return the result of the promisify. Taking a note from https://dev.to/mrm8488/from-callbacks-to-fspromises-to-handle-the-file-system-in-nodejs-56p2, with this change I do not see any errors.