### PR TITLE
updating obsolete method for BigQuery

### DIFF
--- a/functions/sendgrid/index.js
+++ b/functions/sendgrid/index.js
@@ -336,9 +336,9 @@ exports.sendgridLoad = event => {
         autodetect: true,
         sourceFormat: 'NEWLINE_DELIMITED_JSON',
       };
-      return table.import(fileObj, metadata);
+      return table.load(fileObj, metadata);
     })
-    .then(([job]) => job.promise())
+    .then(([job]) => job)
     .then(() => console.log(`Job complete for ${file.name}`))
     .catch(err => {
       console.log(`Job failed for ${file.name}`);


### PR DESCRIPTION
Thank you for providing nice tutorials.
This is quickest proposal to make it work with latest client library.
- Line 339: `table.import(...)` doesn't work and need to use `table.load(...)` instead.
- Line 341: `job` doesn't have `promise()`