### PR TITLE
Update Cloud SQL sample App Engine yaml and README

### DIFF
--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -122,7 +122,7 @@ Navigate towards `http://127.0.0.1:8080` to verify your application is running c
 To run on GAE-Standard, create an App Engine project by following the setup for these 
 [instructions](https://cloud.google.com/appengine/docs/standard/nodejs/quickstart#before-you-begin).
 
-First, update `app.standard.yaml` with the correct values to pass the environment 
+First, update [`app.standard.yaml`](app.standard.yaml) with the correct values to pass the environment 
 variables into the runtime.
 
 Next, the following command will deploy the application to your Google Cloud project:
@@ -138,7 +138,7 @@ gcloud app browse
 
 ## Deploy to Google App Engine Flexible
 
-First, update `app.flexible.yaml` with the correct values to pass the environment 
+First, update [`app.flexible.yaml`](app.flexible.yaml) with the correct values to pass the environment 
 variables into the runtime.
 
 Next, the following command will deploy the application to your Google Cloud project:

--- a/cloud-sql/mysql/mysql/app.standard.yaml
+++ b/cloud-sql/mysql/mysql/app.standard.yaml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs17
+runtime: nodejs16
 
 # The following env variables may contain sensitive information that grants
 # anyone access to your database. Do not add this file to your source control.

--- a/cloud-sql/postgres/knex/README.md
+++ b/cloud-sql/postgres/knex/README.md
@@ -123,7 +123,7 @@ Navigate towards `http://127.0.0.1:8080` to verify your application is running c
 
 ## Deploy to Google App Engine Standard
 
-1. To allow your app to connect to your Cloud SQL instance when the app is deployed, add the user, password, database, and instance unix socket variables from Cloud SQL to the related environment variables in the `app.standard.yaml` file. The deployed application will connect via unix sockets.
+1. To allow your app to connect to your Cloud SQL instance when the app is deployed, add the user, password, database, and instance unix socket variables from Cloud SQL to the related environment variables in the [`app.standard.yaml`](app.standard.yaml) file. The deployed application will connect via unix sockets.
 
     ```yaml
     env_variables:
@@ -147,7 +147,9 @@ Navigate towards `http://127.0.0.1:8080` to verify your application is running c
 
 ## Deploy to Google App Engine Flexible
 
-1. Add the user, password, database, and instance unix socket variables from Cloud SQL to the related environment variables in the `app.flexible.yaml` file. The deployed application will connect via unix sockets.
+1. Add the user, password, database, and instance unix socket variables from Cloud SQL 
+to the related environment variables in the [`app.flexible.yaml`](app.flexible.yaml) file.
+The deployed application will connect via unix sockets.
 
     ```yaml
     env_variables:

--- a/cloud-sql/postgres/knex/app.standard.yaml
+++ b/cloud-sql/postgres/knex/app.standard.yaml
@@ -20,9 +20,3 @@ env_variables:
   DB_USER: MY_DB_USER
   DB_PASS: MY_DB_PASSWORD
   DB_NAME: MY_DATABASE
-
-beta_settings:
-  # The connection name of your instance, available by using
-  # 'gcloud beta sql instances describe [INSTANCE_NAME]' or from
-  # the Instance details page in the Google Cloud Platform Console.
-  cloud_sql_instances: <MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>

--- a/cloud-sql/sqlserver/mssql/README.md
+++ b/cloud-sql/sqlserver/mssql/README.md
@@ -64,7 +64,7 @@ Navigate towards `http://127.0.0.1:8080` to verify your application is running c
 
 App Engine Flexible supports connecting to your SQL Server instance through TCP
 
-First, update `app.yaml` with the correct values to pass the environment 
+First, update [`app.yaml`](app.yaml) with the correct values to pass the environment 
 variables and instance name into the runtime.
 
 Then, make sure that the service account `service-{PROJECT_NUMBER}>@gae-api-prod.google.com.iam.gserviceaccount.com` has the IAM role `Cloud SQL Client`.


### PR DESCRIPTION
- Changes Cloud SQL MySQL sample's `app.standard.yaml` file to use nodejs16 runtime due to `gcloud.app.deploy` INVALID_ARGUMENT: Invalid runtime error. 
- Remove unnecessary `beta_settings` element from Cloud SQL Postgres sample's `app.standard.yaml` file.
- Link to yaml files from README files.