### PR TITLE
test(run): add shallow end-to-end tests to cloud run sample apps.

### DIFF
--- a/run/events-pubsub/package.json
+++ b/run/events-pubsub/package.json
@@ -15,12 +15,14 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks"
+    "test": "mocha test/*.test.js --check-leaks",
+    "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "express": "^4.16.4"
   },
   "devDependencies": {
+    "got": "^11.5.0",
     "mocha": "^8.0.0",
     "sinon": "^9.0.0",
     "supertest": "^4.0.2",

--- a/run/events-pubsub/package.json
+++ b/run/events-pubsub/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks",
+    "test": "mocha test/app.test.js --check-leaks",
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {

--- a/run/events-pubsub/test/deploy.sh
+++ b/run/events-pubsub/test/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+requireEnv CONTAINER_IMAGE
+
+# Deploy the service
+set -x
+gcloud run deploy "${SERVICE_NAME}" \
+  --image="${CONTAINER_IMAGE}" \
+  --region="${REGION:-us-central1}" \
+  ${FLAGS} \
+  --platform=managed \
+  --quiet
+set +x
+
+echo 'Cloud Run Links:'
+echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"
+echo "- Console: https://console.cloud.google.com/run/detail/${REGION:-us-central1}/${SERVICE_NAME}/metrics?project=${GOOGLE_CLOUD_PROJECT}"

--- a/run/events-pubsub/test/deploy.sh
+++ b/run/events-pubsub/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/events-pubsub/test/runner.sh
+++ b/run/events-pubsub/test/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+requireEnv SERVICE_NAME
+
+echo '---'
+test/deploy.sh
+
+echo
+echo '---'
+echo
+
+# Register post-test cleanup.
+# Only needed if deploy completed.
+function cleanup {
+  set -x
+  gcloud run services delete ${SERVICE_NAME} \
+    --platform=managed \
+    --region="${REGION:-us-central1}" \
+    --quiet
+}
+trap cleanup EXIT
+
+# TODO: Perform authentication inside the test.
+export ID_TOKEN=$(gcloud auth print-identity-token)
+export BASE_URL=$(test/url.sh)
+
+test -z "$BASE_URL" && echo "BASE_URL value is empty" && exit 1
+
+# Do not use exec to preserve trap behavior.
+"$@"

--- a/run/events-pubsub/test/runner.sh
+++ b/run/events-pubsub/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/events-pubsub/test/system.test.js
+++ b/run/events-pubsub/test/system.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('assert');
+const got = require('got');
+const {resolve} = require('url');
+
+const request = (method, route, base_url) => {
+  const {ID_TOKEN} = process.env;
+  if (!ID_TOKEN) {
+    throw Error('"ID_TOKEN" environment variable is required.');
+  }
+
+  return got(resolve(base_url.trim(), route), {
+    headers: {
+      Authorization: `Bearer ${ID_TOKEN.trim()}`,
+    },
+    method: method || 'get',
+    throwHttpErrors: false,
+  });
+};
+
+describe('End-to-End Tests', () => {
+  const {BASE_URL} = process.env;
+  if (!BASE_URL) {
+    throw Error(
+      '"BASE_URL" environment variable is required. For example: https://service-x8xabcdefg-uc.a.run.app'
+    );
+  }
+
+  it('post(/) without request parameters is a bad request', async () => {
+    const response = await request('post', '/', BASE_URL);
+    assert.strictEqual(
+      response.statusCode,
+      400,
+      'Bad Requests status not found'
+    );
+  });
+});

--- a/run/events-pubsub/test/url.sh
+++ b/run/events-pubsub/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/events-pubsub/test/url.sh
+++ b/run/events-pubsub/test/url.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+
+set -x
+gcloud run services \
+  describe "${SERVICE_NAME}" \
+  --region="${REGION:-us-central1}" \
+  --format='value(status.url)' \
+  --platform=managed

--- a/run/events-storage/package.json
+++ b/run/events-storage/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks",
+    "test": "mocha test/app.test.js --check-leaks",
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {

--- a/run/events-storage/package.json
+++ b/run/events-storage/package.json
@@ -15,12 +15,14 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks"
+    "test": "mocha test/*.test.js --check-leaks",
+    "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "express": "^4.16.4"
   },
   "devDependencies": {
+    "got": "^11.5.0",
     "mocha": "^8.0.0",
     "sinon": "^9.0.0",
     "supertest": "^4.0.2"

--- a/run/events-storage/test/deploy.sh
+++ b/run/events-storage/test/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+requireEnv CONTAINER_IMAGE
+
+# Deploy the service
+set -x
+gcloud run deploy "${SERVICE_NAME}" \
+  --image="${CONTAINER_IMAGE}" \
+  --region="${REGION:-us-central1}" \
+  ${FLAGS} \
+  --platform=managed \
+  --quiet
+set +x
+
+echo 'Cloud Run Links:'
+echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"
+echo "- Console: https://console.cloud.google.com/run/detail/${REGION:-us-central1}/${SERVICE_NAME}/metrics?project=${GOOGLE_CLOUD_PROJECT}"

--- a/run/events-storage/test/deploy.sh
+++ b/run/events-storage/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/events-storage/test/runner.sh
+++ b/run/events-storage/test/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+requireEnv SERVICE_NAME
+
+echo '---'
+test/deploy.sh
+
+echo
+echo '---'
+echo
+
+# Register post-test cleanup.
+# Only needed if deploy completed.
+function cleanup {
+  set -x
+  gcloud run services delete ${SERVICE_NAME} \
+    --platform=managed \
+    --region="${REGION:-us-central1}" \
+    --quiet
+}
+trap cleanup EXIT
+
+# TODO: Perform authentication inside the test.
+export ID_TOKEN=$(gcloud auth print-identity-token)
+export BASE_URL=$(test/url.sh)
+
+test -z "$BASE_URL" && echo "BASE_URL value is empty" && exit 1
+
+# Do not use exec to preserve trap behavior.
+"$@"

--- a/run/events-storage/test/runner.sh
+++ b/run/events-storage/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/events-storage/test/system.test.js
+++ b/run/events-storage/test/system.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('assert');
+const got = require('got');
+const {resolve} = require('url');
+
+const request = (method, route, base_url) => {
+  const {ID_TOKEN} = process.env;
+  if (!ID_TOKEN) {
+    throw Error('"ID_TOKEN" environment variable is required.');
+  }
+
+  return got(resolve(base_url.trim(), route), {
+    headers: {
+      Authorization: `Bearer ${ID_TOKEN.trim()}`,
+    },
+    method: method || 'get',
+    throwHttpErrors: false,
+  });
+};
+
+describe('End-to-End Tests', () => {
+  const {BASE_URL} = process.env;
+  if (!BASE_URL) {
+    throw Error(
+      '"BASE_URL" environment variable is required. For example: https://service-x8xabcdefg-uc.a.run.app'
+    );
+  }
+
+  it('post(/) without request parameters is a bad request', async () => {
+    const response = await request('post', '/', BASE_URL);
+    assert.strictEqual(
+      response.statusCode,
+      400,
+      'Bad Requests status not found'
+    );
+  });
+});

--- a/run/events-storage/test/url.sh
+++ b/run/events-storage/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/events-storage/test/url.sh
+++ b/run/events-storage/test/url.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+
+set -x
+gcloud run services \
+  describe "${SERVICE_NAME}" \
+  --region="${REGION:-us-central1}" \
+  --format='value(status.url)' \
+  --platform=managed

--- a/run/hello-broken/test/deploy.sh
+++ b/run/hello-broken/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/hello-broken/test/runner.sh
+++ b/run/hello-broken/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/hello-broken/test/url.sh
+++ b/run/hello-broken/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC. All rights reserved.
+# Copyright 2020 Google LLC. All rights reserved.
 # Use of this source code is governed by the Apache 2.0
 # license that can be found in the LICENSE file.
 

--- a/run/image-processing/app.js
+++ b/run/image-processing/app.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/image-processing/index.js
+++ b/run/image-processing/index.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/image-processing/package.json
+++ b/run/image-processing/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks --timeout=5000",
+    "test": "mocha test/app.test.js --check-leaks --timeout=5000",
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {

--- a/run/image-processing/package.json
+++ b/run/image-processing/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks --timeout=5000"
+    "test": "mocha test/*.test.js --check-leaks --timeout=5000",
+    "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.0.0",
@@ -25,6 +26,7 @@
     "gm": "^1.23.1"
   },
   "devDependencies": {
+    "got": "^11.5.0",
     "mocha": "^8.0.0",
     "supertest": "^4.0.2"
   }

--- a/run/image-processing/test/deploy.sh
+++ b/run/image-processing/test/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+requireEnv CONTAINER_IMAGE
+
+# Deploy the service
+set -x
+gcloud run deploy "${SERVICE_NAME}" \
+  --image="${CONTAINER_IMAGE}" \
+  --region="${REGION:-us-central1}" \
+  ${FLAGS} \
+  --platform=managed \
+  --quiet
+set +x
+
+echo 'Cloud Run Links:'
+echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"
+echo "- Console: https://console.cloud.google.com/run/detail/${REGION:-us-central1}/${SERVICE_NAME}/metrics?project=${GOOGLE_CLOUD_PROJECT}"

--- a/run/image-processing/test/deploy.sh
+++ b/run/image-processing/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/image-processing/test/runner.sh
+++ b/run/image-processing/test/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+requireEnv SERVICE_NAME
+
+echo '---'
+test/deploy.sh
+
+echo
+echo '---'
+echo
+
+# Register post-test cleanup.
+# Only needed if deploy completed.
+function cleanup {
+  set -x
+  gcloud run services delete ${SERVICE_NAME} \
+    --platform=managed \
+    --region="${REGION:-us-central1}" \
+    --quiet
+}
+trap cleanup EXIT
+
+# TODO: Perform authentication inside the test.
+export ID_TOKEN=$(gcloud auth print-identity-token)
+export BASE_URL=$(test/url.sh)
+
+test -z "$BASE_URL" && echo "BASE_URL value is empty" && exit 1
+
+# Do not use exec to preserve trap behavior.
+"$@"

--- a/run/image-processing/test/runner.sh
+++ b/run/image-processing/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/image-processing/test/system.test.js
+++ b/run/image-processing/test/system.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('assert');
+const got = require('got');
+const {resolve} = require('url');
+
+const request = (method, route, base_url) => {
+  const {ID_TOKEN} = process.env;
+  if (!ID_TOKEN) {
+    throw Error('"ID_TOKEN" environment variable is required.');
+  }
+
+  return got(resolve(base_url.trim(), route), {
+    headers: {
+      Authorization: `Bearer ${ID_TOKEN.trim()}`,
+    },
+    method: method || 'get',
+    throwHttpErrors: false,
+  });
+};
+
+describe('End-to-End Tests', () => {
+  const {BASE_URL} = process.env;
+  if (!BASE_URL) {
+    throw Error(
+      '"BASE_URL" environment variable is required. For example: https://service-x8xabcdefg-uc.a.run.app'
+    );
+  }
+
+  it('post(/) without body is a bad request', async () => {
+    const response = await request('post', '/', BASE_URL);
+    assert.strictEqual(
+      response.statusCode,
+      400,
+      'Bad Requests status not found'
+    );
+  });
+});

--- a/run/image-processing/test/url.sh
+++ b/run/image-processing/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/image-processing/test/url.sh
+++ b/run/image-processing/test/url.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+
+set -x
+gcloud run services \
+  describe "${SERVICE_NAME}" \
+  --region="${REGION:-us-central1}" \
+  --format='value(status.url)' \
+  --platform=managed

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC. All rights reserved.
+# Copyright 2020 Google LLC. All rights reserved.
 # Use of this source code is governed by the Apache 2.0
 # license that can be found in the LICENSE file.
 

--- a/run/logging-manual/app.js
+++ b/run/logging-manual/app.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/logging-manual/index.js
+++ b/run/logging-manual/index.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/logging-manual/test/deploy.sh
+++ b/run/logging-manual/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/logging-manual/test/runner.sh
+++ b/run/logging-manual/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/logging-manual/test/system.test.js
+++ b/run/logging-manual/test/system.test.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/logging-manual/test/url.sh
+++ b/run/logging-manual/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/markdown-preview/renderer/package.json
+++ b/run/markdown-preview/renderer/package.json
@@ -14,13 +14,15 @@
   "main": "main.js",
   "scripts": {
     "start": "node main.js",
-    "test": "mocha test/*.test.js --exit"
+    "test": "mocha test/*.test.js --exit",
+    "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "express": "^4.17.1",
     "markdown-it": "^11.0.0"
   },
   "devDependencies": {
+    "got": "^11.5.0",
     "mocha": "^8.0.0",
     "sinon": "^9.0.2",
     "supertest": "^4.0.2"

--- a/run/markdown-preview/renderer/package.json
+++ b/run/markdown-preview/renderer/package.json
@@ -14,7 +14,7 @@
   "main": "main.js",
   "scripts": {
     "start": "node main.js",
-    "test": "mocha test/*.test.js --exit",
+    "test": "mocha test/main.test.js --exit",
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {

--- a/run/markdown-preview/renderer/test/deploy.sh
+++ b/run/markdown-preview/renderer/test/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+requireEnv CONTAINER_IMAGE
+
+# Deploy the service
+set -x
+gcloud run deploy "${SERVICE_NAME}" \
+  --image="${CONTAINER_IMAGE}" \
+  --region="${REGION:-us-central1}" \
+  ${FLAGS} \
+  --platform=managed \
+  --quiet
+set +x
+
+echo 'Cloud Run Links:'
+echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"
+echo "- Console: https://console.cloud.google.com/run/detail/${REGION:-us-central1}/${SERVICE_NAME}/metrics?project=${GOOGLE_CLOUD_PROJECT}"

--- a/run/markdown-preview/renderer/test/deploy.sh
+++ b/run/markdown-preview/renderer/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/markdown-preview/renderer/test/runner.sh
+++ b/run/markdown-preview/renderer/test/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+requireEnv SERVICE_NAME
+
+echo '---'
+test/deploy.sh
+
+echo
+echo '---'
+echo
+
+# Register post-test cleanup.
+# Only needed if deploy completed.
+function cleanup {
+  set -x
+  gcloud run services delete ${SERVICE_NAME} \
+    --platform=managed \
+    --region="${REGION:-us-central1}" \
+    --quiet
+}
+trap cleanup EXIT
+
+# TODO: Perform authentication inside the test.
+export ID_TOKEN=$(gcloud auth print-identity-token)
+export BASE_URL=$(test/url.sh)
+
+test -z "$BASE_URL" && echo "BASE_URL value is empty" && exit 1
+
+# Do not use exec to preserve trap behavior.
+"$@"

--- a/run/markdown-preview/renderer/test/runner.sh
+++ b/run/markdown-preview/renderer/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/markdown-preview/renderer/test/system.test.js
+++ b/run/markdown-preview/renderer/test/system.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('assert');
+const got = require('got');
+const {resolve} = require('url');
+
+const request = (method, route, base_url) => {
+  const {ID_TOKEN} = process.env;
+  if (!ID_TOKEN) {
+    throw Error('"ID_TOKEN" environment variable is required.');
+  }
+
+  return got(resolve(base_url.trim(), route), {
+    headers: {
+      Authorization: `Bearer ${ID_TOKEN.trim()}`,
+    },
+    method: method || 'get',
+    throwHttpErrors: false,
+  });
+};
+
+describe('End-to-End Tests', () => {
+  const {BASE_URL} = process.env;
+  if (!BASE_URL) {
+    throw Error(
+      '"BASE_URL" environment variable is required. For example: https://service-x8xabcdefg-uc.a.run.app'
+    );
+  }
+
+  it('post(/) without body is a bad request', async () => {
+    const response = await request('post', '/', BASE_URL);
+    assert.strictEqual(
+      response.statusCode,
+      400,
+      'Bad Requests status not found'
+    );
+  });
+});

--- a/run/markdown-preview/renderer/test/url.sh
+++ b/run/markdown-preview/renderer/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/markdown-preview/renderer/test/url.sh
+++ b/run/markdown-preview/renderer/test/url.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+
+set -x
+gcloud run services \
+  describe "${SERVICE_NAME}" \
+  --region="${REGION:-us-central1}" \
+  --format='value(status.url)' \
+  --platform=managed

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC. All rights reserved.
+# Copyright 2020 Google LLC. All rights reserved.
 # Use of this source code is governed by the Apache 2.0
 # license that can be found in the LICENSE file.
 

--- a/run/pubsub/app.js
+++ b/run/pubsub/app.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/pubsub/index.js
+++ b/run/pubsub/index.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All rights reserved.
+// Copyright 2020 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/pubsub/package.json
+++ b/run/pubsub/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks",
+    "test": "mocha test/app.test.js --check-leaks",
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
@@ -23,6 +23,7 @@
     "express": "^4.16.4"
   },
   "devDependencies": {
+    "got": "^11.5.0",
     "mocha": "^8.0.0",
     "sinon": "^9.0.0",
     "supertest": "^4.0.2",

--- a/run/pubsub/package.json
+++ b/run/pubsub/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/*.test.js --check-leaks"
+    "test": "mocha test/*.test.js --check-leaks",
+    "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "body-parser": "^1.19.0",

--- a/run/pubsub/test/deploy.sh
+++ b/run/pubsub/test/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+requireEnv CONTAINER_IMAGE
+
+# Deploy the service
+set -x
+gcloud run deploy "${SERVICE_NAME}" \
+  --image="${CONTAINER_IMAGE}" \
+  --region="${REGION:-us-central1}" \
+  ${FLAGS} \
+  --platform=managed \
+  --quiet
+set +x
+
+echo 'Cloud Run Links:'
+echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"
+echo "- Console: https://console.cloud.google.com/run/detail/${REGION:-us-central1}/${SERVICE_NAME}/metrics?project=${GOOGLE_CLOUD_PROJECT}"

--- a/run/pubsub/test/deploy.sh
+++ b/run/pubsub/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/pubsub/test/runner.sh
+++ b/run/pubsub/test/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+requireEnv SERVICE_NAME
+
+echo '---'
+test/deploy.sh
+
+echo
+echo '---'
+echo
+
+# Register post-test cleanup.
+# Only needed if deploy completed.
+function cleanup {
+  set -x
+  gcloud run services delete ${SERVICE_NAME} \
+    --platform=managed \
+    --region="${REGION:-us-central1}" \
+    --quiet
+}
+trap cleanup EXIT
+
+# TODO: Perform authentication inside the test.
+export ID_TOKEN=$(gcloud auth print-identity-token)
+export BASE_URL=$(test/url.sh)
+
+test -z "$BASE_URL" && echo "BASE_URL value is empty" && exit 1
+
+# Do not use exec to preserve trap behavior.
+"$@"

--- a/run/pubsub/test/runner.sh
+++ b/run/pubsub/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/pubsub/test/system.test.js
+++ b/run/pubsub/test/system.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('assert');
+const got = require('got');
+const {resolve} = require('url');
+
+const request = (method, route, base_url) => {
+  const {ID_TOKEN} = process.env;
+  if (!ID_TOKEN) {
+    throw Error('"ID_TOKEN" environment variable is required.');
+  }
+
+  return got(resolve(base_url.trim(), route), {
+    headers: {
+      Authorization: `Bearer ${ID_TOKEN.trim()}`,
+    },
+    method: method || 'get',
+    throwHttpErrors: false,
+  });
+};
+
+describe('End-to-End Tests', () => {
+  const {BASE_URL} = process.env;
+  if (!BASE_URL) {
+    throw Error(
+      '"BASE_URL" environment variable is required. For example: https://service-x8xabcdefg-uc.a.run.app'
+    );
+  }
+
+  it('post(/) without body is a bad request', async () => {
+    const response = await request('post', '/', BASE_URL);
+    assert.strictEqual(
+      response.statusCode,
+      400,
+      'Bad Requests status not found'
+    );
+  });
+});

--- a/run/pubsub/test/url.sh
+++ b/run/pubsub/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/pubsub/test/url.sh
+++ b/run/pubsub/test/url.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+
+set -x
+gcloud run services \
+  describe "${SERVICE_NAME}" \
+  --region="${REGION:-us-central1}" \
+  --format='value(status.url)' \
+  --platform=managed

--- a/run/system-package/package.json
+++ b/run/system-package/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/app.test.js"
+    "test": "mocha test/app.test.js",
+    "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "express": "^4.17.1"

--- a/run/system-package/package.json
+++ b/run/system-package/package.json
@@ -6,13 +6,14 @@
   "private": true,
   "scripts": {
     "start": "node index.js",
-    "test": "mocha test/app.test.js",
+    "test": "mocha test/app.test.js --check-leaks",
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
     "express": "^4.17.1"
   },
   "devDependencies": {
+    "got": "^11.5.0",
     "mocha": "^8.0.0",
     "supertest": "^4.0.2"
   }

--- a/run/system-package/test/deploy.sh
+++ b/run/system-package/test/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+requireEnv CONTAINER_IMAGE
+
+# Deploy the service
+set -x
+gcloud run deploy "${SERVICE_NAME}" \
+  --image="${CONTAINER_IMAGE}" \
+  --region="${REGION:-us-central1}" \
+  ${FLAGS} \
+  --platform=managed \
+  --quiet
+set +x
+
+echo 'Cloud Run Links:'
+echo "- Logs: https://console.cloud.google.com/logs/viewer?project=${GOOGLE_CLOUD_PROJECT}&resource=cloud_run_revision%2Fservice_name%2F${SERVICE_NAME}"
+echo "- Console: https://console.cloud.google.com/run/detail/${REGION:-us-central1}/${SERVICE_NAME}/metrics?project=${GOOGLE_CLOUD_PROJECT}"

--- a/run/system-package/test/deploy.sh
+++ b/run/system-package/test/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/system-package/test/runner.sh
+++ b/run/system-package/test/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+requireEnv SERVICE_NAME
+
+echo '---'
+test/deploy.sh
+
+echo
+echo '---'
+echo
+
+# Register post-test cleanup.
+# Only needed if deploy completed.
+function cleanup {
+  set -x
+  gcloud run services delete ${SERVICE_NAME} \
+    --platform=managed \
+    --region="${REGION:-us-central1}" \
+    --quiet
+}
+trap cleanup EXIT
+
+# TODO: Perform authentication inside the test.
+export ID_TOKEN=$(gcloud auth print-identity-token)
+export BASE_URL=$(test/url.sh)
+
+test -z "$BASE_URL" && echo "BASE_URL value is empty" && exit 1
+
+# Do not use exec to preserve trap behavior.
+"$@"

--- a/run/system-package/test/runner.sh
+++ b/run/system-package/test/runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/system-package/test/system.test.js
+++ b/run/system-package/test/system.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('assert');
+const got = require('got');
+const {resolve} = require('url');
+
+const request = (method, route, base_url) => {
+  const {ID_TOKEN} = process.env;
+  if (!ID_TOKEN) {
+    throw Error('"ID_TOKEN" environment variable is required.');
+  }
+
+  return got(resolve(base_url.trim(), route), {
+    headers: {
+      Authorization: `Bearer ${ID_TOKEN.trim()}`,
+    },
+    method: method || 'get',
+    throwHttpErrors: false,
+  });
+};
+
+describe('End-to-End Tests', () => {
+  const {BASE_URL} = process.env;
+  if (!BASE_URL) {
+    throw Error(
+      '"BASE_URL" environment variable is required. For example: https://service-x8xabcdefg-uc.a.run.app'
+    );
+  }
+
+  it('post(/diagram.png) without request parameters is a bad request', async () => {
+    const response = await request('get', '/diagram.png', BASE_URL);
+    assert.strictEqual(
+      response.statusCode,
+      400,
+      'Bad Requests status not found'
+    );
+  });
+});

--- a/run/system-package/test/url.sh
+++ b/run/system-package/test/url.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/system-package/test/url.sh
+++ b/run/system-package/test/url.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail;
+
+requireEnv() {
+  test "${!1}" || (echo "Environment Variable '$1' not found" && exit 1)
+}
+
+requireEnv SERVICE_NAME
+
+set -x
+gcloud run services \
+  describe "${SERVICE_NAME}" \
+  --region="${REGION:-us-central1}" \
+  --format='value(status.url)' \
+  --platform=managed


### PR DESCRIPTION
Fixes #1916
This includes #1915, which is kept broken out to facilitate review.

The approach used in this PR involves a lot of shell script copying. A new approach is being worked on, which I hope will be used to drive simplification here.

cc @jsimonweb @dmahugh 