### PR TITLE
Reference how to test, and remove unneeded step

### DIFF
--- a/appengine/storage/standard/README.md
+++ b/appengine/storage/standard/README.md
@@ -38,3 +38,7 @@ Then set environment variables before starting your application:
     export GCLOUD_STORAGE_BUCKET=<your-bucket-name>
     npm install
     npm start
+
+Run the tests, if desired:
+
+    npm test

--- a/appengine/storage/standard/system-test/app.test.js
+++ b/appengine/storage/standard/system-test/app.test.js
@@ -31,10 +31,6 @@ before(async () => {
     process.env.GCLOUD_PROJECT,
     `Must set GCLOUD_PROJECT environment variable!`
   );
-  assert(
-    process.env.GOOGLE_APPLICATION_CREDENTIALS,
-    `Must set GOOGLE_APPLICATION_CREDENTIALS environment variable!`
-  );
   await bucket.create(bucket).then(() => {
     return bucket.acl.add({
       entity: 'allUsers',


### PR DESCRIPTION
GOOGLE_APPLICATION_CREDENTIALS are not needed, and should not be downloaded unless absolutely necessary.