### PR TITLE
healthcare API: use new request body for notificationConfigs when patching HL7v2 store

### DIFF
--- a/healthcare/hl7v2/patchHl7v2Store.js
+++ b/healthcare/hl7v2/patchHl7v2Store.js
@@ -42,11 +42,13 @@ const main = (
     const name = `projects/${projectId}/locations/${cloudRegion}/datasets/${datasetId}/hl7V2Stores/${hl7v2StoreId}`;
     const request = {
       name,
-      updateMask: 'notificationConfig',
+      updateMask: 'notificationConfigs',
       resource: {
-        notificationConfig: {
-          pubsubTopic: `projects/${projectId}/topics/${pubsubTopic}`,
-        },
+        notificationConfigs: [
+          {
+            pubsubTopic: `projects/${projectId}/topics/${pubsubTopic}`,
+          }
+        ]
       },
     };
 


### PR DESCRIPTION
notificationConfig{} was deprecated in favor of notificationConfigs[].