### PR TITLE
run: use node:10-slim

### DIFF
--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -2,9 +2,9 @@
 # Use of this source code is governed by the Apache 2.0
 # license that can be found in the LICENSE file.
 
-# Use the official Node.js 10 image.
+# Use the official lightweight Node.js 10 image.
 # https://hub.docker.com/_/node
-FROM node:10
+FROM node:10-slim
 
 # [START run_imageproc_dockerfile_imagemagick]
 
@@ -27,9 +27,9 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-RUN npm install --production
-# If you add a package-lock.json, speed your build by switching to 'npm ci'.
+# If you add a package-lock.json speed your build by switching to 'npm ci'.
 # RUN npm ci --only=production
+RUN npm install --production
 
 # Copy local code to the container image.
 COPY . .

--- a/run/image-processing/README.md
+++ b/run/image-processing/README.md
@@ -10,6 +10,9 @@ For more details on how to work with this sample read the [Google Cloud Run Node
 
 * **express**: Web server framework
 * **body-parser**: express middleware for request payload processing
+* **[gm](https://github.com/aheckmann/gm#readme)**: ImageMagick integration library.
+* **@google-cloud/storage**: Google Cloud Storage client library.
+* **@google-cloud/vision**: Cloud Vision API client library.
 
 ## Environment Variables
 

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -2,9 +2,9 @@
 # Use of this source code is governed by the Apache 2.0
 # license that can be found in the LICENSE file.
 
-# Use the official Node.js 10 image.
+# Use the official lightweight Node.js 10 image.
 # https://hub.docker.com/_/node
-FROM node:10
+FROM node:10-slim
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -15,9 +15,9 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-RUN npm install
-# For production deploys, add a package-lock.json and use 'npm ci'.
+# If you add a package-lock.json speed your build by switching to 'npm ci'.
 # RUN npm ci --only=production
+RUN npm install --production
 
 # Copy local code to the container image.
 COPY . .

--- a/run/logging-manual/package.json
+++ b/run/logging-manual/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@google-cloud/logging": "^5.1.2",
-    "@google-cloud/nodejs-repo-tools": "^3.3.0",
     "mocha": "^6.1.4"
   }
 }

--- a/run/pubsub/.envrc
+++ b/run/pubsub/.envrc
@@ -1,0 +1,3 @@
+export GOOGLE_CLOUD_PROJECT=adamross-svls-kibble
+export SERVICE_NAME=pubsub-tutorial
+export DOCKER_IMAGE_TAG=nodejs

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -4,9 +4,9 @@
 
 # [START run_pubsub_dockerfile]
 
-# Use the official Node.js 10 image.
+# Use the official lightweight Node.js 10 image.
 # https://hub.docker.com/_/node
-FROM node:10
+FROM node:10-slim
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -17,9 +17,9 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-RUN npm install --production
-# If you add a package-lock.json, speed your build by switching to 'npm ci'.
+# If you add a package-lock.json speed your build by switching to 'npm ci'.
 # RUN npm ci --only=production
+RUN npm install --production
 
 # Copy local code to the container image.
 COPY . .

--- a/run/pubsub/README.md
+++ b/run/pubsub/README.md
@@ -10,6 +10,3 @@ For more details on how to work with this sample read the [Google Cloud Run Node
 
 * **express**: Web server framework.
 * **body-parser**: express middleware for request payload processing.
-* **[gm](https://github.com/aheckmann/gm#readme)**: ImageMagick integration library.
-* **@google-cloud/storage**: Google Cloud Storage client library.
-* **@google-cloud/vision**: Cloud Vision API client library.


### PR DESCRIPTION
To minimize size and number of security vulnerability in Cloud Run samples, we're switching to the slim version.

This PR also removes node-repo-tools from the logging sample, standardizes the use of --production, and standardizes the note about when to use `npm ci`.