### PR TITLE
feat: add functions_ci_cd_cloud_build_nodejs region tag

### DIFF
--- a/functions/ci_cd/cloudbuild.yaml
+++ b/functions/ci_cd/cloudbuild.yaml
@@ -1,3 +1,4 @@
+# [START functions_ci_cd_cloud_build_nodejs]
 steps:
 - name: 'gcr.io/cloud-builders/yarn'
   args: ['install']
@@ -8,3 +9,4 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['functions', 'deploy', '[YOUR_DEPLOYED_FUNCTION_NAME]', '[YOUR_FUNCTION_TRIGGER]', '--runtime', '[YOUR_RUNTIME]', '--entry-point', '[YOUR_FUNCTION_NAME_IN_CODE]']
   dir: 'functions/autodeploy'
+# [END functions_ci_cd_cloud_build_nodejs]


### PR DESCRIPTION
Adds a region tag to the cicd yaml.
b/144764433

Page:
https://cloud.google.com/functions/docs/testing/test-cicd