### PR TITLE
run: fix hello-broken testing

### DIFF
--- a/.kokoro/run/hello-broken.cfg
+++ b/.kokoro/run/hello-broken.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Set the folder in which the tests are run
+env_vars: {
+    key: "PROJECT"
+    value: "run/hello-broken"
+}

--- a/run/hello-broken/package.json
+++ b/run/hello-broken/package.json
@@ -17,6 +17,7 @@
     "express": "^4.17.1"
   },
   "devDependencies": {
-    "got": "^9.6.0"
+    "got": "^9.6.0",
+    "mocha": "^6.2.1"
   }
 }

--- a/run/hello-broken/package.json
+++ b/run/hello-broken/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "e2e-test": "TARGET=Cloud test/runner.sh mocha test/system.test.js --timeout=20000",
+    "e2e-test": "NAME=Cloud test/runner.sh mocha test/system.test.js --timeout=20000",
     "lint": "eslint '**/*.js'",
     "fix": "eslint --fix '**/*.js'"
   },

--- a/run/hello-broken/test/deploy.sh
+++ b/run/hello-broken/test/deploy.sh
@@ -31,6 +31,7 @@ gcloud beta run deploy "${SERVICE_NAME}" \
   ${FLAGS} \
   --platform=managed \
   --quiet 
+set +x
 
 echo 'Cloud Run Links:'
 echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"

--- a/run/hello-broken/test/system.test.js
+++ b/run/hello-broken/test/system.test.js
@@ -36,7 +36,7 @@ describe('End-to-End Tests', () => {
     throw Error('"NAME" environment variable is required. For example: Cosmos');
   }
 
-  describe('Default Service', () => {
+  describe('Service relying on defaults', () => {
     const {BASE_URL} = process.env;
     if (!BASE_URL) {
       throw Error(
@@ -53,7 +53,7 @@ describe('End-to-End Tests', () => {
       );
     });
 
-    it('Fixed resource successfully falls back to a default value', async () => {
+    it('Fixed resource falls back to a default value', async () => {
       const response = await get('/improved', BASE_URL);
       assert.strictEqual(
         response.statusCode,
@@ -62,13 +62,13 @@ describe('End-to-End Tests', () => {
       );
       assert.strictEqual(
         response.body,
-        `Hello ${NAME}!`,
+        `Hello World!`,
         `Expected fallback "World" not found`
       );
     });
   });
 
-  describe('Overridden Service', () => {
+  describe('Service with specified $NAME', () => {
     const {BASE_URL_OVERRIDE} = process.env;
     if (!BASE_URL_OVERRIDE) {
       throw Error(


### PR DESCRIPTION
run/hello-broken is consistently failing with nothing in the invocation log. This PR is intended to evolve until the test is passing.