### PR TITLE
Update sample.integration.http.test.js

### DIFF
--- a/appengine/analytics/app.js
+++ b/appengine/analytics/app.js
@@ -69,7 +69,7 @@ app.get('/', async (req, res, next) => {
   }
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/building-an-app/build/server.js
+++ b/appengine/building-an-app/build/server.js
@@ -23,7 +23,7 @@ app.get('/', (req, res) => {
 });
 
 // Listen to the App Engine-specified port, or 8080 otherwise
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}...`);
 });

--- a/appengine/building-an-app/update/server.js
+++ b/appengine/building-an-app/update/server.js
@@ -46,7 +46,7 @@ app.post('/submit', (req, res) => {
 // [END add_post_handler]
 
 // Listen to the App Engine-specified port, or 8080 otherwise
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}...`);
 });

--- a/appengine/datastore/app.js
+++ b/appengine/datastore/app.js
@@ -85,8 +85,8 @@ app.get('/', async (req, res, next) => {
   }
 });
 
-const PORT = process.env.PORT || 8080;
-app.listen(process.env.PORT || 8080, () => {
+const PORT = parseInt(process.env.PORT) || 8080;
+app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');
 });

--- a/appengine/datastore/app.js
+++ b/appengine/datastore/app.js
@@ -85,7 +85,7 @@ app.get('/', async (req, res, next) => {
   }
 });
 
