### PR TITLE
fix: update eventarc storage name

### DIFF
--- a/eventarc/audit-storage/app.js
+++ b/eventarc/audit-storage/app.js
@@ -24,10 +24,14 @@ app.post('/', (req, res) => {
       .send('Bad Request: missing required header: ce-subject');
   }
 
-  console.log(`Detected change in Cloud Storage bucket: ${req.header('ce-subject')}`);
+  console.log(
+    `Detected change in Cloud Storage bucket: ${req.header('ce-subject')}`
+  );
   return res
     .status(200)
-    .send(`Detected change in Cloud Storage bucket: ${req.header('ce-subject')}`);
+    .send(
+      `Detected change in Cloud Storage bucket: ${req.header('ce-subject')}`
+    );
 });
 
 module.exports = app;

--- a/eventarc/audit-storage/app.js
+++ b/eventarc/audit-storage/app.js
@@ -24,10 +24,10 @@ app.post('/', (req, res) => {
       .send('Bad Request: missing required header: ce-subject');
   }
 
-  console.log(`Detected change in GCS bucket: ${req.header('ce-subject')}`);
+  console.log(`Detected change in Cloud Storage bucket: ${req.header('ce-subject')}`);
   return res
     .status(200)
-    .send(`Detected change in GCS bucket: ${req.header('ce-subject')}`);
+    .send(`Detected change in Cloud Storage bucket: ${req.header('ce-subject')}`);
 });
 
 module.exports = app;

--- a/eventarc/audit-storage/test/app.test.js
+++ b/eventarc/audit-storage/test/app.test.js
@@ -47,7 +47,7 @@ describe('Unit Tests', () => {
       console.log.restore();
     });
 
-    it('with a minimally valid GCS event', async () => {
+    it('with a minimally valid Cloud Storage event', async () => {
       await request
         .post('/')
         .set('ce-subject', 'test-subject')
@@ -56,7 +56,7 @@ describe('Unit Tests', () => {
         .expect(() =>
           assert.ok(
             console.log.calledWith(
-              'Detected change in GCS bucket: test-subject'
+              'Detected change in Cloud Storage: test-subject'
             )
           )
         );

--- a/eventarc/audit-storage/test/app.test.js
+++ b/eventarc/audit-storage/test/app.test.js
@@ -53,13 +53,14 @@ describe('Unit Tests', () => {
         .set('ce-subject', 'test-subject')
         .send()
         .expect(200)
-        .expect(() =>
-          assert.ok(
+        .expect(() => {
+          assert.strictEqual(
             console.log.calledWith(
-              'Detected change in Cloud Storage: test-subject'
-            )
-          )
-        );
+              'Detected change in Cloud Storage bucket: test-subject'
+            ),
+            true
+          );
+        });
     });
   });
 });


### PR DESCRIPTION
Uses "Cloud Storage" instead of "GCS" for Eventarc Audit quickstart per branding guidelines.

See internal b/180109929