### PR TITLE
Add Secret Manager integration to Cloud SQL sample apps

### DIFF
--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -26,8 +26,11 @@ export DB_USER='my-db-user'
 export DB_PASS='my-db-pass'
 export DB_NAME='my_db'
 ```
-Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) or [Secret Manager](https://cloud.google.com/secret-manager/) to help keep secrets safe.
+Note: Defining credentials in environment variables is convenient, but not secure. For a more secure solution, use
+[Secret Manager](https://cloud.google.com/secret-manager/) to help keep secrets safe. You can then define
+`export CLOUD_SQL_CREDENTIALS_SECRET='projects/PROJECT_ID/secrets/SECRET_ID/versions/VERSION'` to reference a secret
+that stores your Cloud SQL database password. The sample app checks for your defined secret version. If a version is
+present, the app retrieves the `DB_PASS` from Secret Manager before it connects to Cloud SQL.
 
 ## Running locally
 

--- a/cloud-sql/mysql/mysql/package.json
+++ b/cloud-sql/mysql/mysql/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.0",
+    "@google-cloud/secret-manager": "^3.10.0",
     "express": "^4.17.1",
     "promise-mysql": "^5.0.0",
     "prompt": "^1.0.0",

--- a/cloud-sql/mysql/mysql/server.js
+++ b/cloud-sql/mysql/mysql/server.js
@@ -42,6 +42,15 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console(), loggingWinston],
 });
 
+// Retrieve and return a specified secret from Secret Manager
+const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+const client = new SecretManagerServiceClient();
+
+async function accessSecretVersion(secretName) {
+  const [version] = await client.accessSecretVersion({name: secretName});
+  return version.payload.data;
+}
+
 // [START cloud_sql_mysql_mysql_create_tcp_sslcerts]
 const createTcpPoolSslCerts = async config => {
   // Extract host and port from socket address
@@ -130,6 +139,21 @@ const createPool = async () => {
     // connection attempts.
     // [END cloud_sql_mysql_mysql_backoff]
   };
+
+  // Check if a Secret Manager secret version is defined
+  // If a version is defined, retrieve the secret from Secret Manager and set as the DB_PASS
+  const {CLOUD_SQL_CREDENTIALS_SECRET} = process.env;
+  if (CLOUD_SQL_CREDENTIALS_SECRET) {
+    const secrets = await accessSecretVersion(CLOUD_SQL_CREDENTIALS_SECRET);
+    try {
+      process.env.DB_PASS = secrets.toString();
+    } catch(err) {
+      throw Error(
+        `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
+      );
+    }
+  }
+
   if (process.env.DB_HOST) {
     if (process.env.DB_ROOT_CERT) {
       return createTcpPoolSslCerts(config);

--- a/cloud-sql/mysql/mysql/server.js
+++ b/cloud-sql/mysql/mysql/server.js
@@ -147,7 +147,7 @@ const createPool = async () => {
     const secrets = await accessSecretVersion(CLOUD_SQL_CREDENTIALS_SECRET);
     try {
       process.env.DB_PASS = secrets.toString();
-    } catch(err) {
+    } catch (err) {
       throw Error(
         `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
       );

--- a/cloud-sql/mysql/mysql/server.js
+++ b/cloud-sql/mysql/mysql/server.js
@@ -148,9 +148,8 @@ const createPool = async () => {
     try {
       process.env.DB_PASS = secrets.toString();
     } catch (err) {
-      throw Error(
-        `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
-      );
+        err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+        throw err;
     }
   }
 

--- a/cloud-sql/mysql/mysql/server.js
+++ b/cloud-sql/mysql/mysql/server.js
@@ -148,8 +148,8 @@ const createPool = async () => {
     try {
       process.env.DB_PASS = secrets.toString();
     } catch (err) {
-        err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
-        throw err;
+      err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+      throw err;
     }
   }
 

--- a/cloud-sql/postgres/knex/README.md
+++ b/cloud-sql/postgres/knex/README.md
@@ -25,8 +25,11 @@ export DB_USER='my-db-user'
 export DB_PASS='my-db-pass'
 export DB_NAME='my_db'
 ```
-Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) or [Secret Manager](https://cloud.google.com/secret-manager/) to help keep secrets safe.
+Note: Defining credentials in environment variables is convenient, but not secure. For a more secure solution, use
+[Secret Manager](https://cloud.google.com/secret-manager/) to help keep secrets safe. You can then define
+`export CLOUD_SQL_CREDENTIALS_SECRET='projects/PROJECT_ID/secrets/SECRET_ID/versions/VERSION'` to reference a secret
+that stores your Cloud SQL database password. The sample app checks for your defined secret version. If a version is
+present, the app retrieves the `DB_PASS` from Secret Manager before it connects to Cloud SQL.
 
 ## Initialize the Cloud SQL database
 

--- a/cloud-sql/postgres/knex/package.json
+++ b/cloud-sql/postgres/knex/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.0",
+    "@google-cloud/secret-manager": "^3.10.0",
     "express": "^4.16.2",
     "knex": "^1.0.0",
     "pg": "^8.0.0",

--- a/cloud-sql/postgres/knex/server.js
+++ b/cloud-sql/postgres/knex/server.js
@@ -184,9 +184,8 @@ const createPool = async () => {
     try {
       process.env.DB_PASS = secrets.toString();
     } catch (err) {
-      throw Error(
-        `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
-      );
+        err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+        throw err;
     }
   }
 

--- a/cloud-sql/postgres/knex/server.js
+++ b/cloud-sql/postgres/knex/server.js
@@ -45,6 +45,15 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console(), loggingWinston],
 });
 
