### PR TITLE
run: Include `module.exports = app;` in snippet

### DIFF
--- a/run/pubsub/app.js
+++ b/run/pubsub/app.js
@@ -33,6 +33,8 @@ app.post('/', (req, res) => {
   console.log(`Hello ${name}!`);
   res.status(204).send();
 });
-// [END run_pubsub_handler]
 
 module.exports = app;
+// [END run_pubsub_handler]
+
+


### PR DESCRIPTION
By adding this into the snippet the tutorial facilitates copy-and-paste to assemble the working node.js service. While not the intent in the structure of the tutorial this has been asked for and is a minor change.