### PR TITLE
fix(tests): run/logging-manual test failures (#1637)

### DIFF
--- a/run/logging-manual/README.md
+++ b/run/logging-manual/README.md
@@ -10,7 +10,7 @@ For more details on how to work with this sample read the [Google Cloud Run Node
 
 ### `npm run e2e-test`
 
-```
+```sh
 export SERVICE_NAME=logging-manual
 export CONTAINER_IMAGE=gcr.io/${GOOGLE_CLOUD_PROJECT}/logging-manual
 npm run e2e-test
@@ -69,4 +69,3 @@ test/runner.sh sleep 20
   [compute metadata server](https://cloud.google.com/compute/docs/storing-retrieving-metadata)
   and make system test HTTP requests. This is required in production for log correlation without
   manually setting the $GOOGLE_CLOUD_PROJECT environment variable.
-

--- a/run/logging-manual/test/system.test.js
+++ b/run/logging-manual/test/system.test.js
@@ -65,9 +65,8 @@ describe('Logging', () => {
       if (!ID_TOKEN) {
         throw Error('"ID_TOKEN" environment variable is required.');
       }
-
       await request('/', {
-        baseUrl: BASE_URL.trim(),
+        prefixUrl: BASE_URL.trim(),
         headers: {
           Authorization: `Bearer ${ID_TOKEN.trim()}`,
         },


### PR DESCRIPTION
Fixes #1637

run/logging-manual tests started failing due to a compatibility break in upgrading to `got v10` #1557. This was not caught because the broken `got` feature is only used in system tests.