### PR TITLE
migrate code from googleapis/cloud-profiler-nodejs

### DIFF
--- a/profiler/app.js
+++ b/profiler/app.js
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// [START profiler_setup_nodejs_app_engine]
+require('@google-cloud/profiler').start();
+// [END profiler_setup_nodejs_app_engine]

--- a/profiler/package.json
+++ b/profiler/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cloud-profiler-samples",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Google Cloud Profiler samples",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo 'no test yet'"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/googleapis/cloud-profiler-nodejs.git"
+  },
+  "author": "Google LLC.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@google-cloud/profiler": "^5.0.3"
+  },
+  "files": [
+    "*.js"
+  ]
+}

--- a/profiler/snippets.js
+++ b/profiler/snippets.js
@@ -1,0 +1,24 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// [START profiler_setup_nodejs_compute_engine]
+require('@google-cloud/profiler').start({
+  serviceContext: {
+    service: 'your-service',
+    version: '1.0.0',
+  },
+});
+// [END profiler_setup_nodejs_compute_engine]


### PR DESCRIPTION
- Add samples with snippets for documentation (#333)
- build: add lint script (#362)
- chore: update license headers
- build!: require node.js 10.x and up (#623)
- chore: release 4.0.0 (#586)
- chore: release 4.0.1 (#635)
- chore: release 4.0.2 (#667)
- chore: release 4.0.3 (#672)
- chore: release 4.1.0 (#711)
- chore: release 4.1.1 (#723)
- chore: release 4.1.2 (#734)
- chore: release 4.1.3 (#755)
- chore: release 4.1.4 (#764)
- chore: release 4.1.5 (#774)
- chore: release 4.1.6 (#785)
- chore: release 4.1.7 (#786)
- chore(main): release 4.2.0 (#834)
- build!: update library to use Node 12 (#835)
- chore(main): release 5.0.0 (#839)
- chore(main): release 5.0.1 (#848)
- chore(main): release 5.0.2 (#850)
- chore(main): release 5.0.3 (#853)
