### PR TITLE
iot: update samples for yargs v14.0.0

### DIFF
--- a/iot/manager/manager.js
+++ b/iot/manager/manager.js
@@ -942,7 +942,8 @@ const createGateway = async (
   registryId,
   gatewayId,
   publicKeyFormat,
-  publicKeyFile
+  publicKeyFile,
+  gatewayAuthMethod
 ) => {
   // [START iot_create_gateway]
   // const cloudRegion = 'us-central1';
@@ -950,6 +951,7 @@ const createGateway = async (
   // const gatewayId = 'my-gateway';
   // const projectId = 'adjective-noun-123';
   // const registryId = 'my-registry';
+  // const gatewayAuthMethod = 'ASSOCIATION_ONLY';
   const parentName = `projects/${projectId}/locations/${cloudRegion}/registries/${registryId}`;
   console.log('Creating gateway:', gatewayId);
 
@@ -974,7 +976,7 @@ const createGateway = async (
       credentials: credentials,
       gatewayConfig: {
         gatewayType: 'GATEWAY',
-        gatewayAuthMethod: 'ASSOCIATION_ONLY',
+        gatewayAuthMethod: gatewayAuthMethod,
       },
     },
   };
@@ -1669,10 +1671,23 @@ require(`yargs`) // eslint-disable-line
     }
   )
   .command(
-    `createGateway <registryId> <gatewayId>`,
+    `createGateway`,
     `Creates a gateway`,
     {
+      registryId: {
+        description:
+          'Enter a permanent ID that starts with a lower case letter. Must end in a letter or number.',
+        requiresArg: true,
+        type: 'string',
+      },
+      gatewayId: {
+        description:
+          'Enter a permanent ID that starts with a lowercase letter. Must end in a letter or number',
+        requiresArg: true,
+        type: 'string',
+      },
       publicKeyFormat: {
+        alias: 'format',
         default: 'RSA_X509_PEM',
         description: 'Public key format for devices.',
         requiresArg: true,
@@ -1680,9 +1695,23 @@ require(`yargs`) // eslint-disable-line
         type: 'string',
       },
       publicKeyFile: {
+        alias: 'key',
         description:
           'Path to the public key file used for device authentication.',
         requiresArg: true,
+        type: 'string',
+      },
+      gatewayAuthMethod: {
+        default: 'ASSOCIATION_ONLY',
+        description:
+          'Determines how Cloud IoT Core verifies and trusts devices associated with this gateway.',
+        requiresArg: true,
+        choices: [
+          'ASSOCIATION_ONLY',
+          'DEVICE_AUTH_TOKEN_ONLY',
+          'ASSOCIATION_AND_DEVICE_AUTH_TOKEN',
+          'GATEWAY_AUTH_METHOD_UNSPECIFIED',
+        ],
         type: 'string',
       },
     },
@@ -1815,6 +1844,10 @@ require(`yargs`) // eslint-disable-line
   )
   .example(
     `node $0 createRsa256Device my-rsa-device my-registry ../rsa_cert.pem`
+  )
+  .example(
+    `node $0 createGateway --registryId=my-registry --gatewayId=my-gateway\
+    --format=RS256_X509_PEM --key=./rsa_cert.pem`
   )
   .example(`node $0 createUnauthDevice my-device my-registry`)
   .example(`node $0 deleteDevice my-device my-registry`)

--- a/iot/manager/package.json
+++ b/iot/manager/package.json
@@ -20,7 +20,7 @@
     "@google-cloud/iot": "^1.0.0",
     "@google-cloud/pubsub": "^0.28.0",
     "googleapis": "^42.0.0",
-    "yargs": "^13.2.2"
+    "yargs": "^14.0.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",

