### PR TITLE
migrate code from googleapis/nodejs-workflows

### DIFF
--- a/.github/workflows/workflows.json
+++ b/.github/workflows/workflows.json
@@ -50,5 +50,6 @@
   "datacatalog/quickstart",
   "datastore/functions",
   "talent",
-  "contact-center-insights"
+  "contact-center-insights",
+  "workflows"
 ]

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,0 +1,67 @@
+name: workflows
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'workflows/**'
+  pull_request:
+    paths:
+    - 'workflows/**'
+  pull_request_target:
+    types: [labeled]
+  schedule:
+  - cron:  '0 0 * * 0'
+jobs:
+  test:
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+      id-token: 'write'
+    steps:
+    - uses: actions/checkout@v3.1.0
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+    - uses: 'google-github-actions/auth@v0.8.3'
+      with:
+        workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+        service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
+        create_credentials_file: 'true'
+        access_token_lifetime: 600s
+    - uses: actions/setup-node@v3.5.1
+      with:
+        node-version: 16
+    - run: npm install
+      working-directory: workflows
+    - run: npm test
+      working-directory: workflows
+      env:
+        MOCHA_REPORTER_SUITENAME: workflows
+        MOCHA_REPORTER_OUTPUT: workflows_sponge_log.xml
+        MOCHA_REPORTER: xunit
+    - if: ${{ github.event.action == 'labeled' && github.event.label.name == 'actions:force-run' }}
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          try {
+            await github.rest.issues.removeLabel({
+              name: 'actions:force-run',
+              owner: 'GoogleCloudPlatform',
+              repo: 'nodejs-docs-samples',
+              issue_number: context.payload.pull_request.number
+            });
+          } catch (e) {
+            if (!e.message.includes('Label does not exist')) {
+              throw e;
+            }
+          }
+    - if: ${{ github.event_name == 'schedule'}}
+      run: |
+        curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+        chmod +x ./flakybot
+        ./flakybot --repo GoogleCloudPlatform/nodejs-docs-samples --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -32,7 +32,7 @@ Before running the samples, make sure you've followed the steps outlined in
 
 ### Create-execution
 
