### PR TITLE
feat(cloudsql/mysql): update to V2 sample

### DIFF
--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -50,7 +50,7 @@ shown below.
 Use these terminal commands to initialize environment variables:
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
-export DB_HOST='127.0.0.1:3306'
+export INSTANCE_HOST='127.0.0.1:3306'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
@@ -65,7 +65,7 @@ Then use this command to launch the proxy in the background:
 Use these PowerShell commands to initialize environment variables:
 ```powershell
 $env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
-$env:DB_HOST="127.0.0.1:3306"
+$env:INSTANCE_HOST="127.0.0.1:3306"
 $env:DB_USER="<DB_USER_NAME>"
 $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
@@ -88,7 +88,7 @@ sudo chown -R $USER /path/to/the/new/directory
 ```
 You'll also need to initialize an environment variable containing the directory you just created:
 ```bash
-export DB_SOCKET_PATH=/path/to/the/new/directory
+export INSTANCE_UNIX_SOCKET=/path/to/the/new/directory
 ```
 
 Use these terminal commands to initialize other environment variables as well:
@@ -103,7 +103,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -dir=$DB_SOCKET_PATH --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud_sql_proxy -dir=$INSTANCE_UNIX_SOCKET --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
 ```
 
 ### Testing the application

--- a/cloud-sql/mysql/mysql/connect-tcp-sslcerts.js
+++ b/cloud-sql/mysql/mysql/connect-tcp-sslcerts.js
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+// [START cloud_sql_mysql_mysql_create_tcp_sslcerts]
+// [START cloud_sql_mysql_mysql_connect_tcp_sslcerts]
+const mysql = require('promise-mysql');
+const fs = require('fs');
+
+const createTcpPoolSslCerts = async config => {
+    // Extract host and port from socket address
+    const dbSocketAddr = process.env.INSTANCE_HOST.split(':');
+  
+    // Establish a connection to the database
+    return mysql.createPool({
+      user: process.env.DB_USER, // e.g. 'my-db-user'
+      password: process.env.DB_PASS, // e.g. 'my-db-password'
+      database: process.env.DB_NAME, // e.g. 'my-database'
+      host: dbSocketAddr[0], // e.g. '127.0.0.1'
+      port: dbSocketAddr[1], // e.g. '3306'
+      ssl: {
+        sslmode: 'verify-full',
+        ca: fs.readFileSync(process.env.DB_ROOT_CERT), // e.g., '/path/to/my/server-ca.pem'
+        key: fs.readFileSync(process.env.DB_KEY), // e.g. '/path/to/my/client-key.pem'
+        cert: fs.readFileSync(process.env.DB_CERT), // e.g. '/path/to/my/client-cert.pem'
+      },
+      // ... Specify additional properties here.
+      ...config,
+    });
+  };
+// [END cloud_sql_mysql_mysql_connect_tcp_sslcerts]  
+// [END cloud_sql_mysql_mysql_create_tcp_sslcerts]
+module.exports = createTcpPoolSslCerts;

--- a/cloud-sql/mysql/mysql/connect-tcp.js
+++ b/cloud-sql/mysql/mysql/connect-tcp.js
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+// [START cloud_sql_mysql_mysql_create_tcp]
+// [START cloud_sql_mysql_mysql_connect_tcp]
+const mysql = require('promise-mysql');
+
+const createTcpPool = async config => {
+    // Extract host and port from socket address
+    const dbSocketAddr = process.env.INSTANCE_HOST.split(':');
+  
+    // Establish a connection to the database
+    return mysql.createPool({
+      user: process.env.DB_USER, // e.g. 'my-db-user'
+      password: process.env.DB_PASS, // e.g. 'my-db-password'
+      database: process.env.DB_NAME, // e.g. 'my-database'
+      host: dbSocketAddr[0], // e.g. '127.0.0.1'
+      port: dbSocketAddr[1], // e.g. '3306'
+      // ... Specify additional properties here.
+      ...config,
+    });
+  };
+// [END cloud_sql_mysql_mysql_connect_tcp]
+// [END cloud_sql_mysql_mysql_create_tcp]
+module.exports = createTcpPool;

--- a/cloud-sql/mysql/mysql/connect-unix.js
+++ b/cloud-sql/mysql/mysql/connect-unix.js
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+// [START cloud_sql_mysql_mysql_create_socket]
+// [START cloud_sql_mysql_mysql_connect_unix]
+const mysql = require('promise-mysql');
+
+const createUnixSocketPool = async config => {
+    const dbSocketPath = process.env.INSTANCE_UNIX_SOCKET || '/cloudsql';
+  
+    // Establish a connection to the database
+    return mysql.createPool({
+      user: process.env.DB_USER, // e.g. 'my-db-user'
+      password: process.env.DB_PASS, // e.g. 'my-db-password'
+      database: process.env.DB_NAME, // e.g. 'my-database'
+      // If connecting via unix domain socket, specify the path
+      socketPath: `${dbSocketPath}/${process.env.INSTANCE_CONNECTION_NAME}`,
+      // Specify additional properties here.
+      ...config,
+    });
+  };
+  // [END cloud_sql_mysql_mysql_connect_unix]
+  // [END cloud_sql_mysql_mysql_create_socket]
+  module.exports = createUnixSocketPool;
+  

--- a/cloud-sql/mysql/mysql/deployment.yaml
+++ b/cloud-sql/mysql/mysql/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: PORT
           value: "8080"
-        - name: DB_HOST
+        - name: INSTANCE_HOST
           value: "127.0.0.1"
         - name: DB_PORT
           value: "3306"  

--- a/cloud-sql/mysql/mysql/index.js
+++ b/cloud-sql/mysql/mysql/index.js
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const app = require('./server.js');
+
+/**
+ * Responds to GET and POST requests for TABS vs SPACES sample app.
+ *
+ * @param {Object} req Cloud Function request context.
+ * @param {Object} res Cloud Function response context.
+ */
+ exports.votes = (req, res) => {
+    //console.log('req.method', req.method);
+    switch (req.method) {
+      case 'GET':
+        //app.get(req, res);
+        app.httpget(req, res);
+        break;
+      case 'POST':
+        //app.post(req, res);
+        app.httppost(req, res);
+        break;
+      default:
+        res.status(405).send({error: 'Something blew up!'});
+        break;
+    } 
+  };

--- a/cloud-sql/mysql/mysql/test/server-unix.test.js
+++ b/cloud-sql/mysql/mysql/test/server-unix.test.js
@@ -20,14 +20,14 @@ const assert = require('assert');
 
 const SAMPLE_PATH = path.join(__dirname, '../server.js');
 
-const _db_host_backup = process.env.DB_HOST;
-delete process.env.DB_HOST;
+const _INSTANCE_HOST_backup = process.env.INSTANCE_HOST;
+delete process.env.INSTANCE_HOST;
 
 const serverUnix = require(SAMPLE_PATH);
 
 after(() => {
   serverUnix.close();
-  process.env.DB_HOST = _db_host_backup;
+  process.env.INSTANCE_HOST = _INSTANCE_HOST_backup;
 });
 
 it('should display the default via unix socket', async () => {

--- a/cloud-sql/mysql/mysql/views/index.pug
+++ b/cloud-sql/mysql/mysql/views/index.pug
@@ -58,7 +58,7 @@ html(lang="en")
             }
           }
         };
-        xhr.open("POST", "/", true);
+        xhr.open("POST", "/#{templatePath}", true);
         xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
         xhr.send("team=" + team);
       }


### PR DESCRIPTION
- Move TCP, TCP_SSL and UNIX socket examples into separate files
- Add support for Cloud Functions
  - Create index.js file use "/votes" as endpoint
  - Update server.js to export get/post functions and to use new CLOUD_FUNCTION_NAME env. variable
  - Update pug template to use conditional templatePath
- Add new region tags while leaving old tags in place
- Update DB_HOST env. variable to be INSTANCE_HOST
- Update DB_SOCKET_PATH env. variable to be INSTANCE_UNIX_SOCKET