### PR TITLE
chore(functions/pubsub): update gcloud command

### DIFF
--- a/functions/pubsub/README.md
+++ b/functions/pubsub/README.md
@@ -47,7 +47,7 @@ can skip this step):
 
 1. Check the logs for the `subscribe` function:
 
-        gcloud alpha functions get-logs subscribe
+        gcloud functions logs read subscribe
 
     You should see something like this in your console:
 


### PR DESCRIPTION
Improving documentation on checking logs of running google cloud function called subscribe.