### PR TITLE
chore(functions/v2): fix failing region tag check

### DIFF
--- a/functions/v2/cloudEventLogging/test/index.test.js
+++ b/functions/v2/cloudEventLogging/test/index.test.js
@@ -23,7 +23,7 @@ const pkg = require('../package.json');
 // Importing our target file
 require('../index.js');
 
-describe('structured logging: functions cloudevent', () => {
+describe('functions_structured_logging_event', () => {
   let projectId;
 
   before(async () => {

--- a/functions/v2/http-logging/test/index.test.js
+++ b/functions/v2/http-logging/test/index.test.js
@@ -22,7 +22,7 @@ const {getFunction} = require('@google-cloud/functions-framework/testing');
 // Importing our target file
 require('../index.js');
 
-describe('structured logging: functions http', () => {
+describe('functions_structured_logging', () => {
   let mockReq;
   let mockRes;
   let projectId;
@@ -52,7 +52,7 @@ describe('structured logging: functions http', () => {
     process.stdout.write.restore();
   });
 
-  it('structuredLogging: should correctly print logs', async () => {
+  it('structuredLogging functions http: should correctly print logs', async () => {
     const structuredLogging = getFunction('structuredLogging');
 
     // Call our function with dummy request and response objects


### PR DESCRIPTION
This should fix the `ci-region-tags` failures.