### PR TITLE
fix(functions/slack): use @googleapis/kgsearch module

### DIFF
--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -15,7 +15,7 @@
 'use strict';
 
 // [START functions_slack_setup]
-const google = require('googleapis/build/src/apis/kgsearch');
+const google = require('@googleapis/kgsearch');
 const {verifyRequestSignature} = require('@slack/events-api');
 
 // Get a reference to the Knowledge Graph Search component

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -15,8 +15,8 @@
     "test": "mocha test/*.test.js --timeout=20000"
   },
   "dependencies": {
-    "@slack/events-api": "^3.0.0",
-    "googleapis": "^75.0.0"
+    "@googleapis/kgsearch": "^0.2.0",
+    "@slack/events-api": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^8.0.0",

--- a/functions/slack/test/index.test.js
+++ b/functions/slack/test/index.test.js
@@ -42,7 +42,7 @@ const getSample = () => {
 
   return {
     program: proxyquire('../', {
-      'googleapis/build/src/apis/kgsearch': googleapis,
+      '@googleapis/kgsearch': googleapis,
       process: {env: config},
       '@slack/events-api': eventsApi,
     }),


### PR DESCRIPTION
We've split the `googleapis` module so individual services are now installable.  This should drastically reduce the number of PRs we get for renovate updates, and make things faster. 