### PR TITLE
fix(opencensus): remove unused dependencies

### DIFF
--- a/monitoring/opencensus/package.json
+++ b/monitoring/opencensus/package.json
@@ -12,15 +12,11 @@
   "dependencies": {
     "@opencensus/core": "^0.0.22",
     "@opencensus/exporter-stackdriver": "^0.0.22",
-    "chai": "^4.3.0",
     "express": "^4.17.1",
-    "lint": "^0.7.0",
-    "node-stopwatch": "^0.0.1",
-    "request": "^2.88.2",
-    "supertest": "^6.1.3"
+    "node-stopwatch": "^0.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.19.0",
-    "mocha": "^8.2.1"
+    "mocha": "^8.2.1",
+    "supertest": "^6.1.3"
   }
 }


### PR DESCRIPTION
In pursuit of removing `request` dependencies, I ran across these samples that weren't using most of the dependencies.  There are no material code changes here. 