### PR TITLE
fix(functions/billing): use @google-cloud/billing module

### DIFF
--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -13,6 +13,7 @@
   "author": "Ace Nassri <anassri@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/billing": "^2.2.2",
     "google-auth-library": "^7.0.0",
     "googleapis": "^75.0.0",
     "slack": "^11.0.1"


### PR DESCRIPTION
This replaces the usage of the `googleapis` module for billing with the newer `@google-cloud/billing` module.  There will be followup PRs to a.) remove the usage of `googleapis` for compute and b.) to remove the usage of `request` in this sample. 