### PR TITLE
refactor: Delete unused functions_concepts_modules

### DIFF
--- a/functions/concepts/index.js
+++ b/functions/concepts/index.js
@@ -113,22 +113,6 @@ exports.listFiles = (req, res) => {
 };
 // [END functions_concepts_filesystem]
 
-// [START functions_concepts_modules]
-const path = require('path');
-const loadedModule = require(path.join(__dirname, 'loadable.js'));
-
-/**
- * HTTP Cloud Function that runs a function loaded from another Node.js file
- *
- * @param {Object} req Cloud Function request context.
- * @param {Object} res Cloud Function response context.
- */
-exports.runLoadedModule = (req, res) => {
-  console.log(`Loaded function from file ${loadedModule.getFileName()}`);
-  res.end();
-};
-// [END functions_concepts_modules]
-
 // [START functions_concepts_requests]
 const request = require('request');
 


### PR DESCRIPTION
This sample is not accomplishing much.
We don't use it on CloudSite.
We should delete it.

devrel/samples/598