### PR TITLE
Remove tools.checkCredentials()

### DIFF
--- a/appengine/storage/flexible/system-test/app.test.js
+++ b/appengine/storage/flexible/system-test/app.test.js
@@ -17,16 +17,23 @@ const path = require('path');
 const {Storage} = require('@google-cloud/storage');
 const storage = new Storage();
 const assert = require('assert');
-const utils = require('@google-cloud/nodejs-repo-tools');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
 const bucketName = process.env.GCLOUD_STORAGE_BUCKET;
 const bucket = storage.bucket(bucketName);
 
 const cwd = path.join(__dirname, '../');
-const requestObj = utils.getRequest({cwd: cwd});
+const requestObj = tools.getRequest({cwd: cwd});
 
 before(async () => {
-  utils.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   await bucket.create(bucket).then(() => {
     return bucket.acl.add({
       entity: 'allUsers',

--- a/appengine/storage/standard/system-test/app.test.js
+++ b/appengine/storage/standard/system-test/app.test.js
@@ -17,16 +17,23 @@ const path = require('path');
 const {Storage} = require('@google-cloud/storage');
 const storage = new Storage();
 const assert = require('assert');
-const utils = require('@google-cloud/nodejs-repo-tools');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
 const bucketName = process.env.GCLOUD_STORAGE_BUCKET;
 const bucket = storage.bucket(bucketName);
 
 const cwd = path.join(__dirname, '../');
-const requestObj = utils.getRequest({cwd: cwd});
+const requestObj = tools.getRequest({cwd: cwd});
 
 before(async () => {
-  utils.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   await bucket.create(bucket).then(() => {
     return bucket.acl.add({
       entity: 'allUsers',

--- a/auth/system-test/auth.test.js
+++ b/auth/system-test/auth.test.js
@@ -23,7 +23,16 @@ const cmd = 'node auth.js';
 
 const {BUCKET_NAME} = process.env;
 
-before(tools.checkCredentials);
+before(() => {
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
+});
 
 it('should load credentials implicitly', async () => {
   const output = await tools.runAsync(`${cmd} auth-cloud-implicit`, cwd);

--- a/functions/helloworld/test/index.test.js
+++ b/functions/helloworld/test/index.test.js
@@ -66,7 +66,16 @@ const httpInvocation = (fnUrl, port, body) => {
 };
 
 describe('index.test.js', () => {
-  before(tools.checkCredentials);
+  before(() => {
+    assert(
+      process.env.GCLOUD_PROJECT,
+      `Must set GCLOUD_PROJECT environment variable!`
+    );
+    assert(
+      process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+    );
+  });
 
   describe('functions_helloworld_get helloGET', () => {
     const PORT = 8081;

--- a/healthcare/datasets/system-test/datasets.test.js
+++ b/healthcare/datasets/system-test/datasets.test.js
@@ -26,7 +26,16 @@ const destinationDatasetId = `destination-${uuid.v4()}`.replace(/-/gi, '_');
 const keeplistTags = 'PatientID';
 const cloudRegion = 'us-central1';
 
-before(tools.checkCredentials);
+before(() => {
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
+});
 after(async () => {
   try {
     await tools.runAsync(

--- a/healthcare/dicom/system-test/dicom_stores.test.js
+++ b/healthcare/dicom/system-test/dicom_stores.test.js
@@ -43,7 +43,14 @@ const resourceFile = `resources/${dcmFileName}`;
 const gcsUri = `${bucketName}/${dcmFileName}`;
 
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   // Create a Cloud Storage bucket to be used for testing.
   await storage.createBucket(bucketName);
   console.log(`Bucket ${bucketName} created.`);

--- a/healthcare/dicom/system-test/dicomweb.test.js
+++ b/healthcare/dicom/system-test/dicomweb.test.js
@@ -42,7 +42,14 @@ const seriesUid = '1.2.840.113619.2.176.3596.3364818.7819.1259708454.108';
 const instanceUid = '1.2.840.113619.2.176.3596.3364818.7271.1259708501.876';
 
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   await tools.runAsync(
     `node createDataset.js ${projectId} ${cloudRegion} ${datasetId}`,
     cwdDatasets

--- a/healthcare/fhir/system-test/fhir_resources.test.js
+++ b/healthcare/fhir/system-test/fhir_resources.test.js
@@ -35,7 +35,14 @@ const resourceType = 'Patient';
 let resourceId;
 
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   await tools.runAsync(
     `node createDataset.js ${projectId} ${cloudRegion} ${datasetId}`,
     cwdDatasets

--- a/healthcare/fhir/system-test/fhir_stores.test.js
+++ b/healthcare/fhir/system-test/fhir_stores.test.js
@@ -44,7 +44,14 @@ const fhirResourceFile = `resources/${fhirFileName}`;
 const gcsUri = `${bucketName}/${fhirFileName}`;
 
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   // Create a Cloud Storage bucket to be used for testing.
   await storage.createBucket(bucketName);
   console.log(`Bucket ${bucketName} created.`);

--- a/healthcare/hl7v2/system-test/hl7v2_messages.test.js
+++ b/healthcare/hl7v2/system-test/hl7v2_messages.test.js
@@ -36,7 +36,14 @@ const labelKey = 'my-key';
 const labelValue = 'my-value';
 
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   await tools.runAsync(
     `node createDataset.js ${projectId} ${cloudRegion} ${datasetId}`,
     cwdDatasets

--- a/healthcare/hl7v2/system-test/hl7v2_stores.test.js
+++ b/healthcare/hl7v2/system-test/hl7v2_stores.test.js
@@ -34,7 +34,14 @@ const hl7v2StoreId = `nodejs-docs-samples-test-hl7v2-store${uuid.v4()}`.replace(
 const topicName = `nodejs-healthcare-test-topic-${uuid.v4()}`;
 
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   // Create a Pub/Sub topic to be used for testing.
   const [topic] = await pubSubClient.createTopic(topicName);
   console.log(`Topic ${topic.name} created.`);

--- a/iot/http_example/system-test/cloudiot_http_example.test.js
+++ b/iot/http_example/system-test/cloudiot_http_example.test.js
@@ -30,7 +30,14 @@ const installDeps = 'npm install';
 
 assert.ok(tools.run(installDeps, `${cwd}/../manager`));
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   const pubsub = new PubSub();
   const [topic] = await pubsub.createTopic(topicName);
   console.log(`Topic ${topic.name} created.`);

--- a/iot/manager/system-test/manager.test.js
+++ b/iot/manager/system-test/manager.test.js
@@ -39,7 +39,14 @@ const pubSubClient = new PubSub({projectId});
 
 before(async () => {
   tools.run(installDeps, `${cwd}/../mqtt_example`);
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   // Create a topic to be used for testing.
   const [topic] = await pubSubClient.createTopic(topicName);
   console.log(`Topic ${topic.name} created.`);

--- a/iot/mqtt_example/system-test/cloudiot_mqtt_example.test.js
+++ b/iot/mqtt_example/system-test/cloudiot_mqtt_example.test.js
@@ -42,7 +42,14 @@ const pubSubClient = new PubSub({projectId});
 
 assert.ok(tools.run(installDeps, `${cwd}/../manager`));
 before(async () => {
-  tools.checkCredentials();
+  assert(
+    process.env.GCLOUD_PROJECT,
+    `Must set GCLOUD_PROJECT environment variable!`
+  );
+  assert(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
+  );
   // Create a unique topic to be used for testing.
   const [topic] = await pubSubClient.createTopic(topicName);
   console.log(`Topic ${topic.name} created.`);


### PR DESCRIPTION
We want to remove the nodejs-repo-tools dependency. Doing so step by step.

Drive-by fix: Rename `utils` to `tools` for consistency.