### PR TITLE
minor: Update title to reflect compute platform

### DIFF
--- a/run/websockets/public/index.html
+++ b/run/websockets/public/index.html
@@ -17,7 +17,7 @@ limitations under the License.
 <html lang="en">
 
 <head>
-    <title>Socket.IO chat on App Engine</title>
+    <title>Socket.IO chat on Cloud Run</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="index.css">
     <link rel="shortcut icon" href="https://material.io/favicon.ico">


### PR DESCRIPTION
To reduce user confusion, this minor change ensures the compute platform being used for this sample matches the title of the sample app. 

cc @averikitsch 