### PR TITLE
fix: codeowners needs to be based on teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ eventarc @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-revi
 # Other functions samples
 functions/scheduleinstance @askmeegs @GoogleCloudPlatform/nodejs-samples-reviewers
 functions/speech-to-speech @ricalo @GoogleCloudPlatform/nodejs-samples-reviewers 
-functions/memorystore @ericschmidtatwork @GoogleCloudPlatform/nodejs-samples-reviewers
+functions/memorystore @GoogleCloudPlatform/nodejs-samples-reviewers
 functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-samples-reviewers
 
 # SoDa teams
@@ -28,7 +28,7 @@ functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-samples-reviewers
 /datastore/**/*.js @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/nodejs-samples-reviewers
 
 # One-offs
-composer @leahecole @sofisl @yoshi-nodejs @GoogleCloudPlatform/nodejs-samples-reviewers
+composer @leahecole @sofisl @GoogleCloudPlatform/nodejs-samples-reviewers
 healthcare @noerog @GoogleCloudPlatform/nodejs-samples-reviewers
-monitoring/opencensus @yuriatgoogle @GoogleCloudPlatform/nodejs-samples-reviewers
+monitoring/opencensus @GoogleCloudPlatform/nodejs-samples-reviewers
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,30 +2,33 @@
 # for more info about CODEOWNERS file
 
 # Repo owner
-* @GoogleCloudPlatform/nodejs-docs-samples-owners
+* @GoogleCloudPlatform/nodejs-samples-reviewers 
 
 # Kokoro
 .kokoro @GoogleCloudPlatform/nodejs-docs-samples-owners
-.kokoro/appengine @engelke @ace-n @GoogleCloudPlatform/nodejs-docs-samples-owners
-.kokoro/functions @ace-n @GoogleCloudPlatform/nodejs-docs-samples-owners
+.kokoro/appengine @GoogleCloudPlatform/torus-dpe @ace-n @GoogleCloudPlatform/nodejs-docs-samples-owners
+.kokoro/functions @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-docs-samples-owners
 
-# Serverless/CBR
-appengine @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
-functions @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
-run @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
+# Serverless, Orchestration, DevOps
+appengine @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-reviewers
+functions @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-reviewers 
+run @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-reviewers
+cloud-tasks @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-reviewers
+workflows @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-reviewers
+eventarc @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/nodejs-samples-reviewers
 
 # Other functions samples
-functions/scheduleinstance @askmeegs @GoogleCloudPlatform/nodejs-docs-samples-owners
-functions/speech-to-speech @ricalo @GoogleCloudPlatform/nodejs-docs-samples-owners
-functions/memorystore @ericschmidtatwork @GoogleCloudPlatform/nodejs-docs-samples-owners
-functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-docs-samples-owners
+functions/scheduleinstance @askmeegs @GoogleCloudPlatform/nodejs-samples-reviewers
+functions/speech-to-speech @ricalo @GoogleCloudPlatform/nodejs-samples-reviewers 
+functions/memorystore @ericschmidtatwork @GoogleCloudPlatform/nodejs-samples-reviewers
+functions/spanner @jsimonweb @GoogleCloudPlatform/nodejs-samples-reviewers
 
 # SoDa teams
-/cloud-sql/**/*.js @GoogleCloudPlatform/infra-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
-/datastore/**/*.js @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/nodejs-docs-samples-owners
+/cloud-sql/**/*.js @GoogleCloudPlatform/infra-db-dpes @GoogleCloudPlatform/nodejs-samples-reviewers
+/datastore/**/*.js @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/nodejs-samples-reviewers
 
 # One-offs
-composer @leahecole @sofisl @yoshi-nodejs @GoogleCloudPlatform/nodejs-docs-samples-owners
-healthcare @noerog @GoogleCloudPlatform/nodejs-docs-samples-owners
-monitoring/opencensus @yuriatgoogle @GoogleCloudPlatform/nodejs-docs-samples-owners
+composer @leahecole @sofisl @yoshi-nodejs @GoogleCloudPlatform/nodejs-samples-reviewers
+healthcare @noerog @GoogleCloudPlatform/nodejs-samples-reviewers
+monitoring/opencensus @yuriatgoogle @GoogleCloudPlatform/nodejs-samples-reviewers
 


### PR DESCRIPTION
@GoogleCloudPlatform/nodejs-samples-reviewers should be reviewing PRs @GoogleCloudPlatform/nodejs-docs-samples-owners is responsible for repo ownership

Elimination of some individual ownership that should be team ownership migration of aap-dpes to torus-dpe 
adding TORuS DPE responsible repos.