-const PORT = parseInt(process.env.PORT) || 8080;
+const PORT = parseInt(parseInt(process.env.PORT)) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/endpoints/app.js
+++ b/appengine/endpoints/app.js
@@ -38,7 +38,7 @@ app.get('/auth/info/googlejwt', authInfoHandler);
 app.get('/auth/info/googleidtoken', authInfoHandler);
 
 if (module === require.main) {
-  const PORT = process.env.PORT || 8080;
+  const PORT = parseInt(process.env.PORT) || 8080;
   app.listen(PORT, () => {
     console.log(`App listening on port ${PORT}`);
     console.log('Press Ctrl+C to quit.');

--- a/appengine/endpoints/test/appListening.test.js
+++ b/appengine/endpoints/test/appListening.test.js
@@ -1,6 +1,6 @@
 const waitPort = require('wait-port');
 const {expect} = require('chai');
-const PORT = parseInt(process.env.PORT) || 8080;
+const PORT = parseInt(parseInt(process.env.PORT)) || 8080;
 const childProcess = require('child_process');
 const path = require('path');
 const appPath = path.join(__dirname, '../app.js');

--- a/appengine/endpoints/test/appListening.test.js
+++ b/appengine/endpoints/test/appListening.test.js
@@ -1,6 +1,6 @@
 const waitPort = require('wait-port');
 const {expect} = require('chai');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const childProcess = require('child_process');
 const path = require('path');
 const appPath = path.join(__dirname, '../app.js');

--- a/appengine/hello-world/flexible/app.js
+++ b/appengine/hello-world/flexible/app.js
@@ -24,7 +24,7 @@ app.get('/', (req, res) => {
 });
 
 // Start the server
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/hello-world/standard/app.js
+++ b/appengine/hello-world/standard/app.js
@@ -24,7 +24,7 @@ app.get('/', (req, res) => {
 });
 
 // Start the server
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/memcached/app.js
+++ b/appengine/memcached/app.js
@@ -42,7 +42,7 @@ app.get('/', async (req, res, next) => {
   }
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const server = app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/memcached/test/app.test.js
+++ b/appengine/memcached/test/app.test.js
@@ -1,7 +1,7 @@
 const {expect} = require('chai');
 const waitPort = require('wait-port');
 
-const PORT = parseInt(process.env.PORT) || 8080;
+const PORT = parseInt(parseInt(process.env.PORT)) || 8080;
 
 describe('gae_flex_redislabs_memcache', () => {
   it('should be listening', async () => {

--- a/appengine/memcached/test/app.test.js
+++ b/appengine/memcached/test/app.test.js
@@ -1,7 +1,7 @@
 const {expect} = require('chai');
 const waitPort = require('wait-port');
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 describe('gae_flex_redislabs_memcache', () => {
   it('should be listening', async () => {

--- a/appengine/metadata/flexible/server.js
+++ b/appengine/metadata/flexible/server.js
@@ -52,7 +52,7 @@ app.get('/', async (req, res, next) => {
   }
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/metadata/standard/server.js
+++ b/appengine/metadata/standard/server.js
@@ -52,7 +52,7 @@ app.get('/', async (req, res, next) => {
   }
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/pubsub/app.js
+++ b/appengine/pubsub/app.js
@@ -142,7 +142,7 @@ app.post('/pubsub/authenticated-push', jsonBodyParser, async (req, res) => {
 // [END gae_flex_pubsub_auth_push]
 
 // Start the server
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/pubsub/test/appListening.test.js
+++ b/appengine/pubsub/test/appListening.test.js
@@ -17,7 +17,7 @@ const assert = require('assert');
 const {spawn} = require('child_process');
 const path = require('path');
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 const appPath = path.join(__dirname, '../app.js');
 

--- a/appengine/static-files/app.js
+++ b/appengine/static-files/app.js
@@ -28,7 +28,7 @@ app.get('/', (req, res) => {
 });
 
 // Start the server
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/storage/flexible/app.js
+++ b/appengine/storage/flexible/app.js
@@ -80,7 +80,7 @@ app.post('/upload', multer.single('file'), (req, res, next) => {
   blobStream.end(req.file.buffer);
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/storage/standard/app.js
+++ b/appengine/storage/standard/app.js
@@ -82,7 +82,7 @@ app.post('/upload', multer.single('file'), (req, res, next) => {
   blobStream.end(req.file.buffer);
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/appengine/twilio/app.js
+++ b/appengine/twilio/app.js
@@ -86,7 +86,7 @@ app.post('/sms/receive', bodyParser, (req, res) => {
 
 // Start the server
 if (module === require.main) {
-  const PORT = process.env.PORT || 8080;
+  const PORT = parseInt(process.env.PORT) || 8080;
   app.listen(PORT, () => {
     console.log(`App listening on port ${PORT}`);
     console.log('Press Ctrl+C to quit.');

--- a/appengine/typescript/index.ts
+++ b/appengine/typescript/index.ts
@@ -14,7 +14,7 @@
 
 import express = require('express');
 
-const PORT = Number(process.env.PORT) || 8080;
+const PORT = Number(parseInt(process.env.PORT)) || 8080;
 const app = express();
 
 app.get('/', (req, res) => {

--- a/appengine/typescript/test/app.test.js
+++ b/appengine/typescript/test/app.test.js
@@ -1,7 +1,7 @@
 const {expect} = require('chai');
 const waitPort = require('wait-port');
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 describe('server listening', () => {
   it('should be listening', async () => {

--- a/appengine/websockets/app.js
+++ b/appengine/websockets/app.js
@@ -32,7 +32,7 @@ io.on('connection', socket => {
 });
 
 if (module === require.main) {
-  const PORT = process.env.PORT || 8080;
+  const PORT = parseInt(process.env.PORT) || 8080;
   server.listen(PORT, () => {
     console.log(`App listening on port ${PORT}`);
     console.log('Press Ctrl+C to quit.');

--- a/appengine/websockets/test/index.test.js
+++ b/appengine/websockets/test/index.test.js
@@ -23,7 +23,7 @@ const app = require(path.join(path.dirname(__dirname), 'app.js'));
 let browser, browserPage;
 
 before(async () => {
-  const PORT = process.env.PORT || 8080;
+  const PORT = parseInt(process.env.PORT) || 8080;
   app.listen(PORT, () => {});
 
   browser = await puppeteer.launch({

--- a/cloud-sql/mysql/mysql/server.js
+++ b/cloud-sql/mysql/mysql/server.js
@@ -250,7 +250,7 @@ app.post('/', async (req, res) => {
   res.status(200).send(`Successfully voted for ${team} at ${timestamp}`).end();
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const server = app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/cloud-sql/postgres/knex/server.js
+++ b/cloud-sql/postgres/knex/server.js
@@ -320,7 +320,7 @@ app.post('/', async (req, res) => {
   res.status(200).send(`Successfully voted for ${team} at ${timestamp}`).end();
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const server = app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/cloud-sql/sqlserver/mssql/server.js
+++ b/cloud-sql/sqlserver/mssql/server.js
@@ -215,7 +215,7 @@ app.post('/', async (req, res) => {
   res.status(200).send(`Successfully voted for ${team} at ${timestamp}`).end();
 });
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const server = app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/cloud-tasks/app/index.js
+++ b/cloud-tasks/app/index.js
@@ -47,7 +47,7 @@ app.post('/send-email', (req, res) => {
 });
 // [END cloud_tasks_app]
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');

--- a/containerengine/hello-world/server.js
+++ b/containerengine/hello-world/server.js
@@ -21,7 +21,7 @@ const handleRequest = function (req, res) {
   res.end('Hello Kubernetes!');
 };
 const www = http.createServer(handleRequest);
-www.listen(process.env.PORT || 8080);
+www.listen(parseInt(process.env.PORT) || 8080);
 
 // [END all]
 module.exports = www;

--- a/endpoints/getting-started-grpc/system-test/endpoints.test.js
+++ b/endpoints/getting-started-grpc/system-test/endpoints.test.js
@@ -22,7 +22,7 @@ const path = require('path');
 
 const appPath = path.join(__dirname, '../server.js');
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 describe('server listening', () => {
   it('should be listening', async () => {

--- a/endpoints/getting-started/app.js
+++ b/endpoints/getting-started/app.js
@@ -44,7 +44,7 @@ app.get('/auth/info/googleidtoken', authInfoHandler);
 
 if (module === require.main) {
   // [START listen]
-  const PORT = process.env.PORT || 8080;
+  const PORT = parseInt(process.env.PORT) || 8080;
   app.listen(PORT, () => {
     console.log(`App listening on port ${PORT}`);
     console.log('Press Ctrl+C to quit.');

--- a/eventarc/audit-storage/index.js
+++ b/eventarc/audit-storage/index.js
@@ -14,7 +14,7 @@
 
 // [START eventarc_audit_storage_server]
 const app = require('./app.js');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-events-storage listening on port ${PORT}`)

--- a/eventarc/generic/index.js
+++ b/eventarc/generic/index.js
@@ -14,7 +14,7 @@
 
 // [START eventarc_generic_server]
 const app = require('./app.js');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-eventarc-generic listening on port ${PORT}`)

--- a/eventarc/pubsub/index.js
+++ b/eventarc/pubsub/index.js
@@ -14,7 +14,7 @@
 
 // [START eventarc_pubsub_server]
 const app = require('./app.js');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-eventarc-pubsub listening on port ${PORT}`)

--- a/functions/helloworld/test/sample.integration.http.test.js
+++ b/functions/helloworld/test/sample.integration.http.test.js
@@ -19,7 +19,7 @@ const {request} = require('gaxios');
 const uuid = require('uuid');
 const waitPort = require('wait-port');
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const BASE_URL = `http://localhost:${PORT}`;
 
 // [END functions_http_integration_test]

--- a/functions/helloworld/test/sample.integration.http.test.js
+++ b/functions/helloworld/test/sample.integration.http.test.js
@@ -19,7 +19,7 @@ const {request} = require('gaxios');
 const uuid = require('uuid');
 const waitPort = require('wait-port');
 
-const PORT = parseInt(process.env.PORT) || 8080;
+const PORT = parseInt(parseInt(process.env.PORT)) || 8080;
 const BASE_URL = `http://localhost:${PORT}`;
 
 // [END functions_http_integration_test]

--- a/run/hello-broken/index.js
+++ b/run/hello-broken/index.js
@@ -57,7 +57,7 @@ app.get('/improved', (req, res) => {
 
 // [START cloudrun_broken_service]
 // [START run_broken_service]
-const port = process.env.PORT || 8080;
+const port = parseInt(process.env.PORT) || 8080;
 app.listen(port, () => {
   console.log(`hello: listening on port ${port}`);
 });

--- a/run/helloworld/index.js
+++ b/run/helloworld/index.js
@@ -22,7 +22,7 @@ app.get('/', (req, res) => {
   res.send(`Hello ${name}!`);
 });
 
-const port = process.env.PORT || 8080;
+const port = parseInt(process.env.PORT) || 8080;
 app.listen(port, () => {
   console.log(`helloworld: listening on port ${port}`);
 });

--- a/run/idp-sql/index.js
+++ b/run/idp-sql/index.js
@@ -23,7 +23,7 @@ const {createTable, closeConnection} = require('./cloud-sql');
 const {GoogleAuth} = require('google-auth-library');
 const auth = new GoogleAuth();
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 const startServer = () => {
   app.listen(PORT, () => logger.info(`${pkg.name}: listening on port ${PORT}`));

--- a/run/image-processing/index.js
+++ b/run/image-processing/index.js
@@ -5,7 +5,7 @@
 // [START cloudrun_imageproc_server]
 // [START run_imageproc_server]
 const app = require('./app.js');
-const PORT = parseInt(process.env.PORT) || 8080;
+const PORT = parseInt(parseInt(process.env.PORT)) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-image-processing listening on port ${PORT}`)

--- a/run/image-processing/index.js
+++ b/run/image-processing/index.js
@@ -5,7 +5,7 @@
 // [START cloudrun_imageproc_server]
 // [START run_imageproc_server]
 const app = require('./app.js');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-image-processing listening on port ${PORT}`)

--- a/run/logging-manual/index.js
+++ b/run/logging-manual/index.js
@@ -4,7 +4,7 @@
 
 const app = require('./app');
 const metadata = require('./metadata');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 const SERVICE = require('./package').name;
 
 const startServer = () => {

--- a/run/markdown-preview/editor/index.js
+++ b/run/markdown-preview/editor/index.js
@@ -14,6 +14,6 @@
 
 const {app} = require('./app');
 const pkg = require('./package.json');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () => console.log(`${pkg.name} listening on port ${PORT}`));

--- a/run/markdown-preview/renderer/index.js
+++ b/run/markdown-preview/renderer/index.js
@@ -14,6 +14,6 @@
 
 const app = require('./app');
 const pkg = require('./package.json');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () => console.log(`${pkg.name} listening on port ${PORT}`));

--- a/run/pubsub/index.js
+++ b/run/pubsub/index.js
@@ -5,7 +5,7 @@
 // [START cloudrun_pubsub_server]
 // [START run_pubsub_server]
 const app = require('./app.js');
-const PORT = parseInt(process.env.PORT) || 8080;
+const PORT = parseInt(parseInt(process.env.PORT)) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-pubsub-tutorial listening on port ${PORT}`)

--- a/run/pubsub/index.js
+++ b/run/pubsub/index.js
@@ -5,7 +5,7 @@
 // [START cloudrun_pubsub_server]
 // [START run_pubsub_server]
 const app = require('./app.js');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () =>
   console.log(`nodejs-pubsub-tutorial listening on port ${PORT}`)

--- a/run/system-package/index.js
+++ b/run/system-package/index.js
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 const app = require('./app.js');
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 app.listen(PORT, () => console.log(`graphviz-web listening on port ${PORT}`));

--- a/run/websockets/index.js
+++ b/run/websockets/index.js
@@ -18,7 +18,7 @@ const {redisClient} = require('./redis');
 const pkg = require('./package');
 const server = require('./app');
 
-const PORT = process.env.PORT || 8080;
+const PORT = parseInt(process.env.PORT) || 8080;
 
 // Start server
 server.listen(PORT, () =>


### PR DESCRIPTION
Adding a function to cast the environment variable for `PORT` to an int.

Without `parseInt()`, when there is an environment variable set for `PORT`, the test fails because `process.env.PORT` is a string by default.

Test run on Node.js v12.14.1:
```
  1) functions_helloworld_http HTTP integration test
       "before all" hook for "helloHttp: should print a name":
     ValidationError: 'port' must be a number.
      at validateParameters (node_modules/wait-port/lib/validate-parameters.js:14:38)
      at /home/personjeh/Cloud/testing_gcf/http_integration/node_modules/wait-port/lib/wait-port.js:183:9
      at new Promise (<anonymous>)
      at waitPort (node_modules/wait-port/lib/wait-port.js:173:10)
      at Context.<anonymous> (test/sample_integration_test_http.js:22:11)
      at processImmediate (internal/timers.js:439:21)
```