--- a/iot/manager/system-test/manager.test.js
+++ b/iot/manager/system-test/manager.test.js
@@ -235,7 +235,7 @@ it('should create and get an iam policy', async () => {
 });
 
 it('should create and delete a registry', async () => {
-  const createRegistryId = registryName + 'create';
+  const createRegistryId = `${registryName}-create`;
 
   let output = await tools.runAsync(`${cmd} setupIotTopic ${topicName}`, cwd);
   output = await tools.runAsync(
@@ -252,7 +252,7 @@ it('should create and delete a registry', async () => {
 
 it('should send command message to device', async () => {
   const deviceId = 'test-device-command';
-  const commandMessage = 'rotate 180 degrees';
+  const commandMessage = 'rotate:180_degrees';
 
   await tools.runAsync(
     `${cmd} createRsa256Device ${deviceId} ${registryName} ${rsaPublicCert}`,
@@ -260,13 +260,15 @@ it('should send command message to device', async () => {
   );
 
   tools.runAsync(
-    `node cloudiot_mqtt_example_nodejs.js mqttDeviceDemo --deviceId=${deviceId} --registryId=${registryName} --privateKeyFile=${rsaPrivateKey} --algorithm=RS256 --numMessages=20 --mqttBridgePort=8883`,
+    `node cloudiot_mqtt_example_nodejs.js mqttDeviceDemo --deviceId=${deviceId} --registryId=${registryName}\
+    --privateKeyFile=${rsaPrivateKey} --algorithm=RS256 --numMessages=20 --mqttBridgePort=8883`,
     path.join(__dirname, '../../mqtt_example')
   );
 
   const output = await tools.runAsync(
     `${cmd} sendCommand ${deviceId} ${registryName} ${commandMessage}`
   );
+  console.log(output);
   assert.ok(output.includes('Sent command'));
 
   await tools.runAsync(`${cmd} deleteDevice ${deviceId} ${registryName}`, cwd);
@@ -275,7 +277,8 @@ it('should send command message to device', async () => {
 it('should create a new gateway', async () => {
   const gatewayId = `nodejs-test-gateway-iot-${uuid.v4()}`;
   const gatewayOut = await tools.runAsync(
-    `${cmd} createGateway ${registryName} ${gatewayId} RSA_X509_PEM ${rsaPublicCert}`
+    `${cmd} createGateway --registryId=${registryName} --gatewayId=${gatewayId}\
+    --format=RSA_X509_PEM --key=${rsaPublicCert}`
   );
 
   // test no error on create gateway.
@@ -289,7 +292,8 @@ it('should create a new gateway', async () => {
 it('should list gateways', async () => {
   const gatewayId = `nodejs-test-gateway-iot-${uuid.v4()}`;
   await tools.runAsync(
-    `${cmd} createGateway ${registryName} ${gatewayId} RSA_X509_PEM ${rsaPublicCert}`
+    `${cmd} createGateway --registryId=${registryName} --gatewayId=${gatewayId}\
+    --format=RSA_X509_PEM --key=${rsaPublicCert}`
   );
 
   // look for output in list gateway
@@ -304,7 +308,8 @@ it('should list gateways', async () => {
 it('should bind existing device to gateway', async () => {
   const gatewayId = `nodejs-test-gateway-iot-${uuid.v4()}`;
   await tools.runAsync(
-    `${cmd} createGateway ${registryName} ${gatewayId} RSA_X509_PEM ${rsaPublicCert}`
+    `${cmd} createGateway --registryId=${registryName} --gatewayId=${gatewayId}\
+    --format=RSA_X509_PEM --key=${rsaPublicCert}`
   );
 
   // create device
@@ -342,7 +347,8 @@ it('should bind existing device to gateway', async () => {
 it('should list devices bound to gateway', async () => {
   const gatewayId = `nodejs-test-gateway-iot-${uuid.v4()}`;
   await tools.runAsync(
-    `${cmd} createGateway ${registryName} ${gatewayId} RSA_X509_PEM ${rsaPublicCert}`
+    `${cmd} createGateway --registryId=${registryName} --gatewayId=${gatewayId}\
+    --format=RSA_X509_PEM --key=${rsaPublicCert}`
   );
 
   const deviceId = `nodejs-test-device-iot-${uuid.v4()}`;
@@ -384,7 +390,8 @@ it('should list devices bound to gateway', async () => {
 it('should list gateways for bound device', async () => {
   const gatewayId = `nodejs-test-gateway-iot-${uuid.v4()}`;
   await tools.runAsync(
-    `${cmd} createGateway ${registryName} ${gatewayId} RSA_X509_PEM ${rsaPublicCert}`
+    `${cmd} createGateway --registryId=${registryName} --gatewayId=${gatewayId}\
+    --format=RSA_X509_PEM --key=${rsaPublicCert}`
   );
 
   // create device


### PR DESCRIPTION
This fixes some issues with upgrading to yargs v14.0.0:
1. Positional arguments were removed from `createGateway` sample. This is more in line with other samples, and will require migrating other samples to a similar format. For the sake of unblocking #1454, this is the only sample changed for now.
2. Use a single non-whitespaced string for `sendCommand` sample, such that yargs does not interpret the command sting as multiple arguments.

This change also updates the gateway samples + tests such that includes specifying [gateway auth method] (https://cloud.google.com/iot/docs/reference/cloudiot/rest/v1/projects.locations.registries.devices#gatewayauthmethod) which was previously missing.
