### PR TITLE
fix: reduce request usage

### DIFF
--- a/functions/background/index.js
+++ b/functions/background/index.js
@@ -15,7 +15,7 @@
 'use strict';
 
 // [START functions_background_promise]
-const requestPromiseNative = require('request-promise-native');
+const {request} = require('gaxios');
 
 /**
  * Background Cloud Function that returns a Promise. Note that we don't pass
@@ -26,8 +26,8 @@ const requestPromiseNative = require('request-promise-native');
  * @returns {Promise}
  */
 exports.helloPromise = data => {
-  return requestPromiseNative({
-    uri: data.endpoint,
+  return request({
+    url: data.endpoint,
   });
 };
 // [END functions_background_promise]

--- a/functions/background/package.json
+++ b/functions/background/package.json
@@ -1,6 +1,5 @@
 {
   "name": "nodejs-docs-samples-functions-background",
-  "version": "0.0.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
@@ -15,17 +14,11 @@
     "test": "mocha test/*.test.js --timeout=20000"
   },
   "dependencies": {
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.5"
+    "gaxios": "^2.3.1"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^1.1.1",
     "child-process-promise": "^2.2.1",
-    "mocha": "^7.0.0",
-    "requestretry": "^4.0.0"
-  },
-  "cloud-repo-tools": {
-    "requiresKeyFile": true,
-    "requiresProjectId": true
+    "mocha": "^7.0.0"
   }
 }

--- a/functions/background/test/index.test.js
+++ b/functions/background/test/index.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const assert = require('assert');
-const requestRetry = require('requestretry');
+const {request} = require('gaxios');
 const execPromise = require('child-process-promise').exec;
 const path = require('path');
 
@@ -52,14 +52,16 @@ it('should make a promise request', async () => {
     },
   };
 
-  const response = await requestRetry({
+  const response = await request({
     url: `${BASE_URL}/`,
     method: 'POST',
-    body: event,
-    retryDelay: 200,
-    json: true,
+    data: event,
+    responseType: 'text',
+    retryConfig: {
+      httpMethodsToRetry: ['POST'],
+    },
   });
 
-  assert.strictEqual(response.statusCode, 200);
-  assert.ok(response.body.includes(`Example Domain`));
+  assert.strictEqual(response.status, 200);
+  assert.ok(response.data.includes(`Example Domain`));
 });


### PR DESCRIPTION
Request is now [deprecated](https://www.npmjs.com/package/request).  This moves the sample over to using `gaxios`, along with other cleanup.
