### PR TITLE
Memorystore: Add Dockerfile for Cloud Run deployment

### DIFF
--- a/memorystore/redis/.gcloudignore
+++ b/memorystore/redis/.gcloudignore
@@ -1,0 +1,6 @@
+cloud_run_deployment/
+gae_flex_deployment/
+gae_standard_deployment/
+gce_deployment/
+gke_deployment/
+README.md

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official lightweight Node.js 12 image.
+# https://hub.docker.com/_/node
+FROM node:12-slim
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure both package.json AND package-lock.json are copied.
+# Copying this separately prevents re-running npm install on every code change.
+COPY package*.json ./
+
+# Install production dependencies.
+RUN npm install --only=production
+
+# Copy local code to the container image.
+COPY . ./
+
+# Run the web service on container startup.
+CMD [ "npm", "start" ]


### PR DESCRIPTION
I'm working on a tutorial for connecting to Memorystore from Cloud Run via Serverless VPC Access. The existing sample app still works, we just need a Dockerfile to deploy it. Also adding a `.gcloudignore`.