### PR TITLE
Replaced body-parser from run/pubsub sample

### DIFF
--- a/run/pubsub/README.md
+++ b/run/pubsub/README.md
@@ -9,6 +9,5 @@ For more details on how to work with this sample read the [Google Cloud Run Node
 ## Dependencies
 
 * **express**: Web server framework.
-* **body-parser**: express middleware for request payload processing.
 * **mocha**: [development] Test running framework.
 * **supertest**: [development] HTTP assertion test client.

--- a/run/pubsub/app.js
+++ b/run/pubsub/app.js
@@ -5,10 +5,10 @@
 // [START cloudrun_pubsub_server_setup]
 // [START run_pubsub_server_setup]
 const express = require('express');
-const bodyParser = require('body-parser');
 const app = express();
 
-app.use(bodyParser.json());
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 // [END run_pubsub_server_setup]
 // [END cloudrun_pubsub_server_setup]
 

--- a/run/pubsub/package.json
+++ b/run/pubsub/package.json
@@ -19,7 +19,6 @@
     "system-test": "mocha test/system.test.js --timeout=300000 --exit"
   },
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.16.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Removed body-parser from run/pub- sub sample and used internal express.json functionality as this middleware is available in Express v4.16.0 onwards