### PR TITLE
fix: github action doc failures for missing prometheus svg

### DIFF
--- a/monitoring/prometheus/README.md
+++ b/monitoring/prometheus/README.md
@@ -1,4 +1,4 @@
-<img src="https://linuxfoundation.org/wp-content/uploads/prometheus.svg" alt="Prometheus logo" title="Prometheus" align="right" height="96" width="96"/>
+<img src="https://cncf-branding.netlify.app/img/projects/prometheus/icon/color/prometheus-icon-color.svg" alt="Prometheus logo" title="Prometheus" align="right" height="96" width="96"/>
 
 # Prometheus Samples for Node.js - SLIs
 


### PR DESCRIPTION
**Issue:** Should resolve the `JustinBeckwith/linkinator` github doc action. Updating broken svg link.

![Screen Shot 2022-09-22 at 11 50 07 AM](https://user-images.githubusercontent.com/1331216/191828030-680a872e-b2c1-44d5-a9f1-fc01e63d078c.png)
