### PR TITLE
Revert "chore(deps): update dependency got to v12"

### DIFF
--- a/eventarc/audit-storage/package.json
+++ b/eventarc/audit-storage/package.json
@@ -24,7 +24,7 @@
     "express": "^4.16.4"
   },
   "devDependencies": {
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "sinon": "^13.0.0",
     "supertest": "^6.0.0"

--- a/eventarc/generic/package.json
+++ b/eventarc/generic/package.json
@@ -21,7 +21,7 @@
     "express": "^4.16.4"
   },
   "devDependencies": {
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "sinon": "^13.0.0",
     "supertest": "^6.0.0",

--- a/eventarc/pubsub/package.json
+++ b/eventarc/pubsub/package.json
@@ -25,7 +25,7 @@
     "express": "^4.16.4"
   },
   "devDependencies": {
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "sinon": "^13.0.0",
     "supertest": "^6.0.0",

--- a/run/hello-broken/package.json
+++ b/run/hello-broken/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.0.0",
     "mocha": "^9.0.0"
   }
 }

--- a/run/helloworld/package.json
+++ b/run/helloworld/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.0.0",
     "mocha": "^9.0.0",
     "supertest": "^6.0.0"
   }

--- a/run/idp-sql/package.json
+++ b/run/idp-sql/package.json
@@ -28,7 +28,7 @@
     "winston": "3.5.1"
   },
   "devDependencies": {
-    "got": "^12.0.0",
+    "got": "^11.7.0",
     "mocha": "^9.0.0",
     "short-uuid": "^4.1.0",
     "sinon": "^13.0.0",

--- a/run/image-processing/package.json
+++ b/run/image-processing/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "supertest": "^6.0.0"
   }

--- a/run/logging-manual/package.json
+++ b/run/logging-manual/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "express": "^4.17.1",
-    "got": "^12.0.0"
+    "got": "^11.0.0"
   },
   "devDependencies": {
     "@google-cloud/logging": "^9.0.0",

--- a/run/markdown-preview/editor/package.json
+++ b/run/markdown-preview/editor/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.8.0",
     "handlebars": "^4.7.6"
   },
   "devDependencies": {

--- a/run/markdown-preview/renderer/package.json
+++ b/run/markdown-preview/renderer/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "sinon": "^13.0.0",
     "supertest": "^6.0.0"

--- a/run/pubsub/package.json
+++ b/run/pubsub/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "sinon": "^13.0.0",
     "supertest": "^6.0.0",

--- a/run/system-package/package.json
+++ b/run/system-package/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.0.0",
-    "got": "^12.0.0",
+    "got": "^11.5.0",
     "mocha": "^9.0.0",
     "supertest": "^6.0.0"
   }

--- a/run/websockets/package.json
+++ b/run/websockets/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "google-auth-library": "^7.1.2",
-    "got": "^12.0.0",
+    "got": "^11.8.2",
     "puppeteer": "^13.0.0"
   }
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/nodejs-docs-samples#2460

This requires ESM, which we're not quite ready to move to.