### PR TITLE
chore(functions): remove unused exception handler

### DIFF
--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -99,8 +99,8 @@ const verifyWebhook = req => {
     body: req.rawBody,
   };
 
-  // This function throws an exception if an incoming request is invalid.
-  !verifyRequestSignature(signature);
+  // This method throws an exception if an incoming request is invalid.
+  verifyRequestSignature(signature);
 };
 // [END functions_verify_webhook]
 

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -99,11 +99,8 @@ const verifyWebhook = req => {
     body: req.rawBody,
   };
 
-  if (!verifyRequestSignature(signature)) {
-    const error = new Error('Invalid credentials');
-    error.code = 401;
-    throw error;
-  }
+  // This function throws an exception if an incoming request is invalid.
+  !verifyRequestSignature(signature);
 };
 // [END functions_verify_webhook]
 


### PR DESCRIPTION
The relevant Slack API client library method directly throws an exception anyway. (See b/171900608 for details.)