### PR TITLE
refactor: Remove functions_concepts_after_response

### DIFF
--- a/functions/concepts/index.js
+++ b/functions/concepts/index.js
@@ -58,22 +58,6 @@ exports.executionCount = (req, res) => {
 };
 // [END functions_concepts_stateless]
 
-// [START functions_concepts_after_response]
-/**
- * HTTP Cloud Function that may not completely
- * execute due to early HTTP response
- *
- * @param {Object} req Cloud Function request context.
- * @param {Object} res Cloud Function response context.
- */
-exports.afterResponse = (req, res) => {
-  res.end();
-
-  // This statement may not execute
-  console.log('Function complete!');
-};
-// [END functions_concepts_after_response]
-
 // [START functions_concepts_after_timeout]
 /**
  * HTTP Cloud Function that may not completely


### PR DESCRIPTION
Removes `functions_concepts_after_response`.

This is not a useful GCF function, does not have a test, and does not have a strong reason to keep for N languages. Only implemented in Node right now.

[samples/596](https://devrel.corp.google.com/samples/596)
Doc: https://cloud.google.com/functions/docs/concepts/exec#function_execution_timeline