### PR TITLE
Extend retries for Run tests

### DIFF
--- a/.kokoro/build-with-run.sh
+++ b/.kokoro/build-with-run.sh
@@ -53,18 +53,6 @@ set -x
 export SUFFIX="$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | head -c 15)"
 set +x
 export SERVICE_NAME="${SAMPLE_NAME}-${SUFFIX}"
-export CONTAINER_IMAGE="gcr.io/${GOOGLE_CLOUD_PROJECT}/run-${SAMPLE_NAME}:${SAMPLE_VERSION}"
-
-# Build the service
-set -x
-gcloud builds submit --tag="${CONTAINER_IMAGE}"
-set +x
-
-# Register post-test cleanup.
-function cleanup {
-  gcloud --quiet container images delete "${CONTAINER_IMAGE}" || true
-}
-trap cleanup EXIT HUP
 
 # Install dependencies and run Nodejs tests.
 export NODE_ENV=development

--- a/run/idp-sql/static/firebase.js
+++ b/run/idp-sql/static/firebase.js
@@ -33,7 +33,7 @@ function signIn() {
     })
     .catch(err => {
       console.log(`Error during sign in: ${err.message}`);
-      window.alert(`Sign in failed. Retry or check your browser logs.`);
+      window.alert('Sign in failed. Retry or check your browser logs.');
     });
 }
 // [END run_end_user_firebase_sign_in]
@@ -46,7 +46,7 @@ function signOut() {
     .then(result => {})
     .catch(err => {
       console.log(`Error during sign out: ${err.message}`);
-      window.alert(`Sign out failed. Retry or check your browser logs.`);
+      window.alert('Sign out failed. Retry or check your browser logs.');
     });
 }
 

--- a/run/logging-manual/package.json
+++ b/run/logging-manual/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "system-test": "mocha test/system.test.js --timeout=180000 --exit"
+    "system-test": "mocha test/system.test.js --timeout=300000 --exit"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/run/markdown-preview/editor/test/system.test.js
+++ b/run/markdown-preview/editor/test/system.test.js
@@ -104,7 +104,10 @@ describe('End-to-End Tests', () => {
       json: {
         data: '**markdown**',
       },
-      retry: 3,
+      retry: {
+        limit: 5,
+        methods: ['POST']
+      },
     };
     const response = await got('render', options);
     assert.strictEqual(response.statusCode, 200);

--- a/run/markdown-preview/editor/test/system.test.js
+++ b/run/markdown-preview/editor/test/system.test.js
@@ -106,7 +106,7 @@ describe('End-to-End Tests', () => {
       },
       retry: {
         limit: 5,
-        methods: ['POST']
+        methods: ['POST'],
       },
     };
     const response = await got('render', options);


### PR DESCRIPTION
Also extends timeout for another flaky test and removes unneeded container build from Kokoro.

Fixes #2139