### PR TITLE
Updates speech-to-speech and ocr-app samples.

### DIFF
--- a/functions/ocr/app/index.js
+++ b/functions/ocr/app/index.js
@@ -35,7 +35,7 @@ const Vision = require('@google-cloud/vision');
 const vision = new Vision.ImageAnnotatorClient();
 
 // Get a reference to the Translate API component
-const {Translate} = require('@google-cloud/translate');
+const {Translate} = require('@google-cloud/translate').v2;
 const translate = new Translate();
 
 // [END functions_ocr_setup]

--- a/functions/ocr/app/package.json
+++ b/functions/ocr/app/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@google-cloud/pubsub": "^1.0.0",
     "@google-cloud/storage": "^4.0.0",
-    "@google-cloud/translate": "^4.0.0",
+    "@google-cloud/translate": "^5.0.0",
     "@google-cloud/vision": "^1.0.0",
     "nconf": "^0.10.0"
   },

--- a/functions/speech-to-speech/functions/index.js
+++ b/functions/speech-to-speech/functions/index.js
@@ -35,7 +35,7 @@ const voiceSsmlGender = 'NEUTRAL';
 
 // Declare the API clients as global variables to allow them to initiaze at cold start.
 const {SpeechClient} = require('@google-cloud/speech');
-const {Translate} = require('@google-cloud/translate');
+const {Translate} = require('@google-cloud/translate').v2;
 const {TextToSpeechClient} = require('@google-cloud/text-to-speech');
 const {Storage} = require('@google-cloud/storage');
 

--- a/functions/speech-to-speech/functions/package.json
+++ b/functions/speech-to-speech/functions/package.json
@@ -36,7 +36,7 @@
     "@google-cloud/speech": "^3.0.0",
     "@google-cloud/storage": "^4.0.0",
     "@google-cloud/text-to-speech": "^1.0.0",
-    "@google-cloud/translate": "^4.0.0",
+    "@google-cloud/translate": "^5.0.0",
     "uuid": "^3.3.2",
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.0.0"


### PR DESCRIPTION
* Updates [google-cloud/translate][1] dependency to version `5.0.0`.
* Updates declaration of clients to specify the version 2 of the API instead of
the version 3, which is the default in the Translate library.

Note: The google-cloud/translate library made v3 the default in https://github.com/googleapis/nodejs-translate/pull/355

[1]: https://github.com/googleapis/nodejs-translate