### PR TITLE
fix(functions): add fully qualified domain name for metadata sample

### DIFF
--- a/functions/security/index.js
+++ b/functions/security/index.js
@@ -23,7 +23,7 @@ const PROJECT_ID = 'my-project-id';
 const RECEIVING_FUNCTION = 'myFunction';
 
 // Constants for setting up metadata server request
-// See https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature
+// See https://cloud.google.com/functions/docs/securing/function-identity#identity_tokens
 const functionURL = `https://${REGION}-${PROJECT_ID}.cloudfunctions.net/${RECEIVING_FUNCTION}`;
 const metadataServerURL =
   'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=';

--- a/functions/security/index.js
+++ b/functions/security/index.js
@@ -26,7 +26,7 @@ const RECEIVING_FUNCTION = 'myFunction';
 // See https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature
 const functionURL = `https://${REGION}-${PROJECT_ID}.cloudfunctions.net/${RECEIVING_FUNCTION}`;
 const metadataServerURL =
-  'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=';
+  'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=';
 const tokenUrl = metadataServerURL + functionURL;
 
 exports.callingFunction = async (req, res) => {


### PR DESCRIPTION
Due to differences in implementation, there can be issues if
the metadata server isn't fully qualified in code. This
minor fix resolves that issue.

Related b/154412754.
