### PR TITLE
fix(functions/billing): remove usage of request module

### DIFF
--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -21,11 +21,10 @@
   "devDependencies": {
     "@google-cloud/functions-framework": "^1.1.1",
     "child-process-promise": "^2.2.1",
+    "gaxios": "^4.3.0",
     "mocha": "^8.0.0",
     "promise-retry": "^2.0.0",
     "proxyquire": "^2.1.0",
-    "request": "^2.88.0",
-    "requestretry": "^5.0.0",
     "sinon": "^11.0.0"
   }
 }

--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -20,11 +20,11 @@
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^1.1.1",
-    "child-process-promise": "^2.2.1",
     "gaxios": "^4.3.0",
     "mocha": "^8.0.0",
     "promise-retry": "^2.0.0",
     "proxyquire": "^2.1.0",
-    "sinon": "^11.0.0"
+    "sinon": "^11.0.0",
+    "wait-port": "^0.2.9"
   }
 }

--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "compute-test": "mocha test/periodic.test.js --timeout=600000",
-    "test": "mocha test/index.test.js --timeout=5000"
+    "test": "mocha test/index.test.js --timeout=5000 --exit"
   },
   "author": "Ace Nassri <anassri@google.com>",
   "license": "Apache-2.0",

--- a/functions/billing/test/index.test.js
+++ b/functions/billing/test/index.test.js
@@ -15,7 +15,7 @@
 const proxyquire = require('proxyquire');
 const execPromise = require('child-process-promise').exec;
 const path = require('path');
-const requestRetry = require('requestretry');
+const {request} = require('gaxios');
 const assert = require('assert');
 const sinon = require('sinon');
 
@@ -75,17 +75,18 @@ describe('functions/billing tests', () => {
         );
         const pubsubMessage = {data: encodedData, attributes: {}};
 
-        const response = await requestRetry({
+        const response = await request({
           url: `${BASE_URL}/notifySlack`,
           method: 'POST',
           body: {data: pubsubMessage},
-          retryDelay: 200,
-          json: true,
+          retryConfig: {
+            retryDelay: 200,
+          },
         });
 
-        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.status, 200);
         assert.strictEqual(
-          response.body,
+          response.data,
           'Slack notification sent successfully'
         );
       });
@@ -118,16 +119,17 @@ describe('functions/billing tests', () => {
         );
         const pubsubMessage = {data: encodedData, attributes: {}};
 
-        const response = await requestRetry({
+        const response = await request({
           url: `${BASE_URL}/stopBilling`,
           method: 'POST',
           body: {data: pubsubMessage},
-          retryDelay: 200,
-          json: true,
+          retryConfig: {
+            retryDelay: 200,
+          },
         });
 
-        assert.strictEqual(response.statusCode, 200);
-        assert.ok(response.body.includes('Billing disabled'));
+        assert.strictEqual(response.status, 200);
+        assert.ok(response.data.includes('Billing disabled'));
       });
     });
   });

