### PR TITLE
fix: replace extensions/v1beta1 with apps/v1

### DIFF
--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -26,12 +26,15 @@ spec:
     app: esp-echo
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: esp-echo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: esp-echo
   template:
     metadata:
       labels:


### PR DESCRIPTION
kind "Deployment" no longer exists in "extensions/v1beta1", a change in version to "apps/v1" would have fixed the issue.

Fixes #2334 🦕