+// Retrieve and return a specified secret from Secret Manager
+const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+const client = new SecretManagerServiceClient();
+
+async function accessSecretVersion(secretName) {
+  const [version] = await client.accessSecretVersion({name: secretName});
+  return version.payload.data;
+}
+
 // Set up a variable to hold our connection pool. It would be safe to
 // initialize this right away, but we defer its instantiation to ease
 // testing different configurations.
@@ -166,6 +175,20 @@ const createPool = async () => {
   // 'createRetryIntervalMillis' is how long to idle after failed connection creation before trying again
   config.pool.createRetryIntervalMillis = 200; // 0.2 seconds
   // [END cloud_sql_postgres_knex_backoff]
+
+  // Check if a Secret Manager secret version is defined
+  // If a version is defined, retrieve the secret from Secret Manager and set as the DB_PASS
+  const {CLOUD_SQL_CREDENTIALS_SECRET} = process.env;
+  if (CLOUD_SQL_CREDENTIALS_SECRET) {
+    const secrets = await accessSecretVersion(CLOUD_SQL_CREDENTIALS_SECRET);
+    try {
+      process.env.DB_PASS = secrets.toString();
+    } catch (err) {
+      throw Error(
+        `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
+      );
+    }
+  }
 
   if (process.env.DB_HOST) {
     if (process.env.DB_ROOT_CERT) {

--- a/cloud-sql/postgres/knex/server.js
+++ b/cloud-sql/postgres/knex/server.js
@@ -184,8 +184,8 @@ const createPool = async () => {
     try {
       process.env.DB_PASS = secrets.toString();
     } catch (err) {
-        err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
-        throw err;
+      err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+      throw err;
     }
   }
 

--- a/cloud-sql/sqlserver/mssql/README.md
+++ b/cloud-sql/sqlserver/mssql/README.md
@@ -32,8 +32,11 @@ export DB_USER='my-db-user'
 export DB_PASS='my-db-pass'
 export DB_NAME='my_db'
 ```
-Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to help keep secrets safe.
+Note: Defining credentials in environment variables is convenient, but not secure. For a more secure solution, use
+[Secret Manager](https://cloud.google.com/secret-manager/) to help keep secrets safe. You can then define
+`export CLOUD_SQL_CREDENTIALS_SECRET='projects/PROJECT_ID/secrets/SECRET_ID/versions/VERSION'` to reference a secret
+that stores your Cloud SQL database password. The sample app checks for your defined secret version. If a version is
+present, the app retrieves the `DB_PASS` from Secret Manager before it connects to Cloud SQL.
 
 Download and install the `cloud_sql_proxy` by
 following the instructions [here](https://cloud.google.com/sql/docs/mysql/sql-proxy#install). 

--- a/cloud-sql/sqlserver/mssql/package.json
+++ b/cloud-sql/sqlserver/mssql/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.0",
+    "@google-cloud/secret-manager": "^3.10.0",
     "express": "^4.17.1",
     "mssql": "^8.0.0",
     "prompt": "^1.0.0",

--- a/cloud-sql/sqlserver/mssql/server.js
+++ b/cloud-sql/sqlserver/mssql/server.js
@@ -62,8 +62,8 @@ const createPool = async () => {
     try {
       process.env.DB_PASS = secrets.toString();
     } catch (err) {
-        err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
-        throw err;
+      err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+      throw err;
     }
   }
 

--- a/cloud-sql/sqlserver/mssql/server.js
+++ b/cloud-sql/sqlserver/mssql/server.js
@@ -62,9 +62,8 @@ const createPool = async () => {
     try {
       process.env.DB_PASS = secrets.toString();
     } catch (err) {
-      throw Error(
-        `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
-      );
+        err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+        throw err;
     }
   }
 

--- a/cloud-sql/sqlserver/mssql/server.js
+++ b/cloud-sql/sqlserver/mssql/server.js
@@ -41,9 +41,33 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console(), loggingWinston],
 });
 
+// Retrieve and return a specified secret from Secret Manager
+const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+const client = new SecretManagerServiceClient();
+
+async function accessSecretVersion(secretName) {
+  const [version] = await client.accessSecretVersion({name: secretName});
+  return version.payload.data;
+}
+
 // [START cloud_sql_sqlserver_mssql_create]
 const createPool = async () => {
   const config = {pool: {}, options: {}};
+
+  // Check if a Secret Manager secret version is defined
+  // If a version is defined, retrieve the secret from Secret Manager and set as the DB_PASS
+  const {CLOUD_SQL_CREDENTIALS_SECRET} = process.env;
+  if (CLOUD_SQL_CREDENTIALS_SECRET) {
+    const secrets = await accessSecretVersion(CLOUD_SQL_CREDENTIALS_SECRET);
+    try {
+      process.env.DB_PASS = secrets.toString();
+    } catch (err) {
+      throw Error(
+        `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: ${err}`
+      );
+    }
+  }
+
   config.user = process.env.DB_USER; // e.g. 'my-db-user'
   config.password = process.env.DB_PASS; // e.g. 'my-db-password'
   config.database = process.env.DB_NAME; // e.g. 'my-database'


### PR DESCRIPTION
This PR adds the option to retrieve the Cloud SQL database password from Secret Manager.

If a secret version is defined in an environmental variable (`CLOUD_SQL_CREDENTIALS_SECRET`), the secret value is retrieved from Secret Manager and then used in the Cloud SQL connection.

The sample can continue to work as-is for testing / non-production use by defining the password in an environment variable.

An upcoming tutorial in the [Cloud Architecture Center](https://cloud.google.com/architecture) will show a complete example of creating a Secret Manager secret, deploying Cloud SQL, and then running this sample app with the proposed changes to tie it all together.