### PR TITLE
Update CODEOWNERS / Blunderbuss for SoDA teams

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -2,7 +2,7 @@ assign_issues:
   -sofisl
   
 assign_issues_by:
- - labels:
+- labels:
   - 'api: bigtable'
   - 'api: datastore'
   - 'api: firestore'
@@ -14,7 +14,7 @@ assign_issues_by:
   - GoogleCloudPlatform/infra-db-dpes
 
 assign_prs_by:
- - labels:
+- labels:
   - 'api: bigtable'
   - 'api: datastore'
   - 'api: firestore'

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,2 +1,26 @@
 assign_issues:
   -sofisl
+  
+assign_issues_by:
+ - labels:
+  - 'api: bigtable'
+  - 'api: datastore'
+  - 'api: firestore'
+  to:
+  - GoogleCloudPlatform/cloud-native-db-dpes
+- labels:
+  - 'api: cloudsql'
+  to:
+  - GoogleCloudPlatform/infra-db-dpes
+
+assign_prs_by:
+ - labels:
+  - 'api: bigtable'
+  - 'api: datastore'
+  - 'api: firestore'
+  to:
+  - GoogleCloudPlatform/cloud-native-db-dpes
+- labels:
+  - 'api: cloudsql'
+  to:
+  - GoogleCloudPlatform/infra-db-dpes

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,5 +1,5 @@
 assign_issues:
-  -sofisl
+  - sofisl
   
 assign_issues_by:
 - labels:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,10 +21,14 @@ functions/memorystore @ericschmidtatwork @GoogleCloudPlatform/nodejs-docs-sample
 functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-docs-samples-owners
 
 # GCF samples outside of functions/
-datastore/functions @benwhitehead @GoogleCloudPlatform/nodejs-docs-samples-owners
+
+
+# SoDa teams
+cloud-sql @GoogleCloudPlatform/infra-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
+datastore @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
 
 # One-offs
-cloud-sql @kurtisvg @GoogleCloudPlatform/nodejs-docs-samples-owners
+
 composer @leahecole @sofisl @yoshi-nodejs @GoogleCloudPlatform/nodejs-docs-samples-owners
 healthcare @noerog @GoogleCloudPlatform/nodejs-docs-samples-owners
 monitoring/opencensus @yuriatgoogle @GoogleCloudPlatform/nodejs-docs-samples-owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,15 +20,11 @@ functions/speech-to-speech @ricalo @GoogleCloudPlatform/nodejs-docs-samples-owne
 functions/memorystore @ericschmidtatwork @GoogleCloudPlatform/nodejs-docs-samples-owners
 functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-docs-samples-owners
 
-# GCF samples outside of functions/
-
-
 # SoDa teams
-cloud-sql @GoogleCloudPlatform/infra-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
-datastore @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
+/cloud-sql/**/*.js @GoogleCloudPlatform/infra-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
+/datastore/**/*.js @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
 
 # One-offs
-
 composer @leahecole @sofisl @yoshi-nodejs @GoogleCloudPlatform/nodejs-docs-samples-owners
 healthcare @noerog @GoogleCloudPlatform/nodejs-docs-samples-owners
 monitoring/opencensus @yuriatgoogle @GoogleCloudPlatform/nodejs-docs-samples-owners


### PR DESCRIPTION
Updates the CODEOWNERs file and Blunderbuss config for new teamsync managed groups

Before merging, please make sure the follow teams have write access for this repo:

- [x] `@GoogleCloudPlatform/cloud-native-db-dpes`
- [x] `@GoogleCloudPlatform/infra-db-dpes`