### PR TITLE
fix: publish to Build Cop for release jobs

### DIFF
--- a/.kokoro/build-with-appengine.sh
+++ b/.kokoro/build-with-appengine.sh
@@ -65,7 +65,7 @@ npm install
 
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"release"* ]]; then
 	export MOCHA_REPORTER_OUTPUT=sponge_log.xml
 	export MOCHA_REPORTER=xunit
 	cleanup() {

--- a/.kokoro/build-with-run.sh
+++ b/.kokoro/build-with-run.sh
@@ -61,7 +61,7 @@ npm install
 
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"release"* ]]; then
 	export MOCHA_REPORTER_OUTPUT=sponge_log.xml
 	export MOCHA_REPORTER=xunit
 	cleanup() {

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -88,7 +88,7 @@ gcloud config set project $GCLOUD_PROJECT
 
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"release"* ]]; then
 	export MOCHA_REPORTER_OUTPUT=sponge_log.xml
 	export MOCHA_REPORTER=xunit
 	cleanup() {


### PR DESCRIPTION
`KOKORO_BUILD_ARTIFACTS_SUBDIR` is based on the job name.