### PR TITLE
fix(run/markdown-preview): region tags should encompass imports

### DIFF
--- a/run/markdown-preview/editor/render.js
+++ b/run/markdown-preview/editor/render.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START run_secure_request]
+
 const {GoogleAuth} = require('google-auth-library');
 const got = require('got');
 const auth = new GoogleAuth();
@@ -21,7 +23,6 @@ let client, serviceUrl;
 // renderRequest creates a new HTTP request with IAM ID Token credential.
 // This token is automatically handled by private Cloud Run (fully managed) and Cloud Functions.
 const renderRequest = async (markdown) => { 
-  // [START run_secure_request]
   if (!process.env.EDITOR_UPSTREAM_RENDER_URL) throw Error('EDITOR_UPSTREAM_RENDER_URL needs to be set.');
   serviceUrl = process.env.EDITOR_UPSTREAM_RENDER_URL;
 
@@ -53,7 +54,8 @@ const renderRequest = async (markdown) => {
   } catch (err) { 
     throw Error('request to rendering service failed: ', err);
   };
-  // [END run_secure_request]
 };
+
+// [END run_secure_request]
 
 module.exports = renderRequest;


### PR DESCRIPTION
The region tag placement is excluding the import statements, which are very important. Also, unlike the other languages this is hiding that it's wrapped in a function, which the language in the tutorial implies.