### PR TITLE
fix: extend time out for Cloud Run test

### DIFF
--- a/run/logging-manual/package.json
+++ b/run/logging-manual/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "system-test": "mocha test/system.test.js --timeout=360000 --exit"
+    "system-test": "mocha test/system.test.js --timeout=600000 --exit"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This test has retries looking for logs, now the mocha runner will have the same timeout. 
fixes #2372 
fixes #2373 
fixes #2374 
fixes #2375 
fixes #2376 
fixes #2377 
fixes #2378 
fixes #2379 