### PR TITLE
functions + appengine: export XUnit results

### DIFF
--- a/.kokoro/appengine/common.cfg
+++ b/.kokoro/appengine/common.cfg
@@ -14,3 +14,10 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-docs-samples/.kokoro/build.sh"
 }
+
+# Export XUnit test results for further analysis
+action {
+    define_artifacts {
+        regex: "**/all-tests.xml"
+    }
+}

--- a/.kokoro/functions/common.cfg
+++ b/.kokoro/functions/common.cfg
@@ -20,3 +20,10 @@ env_vars: {
     key: "BASE_URL"
     value: "http://localhost:8080"
 }
+
+# Export XUnit test results for further analysis
+action {
+  define_artifacts {
+    regex: "**/all-tests.xml"
+  }
+}


### PR DESCRIPTION
Export XUnit results now that `functions` (#1499) and `appengine` (#1504) have been labeled for the test tracker.