### PR TITLE
Replaced all occurrences of body-parser from the samples

### DIFF
--- a/appengine/building-an-app/update/package.json
+++ b/appengine/building-an-app/update/package.json
@@ -19,7 +19,6 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "body-parser": "^1.18.2",
     "express": "^4.16.3"
   },
   "devDependencies": {

--- a/appengine/building-an-app/update/server.js
+++ b/appengine/building-an-app/update/server.js
@@ -16,13 +16,13 @@
 
 // [START app]
 const express = require('express');
-const bodyParser = require('body-parser');
 const path = require('path');
 
 const app = express();
 
 // [START enable_parser]
-app.use(bodyParser.urlencoded({extended: true}));
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json({extended: true}));
 // [END enable_parser]
 
 app.get('/', (req, res) => {

--- a/appengine/endpoints/app.js
+++ b/appengine/endpoints/app.js
@@ -15,10 +15,11 @@
 'use strict';
 
 const express = require('express');
-const bodyParser = require('body-parser');
 
 const app = express();
-app.use(bodyParser.json());
+
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 
 app.post('/echo', (req, res) => {
   res.status(200).json({message: req.body.message});

--- a/appengine/endpoints/package.json
+++ b/appengine/endpoints/package.json
@@ -19,7 +19,6 @@
     "test": "npm run unit-test"
   },
   "dependencies": {
-    "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "express": "^4.16.4",
     "wait-port": "^0.2.7"

--- a/appengine/endpoints/test/app.test.js
+++ b/appengine/endpoints/test/app.test.js
@@ -16,7 +16,7 @@
 
 const express = require('express');
 const path = require('path');
-const proxyquire = require('proxyquire').noCallThru();
+const proxyquire = require('proxyquire').noPreserveCache();
 const request = require('supertest');
 const sinon = require('sinon');
 const assert = require('assert');

--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const {OAuth2Client} = require('google-auth-library');
 const path = require('path');
 const process = require('process'); // Required for mocking environment variables
@@ -35,8 +34,9 @@ const app = express();
 app.set('view engine', 'pug');
 app.set('views', path.join(__dirname, 'views'));
 
-const formBodyParser = bodyParser.urlencoded({extended: false});
-const jsonBodyParser = bodyParser.json();
+// This middleware is available in Express v4.16.0 onwards
+const formBodyParser = express.urlencoded({extended: false});
+const jsonBodyParser = express.json();
 
 // List of all messages received by this instance
 const messages = [];

--- a/appengine/pubsub/package.json
+++ b/appengine/pubsub/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^2.5.0",
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "google-auth-library": "^7.0.0",
     "path": "^0.12.7",

--- a/appengine/storage/flexible/app.js
+++ b/appengine/storage/flexible/app.js
@@ -20,7 +20,6 @@ const process = require('process'); // Required to mock environment variables
 const {format} = require('util');
 const express = require('express');
 const Multer = require('multer');
-const bodyParser = require('body-parser');
 
 // By default, the client will authenticate using the service account file
 // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
@@ -34,7 +33,9 @@ const storage = new Storage();
 
 const app = express();
 app.set('view engine', 'pug');
-app.use(bodyParser.json());
+
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 
 // Multer is required to process file uploads and make them available via
 // req.files.

--- a/appengine/storage/flexible/package.json
+++ b/appengine/storage/flexible/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.3.0",
-    "body-parser": "^1.19.0",
     "express": "^4.17.0",
     "multer": "^1.4.2",
     "pug": "^3.0.0"

--- a/appengine/storage/standard/app.js
+++ b/appengine/storage/standard/app.js
@@ -20,7 +20,6 @@ const process = require('process'); // Required to mock environment variables
 const {format} = require('util');
 const express = require('express');
 const Multer = require('multer');
-const bodyParser = require('body-parser');
 
 // By default, the client will authenticate using the service account file
 // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
@@ -34,7 +33,9 @@ const storage = new Storage();
 
 const app = express();
 app.set('view engine', 'pug');
-app.use(bodyParser.json());
+
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 
 // Multer is required to process file uploads and make them available via
 // req.files.

--- a/appengine/storage/standard/package.json
+++ b/appengine/storage/standard/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.3.0",
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "multer": "^1.4.2",
     "pug": "^3.0.0"

--- a/appengine/twilio/app.js
+++ b/appengine/twilio/app.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const express = require('express');
-const bodyParser = require('body-parser').urlencoded({
+const bodyParser = express.urlencoded({
   extended: false,
 });
 

--- a/appengine/twilio/package.json
+++ b/appengine/twilio/package.json
@@ -13,7 +13,6 @@
     "test": "mocha test/*.test.js"
   },
   "dependencies": {
-    "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "twilio": "^3.34.0"
   },

--- a/cloud-sql/mysql/mysql/package.json
+++ b/cloud-sql/mysql/mysql/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.0",
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "promise-mysql": "^5.0.0",
     "prompt": "^1.0.0",

--- a/cloud-sql/mysql/mysql/server.js
+++ b/cloud-sql/mysql/mysql/server.js
@@ -16,15 +16,15 @@
 
 const express = require('express');
 const mysql = require('promise-mysql');
-const bodyParser = require('body-parser');
 
 const app = express();
 app.set('view engine', 'pug');
 app.enable('trust proxy');
 
 // Automatically parse request body as form data.
-app.use(bodyParser.urlencoded({extended: false}));
-app.use(bodyParser.json());
+app.use(express.urlencoded({extended: false}));
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 
 // Set Content-Type for all responses for these routes.
 app.use((req, res, next) => {

--- a/cloud-sql/postgres/knex/package.json
+++ b/cloud-sql/postgres/knex/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.0",
-    "body-parser": "^1.18.3",
     "express": "^4.16.2",
     "knex": "^0.95.0",
     "pg": "^8.0.0",

--- a/cloud-sql/postgres/knex/server.js
+++ b/cloud-sql/postgres/knex/server.js
@@ -18,7 +18,6 @@
 const process = require('process');
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const Knex = require('knex');
 
 const app = express();
@@ -26,8 +25,9 @@ app.set('view engine', 'pug');
 app.enable('trust proxy');
 
 // Automatically parse request body as form data.
-app.use(bodyParser.urlencoded({extended: false}));
-app.use(bodyParser.json());
+app.use(express.urlencoded({extended: false}));
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 
 // Set Content-Type for all responses for these routes.
 app.use((req, res, next) => {

--- a/cloud-sql/sqlserver/mssql/package.json
+++ b/cloud-sql/sqlserver/mssql/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.0",
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "mssql": "^6.2.0",
     "prompt": "^1.0.0",

--- a/cloud-sql/sqlserver/mssql/server.js
+++ b/cloud-sql/sqlserver/mssql/server.js
@@ -16,15 +16,15 @@
 
 const express = require('express');
 const mssql = require('mssql');
-const bodyParser = require('body-parser');
 
 const app = express();
 app.set('view engine', 'pug');
 app.enable('trust proxy');
 
+// This middleware is available in Express v4.16.0 onwards
 // Automatically parse request body as form data.
-app.use(bodyParser.urlencoded({extended: false}));
-app.use(bodyParser.json());
+app.use(express.urlencoded({extended: false}));
+app.use(express.json());
 
 // Set Content-Type for all responses for these routes.
 app.use((req, res, next) => {

--- a/endpoints/getting-started/app.js
+++ b/endpoints/getting-started/app.js
@@ -17,12 +17,13 @@
 
 // [START setup]
 const express = require('express');
-const bodyParser = require('body-parser');
 
 const app = express();
 
 app.set('case sensitive routing', true);
-app.use(bodyParser.json());
+
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 // [END setup]
 
 app.post('/echo', (req, res) => {

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -17,7 +17,6 @@
     "test": "mocha -- test/*.test.js --timeout=20000"
   },
   "dependencies": {
-    "body-parser": "^1.18.3",
     "express": "^4.16.4"
   },
   "devDependencies": {

--- a/run/image-processing/README.md
+++ b/run/image-processing/README.md
@@ -9,7 +9,6 @@ For more details on how to work with this sample read the [Google Cloud Run Node
 ## Dependencies
 
 * **express**: Web server framework
-* **body-parser**: express middleware for request payload processing
 * **[gm](https://github.com/aheckmann/gm#readme)**: ImageMagick integration library.
 * **@google-cloud/storage**: Google Cloud Storage client library.
 * **@google-cloud/vision**: Cloud Vision API client library.

--- a/run/image-processing/app.js
+++ b/run/image-processing/app.js
@@ -6,10 +6,10 @@
 // [START run_imageproc_controller]
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const app = express();
 
-app.use(bodyParser.json());
+// This middleware is available in Express v4.16.0 onwards
+app.use(express.json());
 
 const image = require('./image');
 

--- a/run/image-processing/package.json
+++ b/run/image-processing/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@google-cloud/storage": "^5.0.0",
     "@google-cloud/vision": "^2.0.0",
-    "body-parser": "^1.19.0",
     "express": "^4.16.4",
     "gm": "^1.23.1"
   },


### PR DESCRIPTION
Removed body-parser from all samples and used internal express.json functionality as this middleware is available in Express v4.16.0 onwards