### PR TITLE
chore: update CODEOWNERS for serverless

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,13 +7,15 @@
 
 # Kokoro
 .kokoro @fhinkel
-.kokoro/appengine @michaelawyu
+.kokoro/appengine @GoogleCloudPlatform/cdpe-cbr-containers
 .kokoro/functions @ace-n @grant
 
 # Serverless/CBR
-appengine @michaelawyu
+appengine @GoogleCloudPlatform/cdpe-cbr-containers
 functions @ace-n @grant
 run @GoogleCloudPlatform/cdpe-cbr-containers
+eventarc @GoogleCloudPlatform/cdpe-cbr-containers
+workflows @GoogleCloudPlatform/cdpe-cbr-containers
 
 # Other functions samples
 functions/scheduleinstance @askmeegs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,15 +7,15 @@
 
 # Kokoro
 .kokoro @fhinkel
-.kokoro/appengine @GoogleCloudPlatform/cdpe-cbr-containers
+.kokoro/appengine @GoogleCloudPlatform/cdpe-serverless
 .kokoro/functions @ace-n @grant
 
 # Serverless/CBR
-appengine @GoogleCloudPlatform/cdpe-cbr-containers
+appengine @GoogleCloudPlatform/cdpe-serverless
 functions @ace-n @grant
-run @GoogleCloudPlatform/cdpe-cbr-containers
-eventarc @GoogleCloudPlatform/cdpe-cbr-containers
-workflows @GoogleCloudPlatform/cdpe-cbr-containers
+run @GoogleCloudPlatform/cdpe-serverless
+eventarc @GoogleCloudPlatform/cdpe-serverless
+workflows @GoogleCloudPlatform/cdpe-serverless
 
 # Other functions samples
 functions/scheduleinstance @askmeegs


### PR DESCRIPTION
- Updates CODEOWNERs for various serverless folders
- Use updated GitHub team name: https://github.com/orgs/GoogleCloudPlatform/teams/cdpe-serverless

This prevents an admin being a required reviewer for folders.