### PR TITLE
Replaces outdated instructions that reference the Functions emulator.

### DIFF
--- a/functions/speech-to-speech/.nvmrc
+++ b/functions/speech-to-speech/.nvmrc
@@ -1,1 +1,1 @@
-v6.14.4
+lts/dubnium

--- a/functions/speech-to-speech/README.md
+++ b/functions/speech-to-speech/README.md
@@ -26,7 +26,7 @@ prerequisites:
 ## Configuring the sample
 
 To configure the sample you must declare the required environment variables, set
-up NVM, and install the [Cloud Functions Node.js emulator][7].
+up NVM, and install the [Functions Framework][7].
 
 The sample requires the following environment variables:
 
@@ -55,11 +55,13 @@ declared in the `.nvmrc` file:
 nvm install && nvm use
 ```
 
-Run the following commands to install and start the Cloud Functions emulator:
+Run the following commands to install and start the Functions Framework:
 
 ```
-npm install -g @google-cloud/functions-emulator
-functions-emulator start
+cd functions
+npm install
+npm install --global @google-cloud/functions-framework
+functions-framework --target=speechTranslate
 ```
 
 ## Running the tests
@@ -67,7 +69,6 @@ functions-emulator start
 The test script performs the following tasks:
 
 1. Runs the linter.
-1. Deploys the function to the emulator.
 1. Runs tests that don't perform any calls to the Google Cloud APIs.
 1. Creates the output bucket if it doesn't exist.
 1. Runs tests that perform calls to the Google Cloud APIs and drop the
@@ -81,16 +82,16 @@ To run the tests, use the following commands from the
 npm install && npm test
 ```
 
-## Sending a request to the emulator
+## Sending a request to the Functions Framework
 
 Once the tests have run, you can send a request to the emulator using an HTTP
 tool, such as [curl][10]. Before sending a request, make sure that the
 `OUTPUT_BUCKET` environment variable points to an existing bucket. If you update
-the environment variables, you must restart the emulator to apply the new
+the environment variables, you must restart the framework to apply the new
 values. Use the following commands to restart the emulator:
 
 ```
-functions-emulator restart
+functions-framework --target=speechTranslate
 ```
 
 The sample includes a `test/request-body.json` file that includes a JSON object
@@ -99,15 +100,10 @@ message. Run the following command to send a request to the emulator:
 
 ```
 curl --request POST --header "Content-Type:application/json" \
---data @test/request-body.json $BASE_URL/speechTranslate
+--data @test/request-body.json http://localhost:8080/speechTranslate
 ```
 
 The command returns a JSON object with information about the translated message.
-You can also see the logs using the following command:
-
-```
-functions-emulator logs read
-```
 
 [0]: https://cloud.google.com
 [1]: https://cloud.google.com/speech-to-text/
@@ -115,8 +111,8 @@ functions-emulator logs read
 [3]: https://cloud.google.com/text-to-speech/
 [4]: https://cloud.google.com/functions/
 [5]: https://cloud.google.com/storage/
-[6]: https://github.com/creationix/nvm
-[7]: https://cloud.google.com/functions/docs/emulator
+[6]: https://github.com/nvm-sh/nvm/
+[7]: https://cloud.google.com/functions/docs/functions-framework
 [8]: https://cloud.google.com/docs/authentication/api-keys
 [10]: https://curl.haxx.se/
 [11]: https://cloud.google.com/functions/docs/locations

--- a/functions/speech-to-speech/README.md
+++ b/functions/speech-to-speech/README.md
@@ -39,7 +39,7 @@ The sample requires the following environment variables:
 
 Use the following commands to declare the required environment variables:
 
-```
+```shell
 export GOOGLE_CLOUD_PROJECT=[your-GCP-project-id]
 export OUTPUT_BUCKET=[your-Google-Cloud-Storage-bucket]
 export GOOGLE_APPLICATION_CREDENTIALS=[path-to-your-API-key-file]
@@ -51,13 +51,13 @@ you should use to run the app.
 Run the following commands to set up NVM to work with the Node.js version
 declared in the `.nvmrc` file:
 
-```
+```shell
 nvm install && nvm use
 ```
 
 Run the following commands to install and start the Functions Framework:
 
-```
+```shell
 cd functions
 npm install
 npm install --global @google-cloud/functions-framework
@@ -78,7 +78,7 @@ The test script performs the following tasks:
 To run the tests, use the following commands from the
 `functions/speech-to-speech` folder:
 
-```
+```shell
 npm install && npm test
 ```
 
@@ -90,7 +90,7 @@ tool, such as [curl][10]. Before sending a request, make sure that the
 the environment variables, you must restart the framework to apply the new
 values. Use the following commands to restart the emulator:
 
-```
+```shell
 functions-framework --target=speechTranslate
 ```
 
@@ -98,7 +98,7 @@ The sample includes a `test/request-body.json` file that includes a JSON object
 that represents the body of a valid request, including the base64-encoded audio
 message. Run the following command to send a request to the emulator:
 
-```
+```shell
 curl --request POST --header "Content-Type:application/json" \
 --data @test/request-body.json http://localhost:8080/speechTranslate
 ```


### PR DESCRIPTION
Updates README of the speech-to-speech sample with instructions that use the Functions Framework instead of the Functions emulator.

The speech-to-speech sample was updated to replace the Functions emulator in #1255.

This fixes #1500.