### PR TITLE
Add comment about authenticated push JWT token validation.

### DIFF
--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -122,7 +122,7 @@ app.post('/pubsub/authenticated-push', jsonBodyParser, async (req, res) => {
     // by signature and audience verification above, including:
     //   - Ensure that `claim.email` is equal to the expected service
     //     account set up in the push subscription settings.
-    //   - Ensure that `calim.email_verified` is set to true.
+    //   - Ensure that `claim.email_verified` is set to true.
 
     claims.push(claim);
   } catch (e) {

--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -118,12 +118,10 @@ app.post('/pubsub/authenticated-push', jsonBodyParser, async (req, res) => {
 
     const claim = ticket.getPayload();
 
-    // IMPORTANT: user code must validate claim details in addition
-    // to signature verification above:
+    // IMPORTANT: you should validate claim details not covered
+    // by signature and audience verification above, including:
     //   - Ensure that `claim.email` is equal to the expected service
     //     account set up in the push subscription settings.
-    //   - Ensure that `claim.aud` is equal to the audience set up in
-    //     the push subscription settings.
     //   - Ensure that `calim.email_verified` is set to true.
 
     claims.push(claim);

--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -117,6 +117,15 @@ app.post('/pubsub/authenticated-push', jsonBodyParser, async (req, res) => {
     });
 
     const claim = ticket.getPayload();
+
+    // IMPORTANT: user code must validate claim details in addition
+    // to signature verification above:
+    //   - Ensure that `claim.email` is equal to the expected service
+    //     account set up in the push subscription settings.
+    //   - Ensure that `claim.aud` is equal to the audience set up in
+    //     the push subscription settings.
+    //   - Ensure that `calim.email_verified` is set to true.
+
     claims.push(claim);
   } catch (e) {
     res.status(400).send('Invalid token');


### PR DESCRIPTION
This snippet is used in the Cloud Pub/Sub docs (https://cloud.google.com/pubsub/docs/push#validating_tokens) and many users are not aware that signature verification of the token is not enough, the claim needs to be validated also.