### PR TITLE
fix: pin events library to specific version

### DIFF
--- a/eventarc/pubsub/package.json
+++ b/eventarc/pubsub/package.json
@@ -19,7 +19,7 @@
     "system-test": "test/runner.sh mocha test/system.test.js --timeout=10000"
   },
   "dependencies": {
-    "@google/events": "^3.0.0",
+    "@google/events": "3.0.0",
     "express": "^4.16.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes error in releasing the library. We shouldn't be using the head library anyways.