### PR TITLE
Replace app engine js compilation with ts-node

### DIFF
--- a/appengine/typescript/.gcloudignore
+++ b/appengine/typescript/.gcloudignore
@@ -1,5 +1,2 @@
-# Exclude compiled .js files
-*.js
-
 # Exclude dependencies
 node_modules/

--- a/appengine/typescript/.gitignore
+++ b/appengine/typescript/.gitignore
@@ -1,5 +1,2 @@
-# Exclude compiled .js files
-*.js
-
 # Exclude dependencies
 node_modules/

--- a/appengine/typescript/README.md
+++ b/appengine/typescript/README.md
@@ -1,11 +1,7 @@
 # App Engine TypeScript sample
 
-This sample provides an example of how to compile TypeScript files while
-deploying to App Engine.
-
-The `gcp-build` NPM script is used to trigger the TypeScript compilation
-process. This step happens automatically when deploying to App Engine, but must
-be performed manually when developing locally.
+This sample provides an example of how to deploy TypeScript files to
+to App Engine.
 
 ## Setup
 
@@ -14,10 +10,6 @@ Install dependencies:
    npm install
 
 ## Running locally
-
-1. Perform the build step:
-
-    npm run gcp-build
 
 1. Run the completed program
 

--- a/appengine/typescript/package.json
+++ b/appengine/typescript/package.json
@@ -9,17 +9,15 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "prepare": "npm run gcp-build",
-    "pretest": "npm run gcp-build",
-    "test": "repo-tools test app -- index.js",
+    "test": "repo-tools test app -- index.ts",
     "posttest": "npm run lint",
     "lint": "tslint -p .",
-    "start": "node ./index.js",
-    "gcp-build": "tsc -p .",
+    "start": "ts-node ./index.ts",
     "deploy": "gcloud app deploy"
   },
   "dependencies": {
     "express": "^4.16.3",
+    "ts-node": "^8.5.4",
     "typescript": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace app engine js compilation step with running ts-node on the app engine server.

As ts-node gains popularity, the benefits of debugging and instrumenting typescript code in real-time justify skipping compilation to JS altogether.

Not sure if this has already been considered. Also note that `repo-tools test` may not support testing typescript code directly, although many popular typescript testing libraries (e.g. jest) do support this.