### PR TITLE
Specify Node.js engine 10 or greater

### DIFF
--- a/functions/speech-to-speech/functions/package.json
+++ b/functions/speech-to-speech/functions/package.json
@@ -7,7 +7,7 @@
   "author": "Google LLC",
   "private": true,
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Cloud Speech library version 4 requires Node.js version 10 or greater.
This PR updates the speech-to-speech sample to use Node version 10.