### PR TITLE
Update speech sample to use Cloud Speech dependency v4.0.0

### DIFF
--- a/.kokoro/functions/speech-to-speech.cfg
+++ b/.kokoro/functions/speech-to-speech.cfg
@@ -9,7 +9,7 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:8-user"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
 }
 
 # Tell the trampoline which build file to use.

--- a/functions/speech-to-speech/functions/package.json
+++ b/functions/speech-to-speech/functions/package.json
@@ -33,7 +33,7 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
-    "@google-cloud/speech": "^3.0.0",
+    "@google-cloud/speech": "^4.0.0",
     "@google-cloud/storage": "^5.0.0",
     "@google-cloud/text-to-speech": "^2.0.0",
     "@google-cloud/translate": "^5.0.0",


### PR DESCRIPTION
This PR includes the following changes:

* Updates the `google-cloud/speech` dependency to version `4.0.0`.
* Updates the Kokoro configuration to use the Node.js 10 Docker image.