### PR TITLE
refactor(functions/v2): update Pub/Sub sample

### DIFF
--- a/functions/v2/index.js
+++ b/functions/v2/index.js
@@ -14,16 +14,13 @@
 
 'use strict';
 
+const functions = require('@google-cloud/functions-framework');
+
 // [START functions_cloudevent_pubsub]
-/**
- * CloudEvent function to be triggered by Pub/Sub.
- * This function is exported by index.js, and executed when
- * the trigger topic receives a message.
- *
- * @param {object} cloudevent A CloudEvent containing the Pub/Sub message.
- * @param {object} cloudevent.data.message The Pub/Sub message itself.
- */
-exports.helloPubSub = cloudevent => {
+// Register a CloudEvent callback with the Functions Framework that will
+// be executed when the Pub/Sub trigger topic receives a message.
+functions.cloudEvent('helloPubSub', cloudevent => {
+  // The Pub/Sub message is passed as the CloudEvent's data payload.
   const base64name = cloudevent.data.message.data;
 
   const name = base64name
@@ -31,7 +28,7 @@ exports.helloPubSub = cloudevent => {
     : 'World';
 
   console.log(`Hello, ${name}!`);
-};
+});
 // [END functions_cloudevent_pubsub]
 
 // [START functions_cloudevent_storage]

--- a/functions/v2/package.json
+++ b/functions/v2/package.json
@@ -19,7 +19,7 @@
     "@google-cloud/compute": "^3.0.0-alpha.4"
   },
   "devDependencies": {
-    "@google-cloud/functions-framework": "^1.1.1",
+    "@google-cloud/functions-framework": "^2.0.0",
     "gaxios": "^4.3.0",
     "mocha": "^9.1.3",
     "p-retry": "^4.6.1",


### PR DESCRIPTION
Update the GCFv2 Pub/Sub sample to use the new declarative registration
API that was added in v2.0.0 of the Functions Framework.