### PR TITLE
fix(redis): update object passed to createClient to match node-redis v4 specs

### DIFF
--- a/functions/memorystore/redis/index.js
+++ b/functions/memorystore/redis/index.js
@@ -22,7 +22,13 @@ const redis = require('redis');
 const REDISHOST = process.env.REDISHOST || 'localhost';
 const REDISPORT = process.env.REDISPORT || 6379;
 
-const redisClient = redis.createClient(REDISPORT, REDISHOST);
+const redisClient = redis.createClient({
+  socket: {
+    port: REDISPORT,
+    host: REDISHOST,
+  },
+});
+redisClient.connect();
 redisClient.on('error', err => console.error('ERR:REDIS:', err));
 
 const incrAsync = promisify(redisClient.incr).bind(redisClient);


### PR DESCRIPTION
**Issue:** Resolves following issue in sample.
`Error: The client is closed at Commander._RedisClient_sendCommand `
Breaking change introduced in [node-redis](https://github.com/redis/node-redis) v4. 
Changelog: https://github.com/redis/node-redis/blob/master/CHANGELOG.md#v400---24-nov-2021

Related: https://github.com/redis/node-redis/issues/1780

**Resolution:** Updating config and calling `.connect()` as described in updated [specs](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md).

**To reproduce error:**

* Follow the sample directions here (https://cloud.google.com/memorystore/docs/redis/connect-redis-instance-functions#node.js)
* Calling the final function's URL `https://[REGION]-[PROJECT_ID].cloudfunctions.net/visitCount` and you will see the the client closed error above. 

**To verify work:**
* Re-deploy the updated function and verify in the logs that the original behavior has been restored
- `visitCount ... CreateFunction`
- `visitCount ... Function execution started` 