### PR TITLE
fix: Update node version to LTS because app-engine flex does not support node >= 18

### DIFF
--- a/appengine/hello-world/flexible/package.json
+++ b/appengine/hello-world/flexible/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">= 12.20.0"
+    "node": "= 16.17.0"
   },
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
update node version to LTS because app engine flex does not support >= 18. 