### PR TITLE
Delete dead link on README

### DIFF
--- a/functions/scheduleinstance/README.md
+++ b/functions/scheduleinstance/README.md
@@ -10,8 +10,6 @@ See the [Scheduling Instances with Cloud Scheduler tutorial][tutorial].
 
 ## Run the tests
 
-1. Read and follow the [prerequisites](../../#how-to-run-the-tests).
-
 1. Install dependencies:
 
         npm install


### PR DESCRIPTION
I found a broken link in the README .

This is when the link is deleted .

https://github.com/GoogleCloudPlatform/nodejs-docs-samples/commit/66dcad86a4e910c937f9161a385d111a651c405b#diff-04c6e90faac2675aa89e2176d2eec7d8


As a result of checking the contents, you may delete the wording of README