### PR TITLE
chore: assign scheduleinstance sample ownership to TORuS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,6 @@ functions @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/nodejs-docs-samples
 run @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
 
 # Other functions samples
-functions/scheduleinstance @askmeegs @GoogleCloudPlatform/nodejs-docs-samples-owners
 functions/speech-to-speech @ricalo @GoogleCloudPlatform/nodejs-docs-samples-owners
 functions/memorystore @ericschmidtatwork @GoogleCloudPlatform/nodejs-docs-samples-owners
 functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-docs-samples-owners


### PR DESCRIPTION
@donmccasland `askmeegs` no longer owns these, so we want to point them at our team.

**Please confirm this works for you.**