### PR TITLE
ci: update workflow template

### DIFF
--- a/.github/workflows/ci.yaml.njk
+++ b/.github/workflows/ci.yaml.njk
@@ -1,67 +1,30 @@
-name: {{name}}
-on:
-  push:
-    branches:
-    - main
-    paths:
-    - '{{path}}/**'
-  pull_request:
-    paths:
-    - '{{path}}/**'
-  pull_request_target:
-    types: [labeled]
-  schedule:
-  - cron:  '0 0 * * 0'
-jobs:
-  test:
-    if: {% raw %}${{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}{% endraw %}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: 'write'
-      pull-requests: 'write'
-      id-token: 'write'
-    steps:
-    - uses: actions/checkout@v3.1.0
-      with:
-        ref: {% raw %}${{github.event.pull_request.head.ref}}{% endraw %}
-        repository: {% raw %}${{github.event.pull_request.head.repo.full_name}}{% endraw %}
-    - uses: 'google-github-actions/auth@v0.8.3'
-      with:
-        workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
-        service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
-        create_credentials_file: 'true'
-        access_token_lifetime: 600s
-    - uses: actions/setup-node@v3.5.1
-      with:
-        node-version: 16
-    - run: npm install
-      working-directory: {{path}}
-    - run: npm test
-      working-directory: {{path}}
-      env:
-        MOCHA_REPORTER_SUITENAME: {{suite}}
-        MOCHA_REPORTER_OUTPUT: {{suite}}_sponge_log.xml
-        MOCHA_REPORTER: xunit
-    - if: {% raw %}${{ github.event.action == 'labeled' && github.event.label.name == 'actions:force-run' }}{% endraw %}
-      uses: actions/github-script@v6
-      with:
-        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        script: |
-          try {
-            await github.rest.issues.removeLabel({
-              name: 'actions:force-run',
-              owner: 'GoogleCloudPlatform',
-              repo: 'nodejs-docs-samples',
-              issue_number: context.payload.pull_request.number
-            });
-          } catch (e) {
-            if (!e.message.includes('Label does not exist')) {
-              throw e;
-            }
-          }
-    - if: {% raw %}${{ github.event_name == 'schedule'}}{% endraw %}
-      run: |
-        curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
-        chmod +x ./flakybot
-        {% raw %}./flakybot --repo GoogleCloudPlatform/nodejs-docs-samples --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}{% endraw %}
+name : {{name}}
+on : push : branches : -main
+paths : - '{{path}}/**'
+pull_request : paths : - '{{path}}/**'
+pull_request_target : types : [labeled]
+paths : - '{{path}}/**'
+schedule : -cron : '0 0 * * 0'
+jobs : test : if :{% raw %}
+  $ {{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}{% endraw %}runs - on : ubuntu - latest timeout - minutes : 60 permissions : contents : 'write' pull - requests : 'write' id - token : 'write' steps : -uses : actions / checkout@v3.1.0 with : ref :{% raw %}
+  $ {{github.event.pull_request.head.sha}}{% endraw %} - uses : 'google-github-actions/auth@v1.0.0' with : workload_identity_provider : 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider' service_account : 'kokoro-system-test@long-door-651.iam.gserviceaccount.com' create_credentials_file : 'true' access_token_lifetime : 600 s - uses : actions / setup - node@v3.5.1 with : node - version : 16 - run : npm install working - directory : {{path}} - run : npm test working - directory : {{path}}
+env : MOCHA_REPORTER_SUITENAME : {{suite}}
+MOCHA_REPORTER_OUTPUT : {{suite}}
+_sponge_log.xml MOCHA_REPORTER : xunit - if  :{% raw %}
+  $ {{ github.event.action == 'labeled' && github.event.label.name == 'actions:force-run' }}{% endraw %}uses : actions / github - script@v6 with : github - token :{% raw %}
+  $ {{ secrets.GITHUB_TOKEN }}{% endraw %}script : | try {
+  await github
+    .rest
+    .issues
+    .removeLabel({
+      name: 'actions:force-run', owner: 'GoogleCloudPlatform', repo: 'nodejs-docs-samples', issue_number: context
+        .payload
+        .pull_request
+        .number
+    });
+} catch (e) {
+if (!e.message.includes('Label does not exist')) {
+  throw e;
+}} - if  :{% raw %}
+$ {{ github.event_name == 'schedule'}}{% endraw %}run : | curl https : // github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -Lchmod + x./flakybot
+        {% raw %}./flakybot -- repo GoogleCloudPlatform / nodejs - docs - samples -- commit_hash $ {{github.sha}}-- build_url https : // github.com/${{github.repository}}/actions/runs/${{github.run_id}}{% endraw %}

--- a/.github/workflows/ci.yaml.njk
+++ b/.github/workflows/ci.yaml.njk
@@ -1,30 +1,68 @@
-name : {{name}}
-on : push : branches : -main
-paths : - '{{path}}/**'
-pull_request : paths : - '{{path}}/**'
-pull_request_target : types : [labeled]
-paths : - '{{path}}/**'
-schedule : -cron : '0 0 * * 0'
-jobs : test : if :{% raw %}
-  $ {{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}{% endraw %}runs - on : ubuntu - latest timeout - minutes : 60 permissions : contents : 'write' pull - requests : 'write' id - token : 'write' steps : -uses : actions / checkout@v3.1.0 with : ref :{% raw %}
-  $ {{github.event.pull_request.head.sha}}{% endraw %} - uses : 'google-github-actions/auth@v1.0.0' with : workload_identity_provider : 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider' service_account : 'kokoro-system-test@long-door-651.iam.gserviceaccount.com' create_credentials_file : 'true' access_token_lifetime : 600 s - uses : actions / setup - node@v3.5.1 with : node - version : 16 - run : npm install working - directory : {{path}} - run : npm test working - directory : {{path}}
-env : MOCHA_REPORTER_SUITENAME : {{suite}}
-MOCHA_REPORTER_OUTPUT : {{suite}}
-_sponge_log.xml MOCHA_REPORTER : xunit - if  :{% raw %}
-  $ {{ github.event.action == 'labeled' && github.event.label.name == 'actions:force-run' }}{% endraw %}uses : actions / github - script@v6 with : github - token :{% raw %}
-  $ {{ secrets.GITHUB_TOKEN }}{% endraw %}script : | try {
-  await github
-    .rest
-    .issues
-    .removeLabel({
-      name: 'actions:force-run', owner: 'GoogleCloudPlatform', repo: 'nodejs-docs-samples', issue_number: context
-        .payload
-        .pull_request
-        .number
-    });
-} catch (e) {
-if (!e.message.includes('Label does not exist')) {
-  throw e;
-}} - if  :{% raw %}
-$ {{ github.event_name == 'schedule'}}{% endraw %}run : | curl https : // github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -Lchmod + x./flakybot
-        {% raw %}./flakybot -- repo GoogleCloudPlatform / nodejs - docs - samples -- commit_hash $ {{github.sha}}-- build_url https : // github.com/${{github.repository}}/actions/runs/${{github.run_id}}{% endraw %}
+name: {{name}}
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '{{path}}/**'
+  pull_request:
+    paths:
+    - '{{path}}/**'
+  pull_request_target:
+    types: [labeled]
+    paths:
+    - '{{path}}/**'
+  schedule:
+  - cron:  '0 0 * * 0'
+jobs:
+  test:
+    if: {% raw %}${{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}{% endraw %}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+      id-token: 'write'
+    steps:
+    - uses: actions/checkout@v3.1.0
+      with:
+        ref: {% raw %}${{github.event.pull_request.head.sha}}{% endraw %}
+    - uses: 'google-github-actions/auth@v1.0.0'
+      with:
+        workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+        service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
+        create_credentials_file: 'true'
+        access_token_lifetime: 600s
+    - uses: actions/setup-node@v3.5.1
+      with:
+        node-version: 16
+    - run: npm install
+      working-directory: {{path}}
+    - run: npm test
+      working-directory: {{path}}
+      env:
+        MOCHA_REPORTER_SUITENAME: {{suite}}
+        MOCHA_REPORTER_OUTPUT: {{suite}}_sponge_log.xml
+        MOCHA_REPORTER: xunit
+    - if: {% raw %}${{ github.event.action == 'labeled' && github.event.label.name == 'actions:force-run' }}{% endraw %}
+      uses: actions/github-script@v6
+      with:
+        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        script: |
+          try {
+            await github.rest.issues.removeLabel({
+              name: 'actions:force-run',
+              owner: 'GoogleCloudPlatform',
+              repo: 'nodejs-docs-samples',
+              issue_number: context.payload.pull_request.number
+            });
+          } catch (e) {
+            if (!e.message.includes('Label does not exist')) {
+              throw e;
+            }
+          }
+    - if: {% raw %}${{ github.event_name == 'schedule'}}{% endraw %}
+      run: |
+        curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+        chmod +x ./flakybot
+        {% raw %}./flakybot --repo GoogleCloudPlatform/nodejs-docs-samples --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}{% endraw %}


### PR DESCRIPTION
This issue updates the template for #2796, #2814, and an internal issue.

This PR does not re-generate existing workflows using this template, as there are currently many outstanding PRs. It will ensure that future PRs have these changes. We can keep #2796 open until we've re-generated workflows.