### PR TITLE
docs: Add GitHub Actions instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,16 @@ need to enable the appropriate APIs in the [Cloud Console](https://console.cloud
 
 ## Adding new samples
 
-All samples must have tests. We use `mocha` as testing framework.
+All samples must have tests. We use `mocha` as testing framework. The package.json file within your sample directory must contain a test script that executes the `mocha` tests via `npm test` ([example](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/batch/package.json#L13)).
 
-Add a **build configuration file (`.cfg`)** for your samples in **[`.kokoro/`](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/main/.kokoro)**. Check existing config files for the right format.
+A GitHub Actions workflow should be created to run your tests on the CI system:
 
-All tests need a corresponding job file outside of GitHub. If you are a Googler, please provide the CL alongside your PR. See the internal codelab for Kokoro for details. If you don't work at Google, the person reviewing your PR will create the job config for you.
+1. Add an entry to [.github/workflows/workflows.json](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows/workflows.json) matching the directory with your sample code.
+
+1. From the root of the repo, use generate a new workflow in the [workflows](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows) directory.
+
+        node .github/workflows/generate.js
+
 
 ### Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ For new samples, a GitHub Actions workflow should be created to run your tests o
 
 1. Add an entry to [.github/workflows/workflows.json](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows/workflows.json) matching the directory with your sample code.
 
-1. From the root of the repo, use generate a new workflow in the [workflows](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows) directory.
+1. From the root of the repo, generate a new workflow in the [workflows](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows) directory:
 
         node .github/workflows/generate.js
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,11 @@ For new samples, a GitHub Actions workflow should be created to run your tests o
         node .github/workflows/generate.js
 
 > **Note**
-> There are some existing samples that use an alternative CI system. It is recommended to use GitHub Actions for new samples, but the instructions are provided below for your reference.
+> There are some existing samples that use an alternative CI system. It is recommended to use GitHub Actions for new samples, but these instructions are provided below for your reference.
 > 
 > Add a **build configuration file (`.cfg`)** for your samples in **[`.kokoro/`](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/main/.kokoro)**. Check existing config files for the right format.
 > 
-> All tests need a corresponding job file outside of GitHub. If you are a Googler, please provide the CL alongside your PR. See the internal codelab for Kokoro for details. If you don't work at Google, the person reviewing > your PR will create the job config for you.
+> All tests need a corresponding job file outside of GitHub. If you are a Googler, please provide the CL alongside your PR. See the internal codelab for Kokoro for details. If you don't work at Google, the person reviewing your PR will create the job config for you.
 
 
 ### Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,20 @@ need to enable the appropriate APIs in the [Cloud Console](https://console.cloud
 
 All samples must have tests. We use `mocha` as testing framework. The package.json file within your sample directory must contain a test script that executes the `mocha` tests via `npm test` ([example](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/batch/package.json#L13)).
 
-A GitHub Actions workflow should be created to run your tests on the CI system:
+For new samples, a GitHub Actions workflow should be created to run your tests on the CI system:
 
 1. Add an entry to [.github/workflows/workflows.json](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows/workflows.json) matching the directory with your sample code.
 
 1. From the root of the repo, use generate a new workflow in the [workflows](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows) directory.
 
         node .github/workflows/generate.js
+
+> **Note**
+> There are some existing samples that use an alternative CI system. It is recommended to use GitHub Actions for new samples, but the instructions are provided below for your reference.
+> 
+> Add a **build configuration file (`.cfg`)** for your samples in **[`.kokoro/`](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/main/.kokoro)**. Check existing config files for the right format.
+> 
+> All tests need a corresponding job file outside of GitHub. If you are a Googler, please provide the CL alongside your PR. See the internal codelab for Kokoro for details. If you don't work at Google, the person reviewing > your PR will create the job config for you.
 
 
 ### Style


### PR DESCRIPTION
This PR adds instructions for creating new GitHub Actions workflows, which are currently not included in CONTRIBUTING.md.