### PR TITLE
Add --runtime argument to gcloud deploy in README.

### DIFF
--- a/datastore/functions/README.md
+++ b/datastore/functions/README.md
@@ -25,18 +25,18 @@ Functions for your project.
 
 1. Deploy the "get" function with an HTTP trigger:
 
-        gcloud functions deploy get --runtime [YOUR_RUNTIME} --trigger-http
+        gcloud functions deploy get --runtime [YOUR_RUNTIME] --trigger-http
 
     * Replace `[YOUR_RUNTIME]` with the name of the runtime you are using. For a complete list,
     see the [gcloud reference](https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--runtime).
 
 1. Deploy the "set" function with an HTTP trigger:
 
-        gcloud functions deploy set --runtime [YOUR_RUNTIME} --trigger-http
+        gcloud functions deploy set --runtime [YOUR_RUNTIME] --trigger-http
 
 1. Deploy the "del" function with an HTTP trigger:
 
-        gcloud functions deploy del --runtime [YOUR_RUNTIME} --trigger-http
+        gcloud functions deploy del --runtime [YOUR_RUNTIME] --trigger-http
 
 1. Call the "set" function to create a new entity:
 

--- a/datastore/functions/README.md
+++ b/datastore/functions/README.md
@@ -25,15 +25,18 @@ Functions for your project.
 
 1. Deploy the "get" function with an HTTP trigger:
 
-        gcloud functions deploy get --runtime nodejs8 --trigger-http
+        gcloud functions deploy get --runtime [YOUR_RUNTIME} --trigger-http
+
+    * Replace `[YOUR_RUNTIME]` with the name of the runtime you are using. For a complete list,
+    see the [gcloud reference](https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--runtime).
 
 1. Deploy the "set" function with an HTTP trigger:
 
-        gcloud functions deploy set --runtime nodejs8 --trigger-http
+        gcloud functions deploy set --runtime [YOUR_RUNTIME} --trigger-http
 
 1. Deploy the "del" function with an HTTP trigger:
 
-        gcloud functions deploy del --runtime nodejs8 --trigger-http
+        gcloud functions deploy del --runtime [YOUR_RUNTIME} --trigger-http
 
 1. Call the "set" function to create a new entity:
 

--- a/datastore/functions/README.md
+++ b/datastore/functions/README.md
@@ -25,15 +25,15 @@ Functions for your project.
 
 1. Deploy the "get" function with an HTTP trigger:
 
-        gcloud functions deploy get --trigger-http
+        gcloud functions deploy get --runtime nodejs8 --trigger-http
 
 1. Deploy the "set" function with an HTTP trigger:
 
-        gcloud functions deploy set --trigger-http
+        gcloud functions deploy set --runtime nodejs8 --trigger-http
 
 1. Deploy the "del" function with an HTTP trigger:
 
-        gcloud functions deploy del --trigger-http
+        gcloud functions deploy del --runtime nodejs8 --trigger-http
 
 1. Call the "set" function to create a new entity:
 

--- a/functions/helloworld/README.md
+++ b/functions/helloworld/README.md
@@ -17,10 +17,13 @@ See the [Cloud Functions Hello World tutorial][tutorial].
 **Note:** in order for the tests to run properly, you'll have to deploy some of the sample functions:
 
 ```
-gcloud functions deploy helloHttp --runtime nodejs8 --trigger-http
-gcloud functions deploy helloPubSub --trigger-topic $FUNCTIONS_TOPIC --runtime nodejs8
-gcloud functions deploy helloGCS --runtime nodejs8 --trigger-resource $FUNCTIONS_DELETABLE_BUCKET --trigger-event providers/cloud.storage/eventTypes/object.change
+gcloud functions deploy helloHttp --runtime [YOUR_RUNTIME] --trigger-http
+gcloud functions deploy helloPubSub --trigger-topic $FUNCTIONS_TOPIC --runtime [YOUR_RUNTIME]
+gcloud functions deploy helloGCS --runtime [YOUR_RUNTIME] --trigger-resource $FUNCTIONS_DELETABLE_BUCKET --trigger-event providers/cloud.storage/eventTypes/object.change
 ```
+
+* Replace `[YOUR_RUNTIME]` with the name of the runtime you are using. For a
+complete list, see the [gcloud reference](https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--runtime).
 
 ## Run the tests
 

--- a/functions/imagemagick/README.md
+++ b/functions/imagemagick/README.md
@@ -35,8 +35,10 @@ Functions for your project.
 
 1. Deploy the `blurOffensiveImages` function with a Storage trigger:
 
-        gcloud functions deploy blurOffensiveImages --trigger-bucket=YOUR_INPUT_BUCKET_NAME --set-env-vars BLURRED_BUCKET_NAME=YOUR_OUTPUT_BUCKET_NAME
+        gcloud functions deploy blurOffensiveImages --runtime YOUR_RUNTIME --trigger-bucket=YOUR_INPUT_BUCKET_NAME --set-env-vars BLURRED_BUCKET_NAME=YOUR_OUTPUT_BUCKET_NAME
 
+    * Replace `YOUR_RUNTIME` with the name of the runtime you are using. For a
+    complete list, see the [gcloud reference](https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--runtime).
     * Replace `YOUR_INPUT_BUCKET_NAME` and `YOUR_OUTPUT_BUCKET_NAME` with the names of the respective Cloud Storage Buckets you created earlier.
 
 1.  Upload an offensive image to the Storage bucket, such as this image of

--- a/functions/pubsub/README.md
+++ b/functions/pubsub/README.md
@@ -28,11 +28,14 @@ can skip this step):
 
 1. Deploy the `publish` function with an HTTP trigger:
 
-        gcloud functions deploy publish --trigger-http
+        gcloud functions deploy publish --trigger-http --runtime YOUR_RUNTIME
+
+    * Replace `YOUR_RUNTIME` with the name of the runtime you are using. For a
+    complete list, see the [gcloud reference](https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--runtime).
 
 1. Deploy the `subscribe` function with the Pub/Sub topic as a trigger:
 
-        gcloud functions deploy subscribe --trigger-topic YOUR_TOPIC_NAME
+        gcloud functions deploy subscribe --trigger-topic YOUR_TOPIC_NAME --runtime YOUR_RUNTIME
 
     * Replace `YOUR_TOPIC_NAME` with the name of your Pub/Sub Topic.
 


### PR DESCRIPTION
gcloud requires a `--runtime` argument when deploying new functions, otherwise the user sees:

`ERROR: (gcloud.functions.deploy) Missing required argument [runtime]: Flag `--runtime` is required for new functions.`

This addition is consistent with the tutorial (https://cloud.google.com/functions/docs/tutorials/http).