### PR TITLE
ci: add option to generate one workflow

### DIFF
--- a/.github/workflows/generate.js
+++ b/.github/workflows/generate.js
@@ -18,12 +18,18 @@ const fs = require('fs').promises;
 
 async function main() {
   nunjucks.configure('.github/workflows', {autoescape: true});
+
+  // Optional filter to generate one workflow
+  const filter = process.argv.slice(2)[0];
+
   for (const workflow of workflows) {
-    const path = workflow;
-    const name = workflow.split('/').join('-');
-    const suite = name.split('-').join('_');
-    const data = nunjucks.render('ci.yaml.njk', {path, name, suite});
-    await fs.writeFile(`.github/workflows/${name}.yaml`, data);
+    if (!filter || filter === workflow) {
+      const path = workflow;
+      const name = workflow.split('/').join('-');
+      const suite = name.split('-').join('_');
+      const data = nunjucks.render('ci.yaml.njk', {path, name, suite});
+      await fs.writeFile(`.github/workflows/${name}.yaml`, data);
+    }
   }
 }
 

--- a/.github/workflows/generate.js
+++ b/.github/workflows/generate.js
@@ -20,7 +20,7 @@ async function main() {
   nunjucks.configure('.github/workflows', {autoescape: true});
 
   // Optional filter to generate one workflow
-  const filter = process.argv.slice(2)[0];
+  const specificWorkflowPath = process.argv.slice(2)[0];
 
   for (const workflow of workflows) {
     if (!filter || filter === workflow) {

--- a/.github/workflows/generate.js
+++ b/.github/workflows/generate.js
@@ -23,7 +23,7 @@ async function main() {
   const specificWorkflowPath = process.argv.slice(2)[0];
 
   for (const workflow of workflows) {
-    if (!filter || filter === workflow) {
+    if (!specificWorkflowPath || specificWorkflowPath === workflow) {
       const path = workflow;
       const name = workflow.split('/').join('-');
       const suite = name.split('-').join('_');

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ For new samples, a GitHub Actions workflow should be created to run your tests o
 
 1. Add an entry to [.github/workflows/workflows.json](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows/workflows.json) matching the directory with your sample code.
 
-1. From the root of the repo, generate a new workflow in the [workflows](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows) directory:
+1. From the root of the repo, generate a new workflow in the [workflows](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows) directory. You can specify a `path` to only generate the specific workflow, e.g. `cloud-tasks`. If the path is omitted, all workflows will be generated.
 
-        node .github/workflows/generate.js
+        node .github/workflows/generate.js [path]
 
 > **Note**
 > There are some existing samples that use an alternative CI system. It is recommended to use GitHub Actions for new samples, but these instructions are provided below for your reference.


### PR DESCRIPTION
The workflow generation script currently creates all workflows, every time it is run.

This minor change enables an extra optional parameter with the workflow title, e.g. `cloud-tasks`.

A workflow will only be generated if it matches that parameter. If the parameter is not specified, the behavior remains the same, generating all workflows.