### PR TITLE
feat: adding cloud event structured logging sample

### DIFF
--- a/functions/v2/cloud-event-logging/index.js
+++ b/functions/v2/cloud-event-logging/index.js
@@ -1,0 +1,40 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// [START functions_structured_logging_event]
+const {Logging} = require('@google-cloud/logging');
+const functions = require('@google-cloud/functions-framework');
+const pkg = require('./package.json');
+
+functions.cloudEvent('structuredLoggingEvent', async () => {
+  const projectId = 'MY_PROJECT';
+  // Initialize the logging client
+  const logging = new Logging();
+  // Create a LogSync transport, defaulting to process.stdout
+  const log = logging.logSync(pkg.name);
+  // Required to capture your project id
+  await logging.setProjectId(projectId);
+  const text = 'Hello, world!';
+  const entry = log.entry(
+    {
+      severity: 'NOTICE',
+      component: 'arbitrary-property',
+    },
+    text
+  );
+  log.write(entry);
+});
+// [END functions_structured_logging_event]

--- a/functions/v2/cloud-event-logging/index.js
+++ b/functions/v2/cloud-event-logging/index.js
@@ -20,21 +20,20 @@ const functions = require('@google-cloud/functions-framework');
 const pkg = require('./package.json');
 
 functions.cloudEvent('structuredLoggingEvent', async () => {
-  const projectId = 'MY_PROJECT';
   // Initialize the logging client
   const logging = new Logging();
   // Create a LogSync transport, defaulting to process.stdout
   const log = logging.logSync(pkg.name);
   // Required to capture your project id
-  await logging.setProjectId(projectId);
+  await logging.setProjectId();
   const text = 'Hello, world!';
   const entry = log.entry(
     {
-      severity: 'NOTICE',
       component: 'arbitrary-property',
     },
     text
   );
-  log.write(entry);
+  // Indicates severity using error()
+  log.error(entry);
 });
 // [END functions_structured_logging_event]

--- a/functions/v2/cloud-event-logging/package.json
+++ b/functions/v2/cloud-event-logging/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "structured-logging-cloudevent",
+  "version": "0.0.1",
+  "description": "Simple structured logging clouevent example",
+  "license": "Apache-2.0",
+  "author": "Google LLC",
+  "main": "index.js",
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "scripts": {
+    "test": "mocha test/*.test.js"
+  },
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.0",
+    "@google-cloud/logging": "^9.8.0"
+  },
+  "devDependencies": {
+    "assert": "^2.0.0",
+    "cloudevents": "^6.0.1",
+    "mocha": "^9.2.2",
+    "sinon": "^13.0.1"
+  }
+}

--- a/functions/v2/cloud-event-logging/test/index.test.js
+++ b/functions/v2/cloud-event-logging/test/index.test.js
@@ -1,0 +1,69 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const {getFunction} = require('@google-cloud/functions-framework/testing');
+const {Logging} = require('@google-cloud/logging');
+const {CloudEvent} = require('cloudevents');
+const pkg = require('../package.json');
+// Importing our target file
+require('../index.js');
+
+describe('structured logging: functions cloudevent', () => {
+  let projectId;
+
+  before(async () => {
+    const logging = new Logging();
+    projectId = await logging.auth.getProjectId();
+    // Adding a spy to the write function in stdout
+    sinon.spy(process.stdout, 'write');
+  });
+
+  afterEach(() => {
+    process.stdout.write.restore();
+  });
+
+  it('structuredLoggingEvent: should correctly print logs', async () => {
+    const structuredLoggingEvent = getFunction('structuredLoggingEvent');
+
+    const expected = {
+      severity: 'NOTICE',
+      component: 'arbitrary-property',
+      logName: `projects/${projectId}/logs/${pkg.name}`,
+      message: 'Hello, world!',
+    };
+
+    // Passing in a mocked CloudEvent object
+    await structuredLoggingEvent(
+      new CloudEvent({
+        type: 'google.cloud.pubsub.topic.v2.messagePublished',
+        source: '//pubsub.googleapis.com/test-topic',
+      })
+    );
+
+    assert.ok(process.stdout.write.calledOnce);
+    assert.ok(process.stdout.write.getCall(0).args.length);
+
+    // Capture the string output & parse
+    const result = JSON.parse(process.stdout.write.getCall(0).args[0]);
+
+    assert.equal(result.severity, expected.severity);
+    assert.equal(result.logName, expected.logName);
+    assert.equal(result.component, expected.component);
+    assert.equal(result.message, expected.message);
+  });
+});


### PR DESCRIPTION
Structured logging http for GCFv2


**To run sample:**
1)  You will need to create a pubsub topic to test this sample. 
`gcloud pubsub topics create YOUR_TOPIC_NAME `

1) Execute below commands in either local terminal or cloud shell.
```
npm i
gcloud beta functions deploy nodejs-pubsub-function --gen2 --runtime nodejs16 --trigger-topic YOUR_TOPIC_NAME --entry-point structuredLoggingEvent --source . --project YOUR_PROJ
```

2) After successful deployment, trigger the function w/ empty message.
`gcloud pubsub topics publish my-logging-topic --message=""`

3) Open up logs and verify `Hello, world!` has logged and that you are able to see something similar to below.

![Screen Shot 2022-04-11 at 9 53 23 AM](https://user-images.githubusercontent.com/1331216/162791705-56aa972d-d663-43ed-9fc3-0f1f2295e224.png)


4) Run unit test via `npm run test`
