### PR TITLE
docs: add new error-reporting CODEOWNER and README

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,7 @@ orgpolicy @GoogleCloudPlatform/dee-infra @GoogleCloudPlatform/nodejs-samples-rev
 
 # DEE Platform Ops (DEEPO)
 container-analysis @GoogleCloudPlatform/dee-platform-ops
+error-reporting @GoogleCloudPlatform/dee-platform-ops @GoogleCloudPlatform/nodejs-samples-reviewers @googleapis/api-logging
 
 # Other functions samples
 functions/scheduleinstance @askmeegs @GoogleCloudPlatform/nodejs-samples-reviewers
@@ -42,6 +43,3 @@ monitoring/opencensus @GoogleCloudPlatform/nodejs-samples-reviewers
 # Data & AI
 contact-center-insights @GoogleCloudPlatform/dee-data-ai @GoogleCloudPlatform/nodejs-samples-reviewers
 talent @GoogleCloudPlatform/dee-data-ai @GoogleCloudPlatform/nodejs-samples-reviewers
-
-# DEE-PO
-error-reporting @GoogleCloudPlatform/dee-platform-ops @GoogleCloudPlatform/nodejs-samples-reviewers

--- a/error-reporting/README.md
+++ b/error-reporting/README.md
@@ -1,0 +1,19 @@
+# Error Reporting: Samples
+
+Each sample's `README.md` has instructions for running its sample.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+| Explicit setup | [source code](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/error-reporting/explicitSetup.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/nodejs-docs-samples&page=editor&open_in_editor=error-reporting/explicitSetup.js,samples/README.md) |
+| Express integration | [source code](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/error-reporting/express.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/nodejs-docs-samples&page=editor&open_in_editor=error-reporting/express.js,samples/README.md) |
+| Implicit setup | [source code](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/error-reporting/implicitSetup.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/nodejs-docs-samples&page=editor&open_in_editor=error-reporting/implicitSetup.js,samples/README.md) |
+| Manual reporting | [source code](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/error-reporting/manual.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/nodejs-docs-samples&page=editor&open_in_editor=error-reporting/manual.js,samples/README.md) |
+| Quickstart | [source code](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/error-reporting/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/nodejs-docs-samples&page=editor&open_in_editor=error-reporting/quickstart.js,samples/README.md) |
+
+
+
+The [Error Reporting Node.js Client API Reference][client-docs] documentation
+also contains samples.
+
+[client-docs]: https://cloud.google.com/nodejs/docs/reference/error-reporting/latest
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png


### PR DESCRIPTION
I noticed that `@googleapis/api-logging` is a CODEOWNER in the original repository, so I added it here.

Also, I added a README. This isn't a required migration step, so please feel free to use or ignore. Just a placeholder until we have a README strategy / tooling. I brought in the ##Samples section from the `nodejs-error-reporting` main README.md here, and updated the paths.