### PR TITLE
Remove extra parenthesis from region tag

### DIFF
--- a/functions/helloworld/test/sample.integration.http.test.js
+++ b/functions/helloworld/test/sample.integration.http.test.js
@@ -72,6 +72,4 @@ describe('functions_helloworld_http HTTP integration test', () => {
     assert.strictEqual(response.statusCode, 200);
     assert.strictEqual(response.body, `Hello World!`);
   });
-  // [START functions_http_integration_test]
 });
-// [END functions_http_integration_test]


### PR DESCRIPTION
**N.B:** this causes the unit test block itself to be indented. @labtopia we should fix that in the docs (using the `adjust_indentation` parameter - see my comment on the bug).

Or if we can't (e.g. because indentation is not consistent throughout the file), we may have to add a `describe` statement anyway. If it comes to that, we should try to exclude the region tag labeling. 🙂