-View the [source code](https://github.com/googleapis/nodejs-workflows/blob/master/samples/create-execution.js).
+View the [source code](https://github.com/googleapis/nodejs-workflows/blob/main/samples/create-execution.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-workflows&page=editor&open_in_editor=samples/create-execution.js,samples/README.md)
 
@@ -49,7 +49,7 @@ __Usage:__
 
 ### Quickstart
 
-View the [source code](https://github.com/googleapis/nodejs-workflows/blob/master/samples/quickstart.js).
+View the [source code](https://github.com/googleapis/nodejs-workflows/blob/main/samples/quickstart.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-workflows&page=editor&open_in_editor=samples/quickstart.js,samples/README.md)
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,68 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# [Workflows: Node.js Samples](https://github.com/googleapis/nodejs-workflows)
+
+[![Open in Cloud Shell][shell_img]][shell_link]
+
+
+
+## Table of Contents
+
+* [Before you begin](#before-you-begin)
+* [Samples](#samples)
+  * [Create-execution](#create-execution)
+  * [Quickstart](#quickstart)
+
+## Before you begin
+
+Before running the samples, make sure you've followed the steps outlined in
+[Using the client library](https://github.com/googleapis/nodejs-workflows#using-the-client-library).
+
+`cd samples`
+
+`npm install`
+
+`cd ..`
+
+## Samples
+
+
+
+### Create-execution
+
+View the [source code](https://github.com/googleapis/nodejs-workflows/blob/master/samples/create-execution.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-workflows&page=editor&open_in_editor=samples/create-execution.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/create-execution.js`
+
+
+-----
+
+
+
+
+### Quickstart
+
+View the [source code](https://github.com/googleapis/nodejs-workflows/blob/master/samples/quickstart.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-workflows&page=editor&open_in_editor=samples/quickstart.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/quickstart.js`
+
+
+
+
+
+
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-workflows&page=editor&open_in_editor=samples/README.md
+[product-docs]: https://cloud.google.com/workflows/docs/

--- a/workflows/create-execution.js
+++ b/workflows/create-execution.js
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, location, name) {
+  // [START workflows_create_execution]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const location = 'us-central1';
+  // const name = 'my-test-workflow';
+  const {ExecutionsClient} = require('@google-cloud/workflows');
+  const client = new ExecutionsClient();
+  async function createExecution() {
+    const [resp] = await client.createExecution({
+      parent: client.workflowPath(projectId, location, name),
+    });
+    console.info(`name: ${resp.name}`);
+  }
+  createExecution();
+  // [END workflows_create_execution]
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/workflows/create-execution.js
+++ b/workflows/create-execution.js
@@ -34,7 +34,7 @@ async function main(projectId, location, name) {
   // [END workflows_create_execution]
 }
 
-process.on('unhandledRejection', (err) => {
+process.on('unhandledRejection', err => {
   console.error(err.message);
   process.exitCode = 1;
 });

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.3.0"
+    "@google-cloud/workflows": "^1.3.1"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.3.1"
+    "@google-cloud/workflows": "^1.4.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.1.0"
+    "@google-cloud/workflows": "^1.2.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.6"
+    "@google-cloud/workflows": "^1.3.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.4"
+    "@google-cloud/workflows": "^1.2.5"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.2"
+    "@google-cloud/workflows": "^1.2.3"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.5"
+    "@google-cloud/workflows": "^1.2.6"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.0"
+    "@google-cloud/workflows": "^1.2.1"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.3"
+    "@google-cloud/workflows": "^1.2.4"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.2.1"
+    "@google-cloud/workflows": "^1.2.2"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=10"
+    "node": ">=12.0.0"
   },
   "files": [
     "*.js"

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^2.1.0"
+    "@google-cloud/workflows": "^2.1.1"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.4.0"
+    "@google-cloud/workflows": "^2.0.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^2.0.0"
+    "@google-cloud/workflows": "^2.1.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.0.1"
+    "@google-cloud/workflows": "^1.0.2"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^0.1.0"
+    "@google-cloud/workflows": "^1.0.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.0.0"
+    "@google-cloud/workflows": "^1.0.1"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -13,7 +13,7 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/workflows": "^1.0.2"
+    "@google-cloud/workflows": "^1.1.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nodejs-workflows-samples",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google LLC",
+  "engines": {
+    "node": ">=10"
+  },
+  "files": [
+    "*.js"
+  ],
+  "scripts": {
+    "test": "c8 mocha --timeout 600000 test/*.js"
+  },
+  "dependencies": {
+    "@google-cloud/workflows": "^0.1.0"
+  },
+  "devDependencies": {
+    "c8": "^7.3.0",
+    "mocha": "^8.1.1"
+  }
+}

--- a/workflows/quickstart.js
+++ b/workflows/quickstart.js
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, location) {
+  // [START workflows_quickstart]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const location = 'us-central1';
+  const {WorkflowsClient} = require('@google-cloud/workflows');
+  const client = new WorkflowsClient();
+  async function listWorkflows() {
+    const [workflows] = await client.listWorkflows({
+      parent: client.locationPath(projectId, location),
+    });
+    for (const workflow of workflows) {
+      console.info(`name: ${workflow.name}`);
+    }
+  }
+  listWorkflows();
+  // [END workflows_quickstart]
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/workflows/quickstart.js
+++ b/workflows/quickstart.js
@@ -35,7 +35,7 @@ async function main(projectId, location) {
   // [END workflows_quickstart]
 }
 
-process.on('unhandledRejection', (err) => {
+process.on('unhandledRejection', err => {
   console.error(err.message);
   process.exitCode = 1;
 });

--- a/workflows/test/create-execution.js
+++ b/workflows/test/create-execution.js
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const cp = require('child_process');
+const {describe, it} = require('mocha');
+
+const execSync = (cmd) => cp.execSync(cmd, {encoding: 'utf-8'});
+
+const cwd = path.join(__dirname, '..');
+
+const project = process.env.GCLOUD_PROJECT;
+const location = 'us-central1';
+const workflow = 'test-workflow-dont-delete';
+
+describe('create-execution', () => {
+  it('should create an execution', async () => {
+    const output = execSync(
+      `node ./create-execution.js ${project} ${location} ${workflow}`,
+      {
+        cwd,
+      }
+    );
+    assert(output.match(/name: projects.*executions.*/));
+  });
+});

--- a/workflows/test/create-execution.js
+++ b/workflows/test/create-execution.js
@@ -19,7 +19,7 @@ const assert = require('assert');
 const cp = require('child_process');
 const {describe, it} = require('mocha');
 
-const execSync = (cmd) => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 

--- a/workflows/test/quickstart.js
+++ b/workflows/test/quickstart.js
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const cp = require('child_process');
+const {describe, it} = require('mocha');
+
+const execSync = (cmd) => cp.execSync(cmd, {encoding: 'utf-8'});
+
+const cwd = path.join(__dirname, '..');
+
+const project = process.env.GCLOUD_PROJECT;
+
+describe('Quickstart', () => {
+  it('should run quickstart', async () => {
+    const output = execSync(`node ./quickstart.js ${project} us-central1`, {
+      cwd,
+    });
+    assert(output.match(/name: projects.*/));
+  });
+});

--- a/workflows/test/quickstart.js
+++ b/workflows/test/quickstart.js
@@ -19,7 +19,7 @@ const assert = require('assert');
 const cp = require('child_process');
 const {describe, it} = require('mocha');
 
-const execSync = (cmd) => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 


### PR DESCRIPTION
- feat!: initial library generation (#8)
- chore: release 1.0.0 (#11)
- chore: release 1.0.1 (#21)
- chore: release 1.0.2 (#24)
- chore: release 1.1.0 (#31)
- chore: release 1.2.0 (#53)
- chore: release 1.2.1 (#62)
- chore: release 1.2.2 (#70)
- chore: release 1.2.3 (#76)
- chore: release 1.2.4 (#79)
- chore: release 1.2.5 (#81)
- chore: release 1.2.6 (#88)
- chore: release 1.3.0 (#90)
- fix(build): migrate to using main branch (#92)
- chore: release 1.3.1 (#93)
- chore: release 1.4.0 (#107)
- build!: update library to use Node 12 (#140)
- chore(main): release 2.0.0 (#142)
- chore(main): release 2.1.0 (#147)
- chore(main): release 2.1.1 (#157)