--- a/functions/billing/test/index.test.js
+++ b/functions/billing/test/index.test.js
@@ -44,13 +44,19 @@ describe('functions/billing tests', () => {
     const BASE_URL = `http://localhost:${PORT}`;
 
     before(async () => {
+      console.log('Starting functions-framework process...');
       ffProc = exec(
         `npx functions-framework --target=notifySlack --signature-type=event --port ${PORT}`
       );
       await waitPort({host: 'localhost', port: PORT});
+      console.log('functions-framework process started and listening!');
     });
 
-    after(() => ffProc.kill());
+    after(() => {
+      console.log('Ending functions-framework process...');
+      ffProc.kill();
+      console.log('functions-framework process stopped.');
+    });
 
     describe('functions_billing_slack', () => {
       it('should notify Slack when budget is exceeded', async () => {
@@ -81,13 +87,19 @@ describe('functions/billing tests', () => {
     const BASE_URL = `http://localhost:${PORT}`;
 
     before(async () => {
+      console.log('Starting functions-framework process...');
       ffProc = exec(
         `npx functions-framework --target=stopBilling --signature-type=event --port ${PORT}`
       );
       await waitPort({host: 'localhost', port: PORT});
+      console.log('functions-framework process started and listening!');
     });
 
-    after(() => ffProc.kill());
+    after(() => {
+      console.log('Ending functions-framework process...');
+      ffProc.kill();
+      console.log('functions-framework process stopped.');
+    });
 
     describe('functions_billing_stop', () => {
       it('should disable billing when budget is exceeded', async () => {

--- a/functions/billing/test/periodic.test.js
+++ b/functions/billing/test/periodic.test.js
@@ -14,7 +14,7 @@
 
 const execPromise = require('child-process-promise').exec;
 const path = require('path');
-const requestRetry = require('requestretry');
+const {request} = require('gaxios');
 const assert = require('assert');
 
 const promiseRetry = require('promise-retry');
@@ -64,21 +64,22 @@ describe('functions_billing_limit', () => {
     );
     const pubsubMessage = {data: encodedData, attributes: {}};
 
-    const response = await requestRetry({
+    const response = await request({
       url: `${BASE_URL}/`,
       method: 'POST',
       body: {data: pubsubMessage},
-      retryDelay: 200,
-      json: true,
+      retryConfig: {
+        retryDelay: 200,
+      },
     });
 
     // Wait for the functions framework to stop
     // Must be BEFORE assertions, in case they fail
     await ffProc;
 
-    console.log(response.body);
+    console.log(response.data);
 
-    assert.strictEqual(response.statusCode, 200);
-    assert.ok(response.body.includes('instance(s) stopped successfully'));
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.data.includes('instance(s) stopped successfully'));
   });
 });

--- a/functions/billing/test/periodic.test.js
+++ b/functions/billing/test/periodic.test.js
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const execPromise = require('child-process-promise').exec;
-const path = require('path');
+const {exec} = require('child_process');
 const {request} = require('gaxios');
 const assert = require('assert');
-
 const promiseRetry = require('promise-retry');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
-const cwd = path.join(__dirname, '..');
 
 before(async () => {
   // Re-enable compute instances using the sample file itself
@@ -53,9 +50,8 @@ before(async () => {
 
 describe('functions_billing_limit', () => {
   it('should shut down GCE instances when budget is exceeded', async () => {
-    const ffProc = execPromise(
-      'functions-framework --target=limitUse --signature-type=event',
-      {timeout: 1000, shell: true, cwd}
+    const ffProc = exec(
+      'functions-framework --target=limitUse --signature-type=event'
     );
 
     const jsonData = {costAmount: 500, budgetAmount: 400};
@@ -67,8 +63,9 @@ describe('functions_billing_limit', () => {
     const response = await request({
       url: `${BASE_URL}/`,
       method: 'POST',
-      body: {data: pubsubMessage},
+      data: {data: pubsubMessage},
       retryConfig: {
+        retries: 3,
         retryDelay: 200,
       },
     });

--- a/functions/billing/test/periodic.test.js
+++ b/functions/billing/test/periodic.test.js
@@ -20,7 +20,9 @@ const promiseRetry = require('promise-retry');
 const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
 
 describe('functions_billing_limit', () => {
+  let ffProc;
   before(async () => {
+    console.log('Running periodic before hook....');
     // Re-enable compute instances using the sample file itself
     const {startInstances, listRunningInstances} = require('../');
 
@@ -47,12 +49,21 @@ describe('functions_billing_limit', () => {
     } catch (err) {
       console.error('Failed to restart GCE instances:', err);
     }
+    console.log('Periodic before hook complete.');
+  });
+
+  after(() => {
+    console.log('Ending functions-framework process...');
+    ffProc.kill();
+    console.log('functions-framework process stopped.');
   });
 
   it('should shut down GCE instances when budget is exceeded', async () => {
-    const ffProc = exec(
+    console.log('Starting functions-framework process...');
+    ffProc = exec(
       'npx functions-framework --target=limitUse --signature-type=event'
     );
+    console.log('functions-framework process started and listening!');
 
     const jsonData = {costAmount: 500, budgetAmount: 400};
     const encodedData = Buffer.from(JSON.stringify(jsonData)).toString(


### PR DESCRIPTION
The `request` module is fully deprecated, and we shouldn't be using it.  This transitions us to `gaxios` for tests, which we actively support. 