### PR TITLE
Fix HTTP package being deprecated

### DIFF
--- a/functions/concepts/index.js
+++ b/functions/concepts/index.js
@@ -123,9 +123,7 @@ const fetch = require('node-fetch');
  * @param {Object} res Cloud Function response context.
  */
 exports.makeRequest = async (req, res) => {
-  // The URL to send the request to
-  const url = 'https://example.com';
-
+  const url = 'https://example.com'; // URL to send the request to
   const externalRes = await fetch(url);
   res.sendStatus(externalRes.ok ? 200 : 500);
 };

--- a/functions/concepts/index.js
+++ b/functions/concepts/index.js
@@ -114,7 +114,7 @@ exports.listFiles = (req, res) => {
 // [END functions_concepts_filesystem]
 
 // [START functions_concepts_requests]
-const request = require('request');
+const fetch = require('node-fetch');
 
 /**
  * HTTP Cloud Function that makes an HTTP request
@@ -122,16 +122,11 @@ const request = require('request');
  * @param {Object} req Cloud Function request context.
  * @param {Object} res Cloud Function response context.
  */
-exports.makeRequest = (req, res) => {
+exports.makeRequest = async (req, res) => {
   // The URL to send the request to
   const url = 'https://example.com';
 
-  request(url, (err, response) => {
-    if (!err && response.statusCode === 200) {
-      res.sendStatus(200);
-    } else {
-      res.sendStatus(500);
-    }
-  });
+  const externalRes = await fetch(url);
+  res.sendStatus(externalRes.ok ? 200 : 500);
 };
 // [END functions_concepts_requests]

--- a/functions/concepts/package.json
+++ b/functions/concepts/package.json
@@ -12,7 +12,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "request": "^2.85.0"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.3.0",


### PR DESCRIPTION
[`request` is being deprecated](https://github.com/request/request/issues/3143) - so let's use `node-fetch` instead.