### PR TITLE
Add "gcf filesystem is not persistent" note

### DIFF
--- a/functions/http/index.js
+++ b/functions/http/index.js
@@ -153,7 +153,10 @@ exports.uploadFile = (req, res) => {
     const writeStream = fs.createWriteStream(filepath);
     file.pipe(writeStream);
 
-    // File was processed by Busboy; wait for it to be written to disk.
+    // File was processed by Busboy; wait for it to be written.
+    // Note: GCF may not persist saved files across invocations.
+    // Persistent files must be kept in other locations
+    // (such as Cloud Storage buckets).
     const promise = new Promise((resolve, reject) => {
       file.on('end', () => {
         writeStream.end();


### PR DESCRIPTION
Given that we added this note in the [Java sample](https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2688), I thought it was worth adding here.