### PR TITLE
migrate code from googleapis/nodejs-cloud-container

### DIFF
--- a/container/snippets/package.json
+++ b/container/snippets/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "nodejs-docs-samples-container",
+  "license": "Apache-2.0",
+  "author": "Google Inc.",
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "repository": "googleapis/nodejs-cloud-container",
+  "private": true,
+  "files": [
+    "*.js"
+  ],
+  "scripts": {
+    "test": "mocha system-test --timeout 1000000"
+  },
+  "dependencies": {
+    "@google-cloud/container": "^4.4.0",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^8.0.0"
+  }
+}

--- a/container/snippets/quickstart.js
+++ b/container/snippets/quickstart.js
@@ -1,0 +1,41 @@
+// Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// [START gke_list_cluster]
+async function main() {
+  // [START container_quickstart]
+  const container = require('@google-cloud/container');
+
+  // Create the Cluster Manager Client
+  const client = new container.v1.ClusterManagerClient();
+
+  async function quickstart() {
+    const zone = 'us-central1-a';
+    const projectId = await client.getProjectId();
+    const request = {
+      projectId: projectId,
+      zone: zone,
+    };
+
+    const [response] = await client.listClusters(request);
+    console.log('Clusters: ', response);
+  }
+  quickstart();
+  // [END container_quickstart]
+}
+
+main().catch(console.error);
+// [END gke_list_cluster]

--- a/container/snippets/system-test/create_cluster.test.js
+++ b/container/snippets/system-test/create_cluster.test.js
@@ -1,0 +1,91 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert, expect} = require('chai');
+const {describe, it, before, after} = require('mocha');
+const uuid = require('uuid');
+const cp = require('child_process');
+const container = require('@google-cloud/container');
+const untilDone = require('./test_util.js');
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const zones = [
+  'us-central1-a',
+  'us-central1-b',
+  'us-central1-c',
+  'us-central1-f',
+];
+const randomZone = zones[Math.floor(Math.random() * zones.length)];
+const randomUUID = uuid.v1().substring(0, 8);
+const randomClusterName = `nodejs-container-test-${randomUUID}`;
+const client = new container.v1.ClusterManagerClient();
+const ciNetwork = 'default-compute';
+let projectId;
+let clusterLocation;
+
+// create a new cluster to test the delete sample on
+before(async () => {
+  projectId = await client.getProjectId();
+  clusterLocation = `projects/${projectId}/locations/${randomZone}`;
+});
+
+// clean up the cluster regardless of whether the test passed or not
+after(async () => {
+  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+  const [deleteOperation] = await client.deleteCluster(request);
+  const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+  await untilDone(client, opIdentifier);
+});
+
+describe('container samples - create cluster long running op', () => {
+  it('should create cluster and wait for completion, and see the cluster in list', async () => {
+    let stdout;
+    let test = true;
+    try {
+      stdout = execSync(
+        `node create_cluster.js ${randomClusterName} ${randomZone} ${ciNetwork}`
+      );
+    } catch (err) {
+      if (
+        err
+          .toString()
+          .includes('7 PERMISSION_DENIED: Insufficient regional quota')
+      ) {
+        test = false;
+      } else {
+        throw err;
+      }
+    }
+
+    if (test) {
+      assert.match(
+        stdout,
+        /Cluster creation not complete. will try after .* delay/
+      );
+      assert.match(stdout, /Cluster creation completed./);
+
+      const [response] = await client.listClusters({
+        projectId: projectId,
+        zone: randomZone,
+      });
+      const clustersList = response.clusters.reduce(
+        (acc, curr) => [curr.name, ...acc],
+        []
+      );
+      expect(clustersList).to.include(randomClusterName);
+    }
+  });
+});

--- a/container/snippets/system-test/delete_cluster.test.js
+++ b/container/snippets/system-test/delete_cluster.test.js
@@ -1,0 +1,115 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert, expect} = require('chai');
+const {describe, it, after, before} = require('mocha');
+const uuid = require('uuid');
+const cp = require('child_process');
+const container = require('@google-cloud/container');
+const untilDone = require('./test_util.js');
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const zones = [
+  'us-central1-a',
+  'us-central1-b',
+  'us-central1-c',
+  'us-central1-f',
+];
+const randomZone = zones[Math.floor(Math.random() * zones.length)];
+const randomUUID = uuid.v1().substring(0, 8);
+const randomClusterName = `nodejs-container-test-${randomUUID}`;
+const client = new container.v1.ClusterManagerClient();
+const ciNetwork = 'default-compute';
+let projectId;
+let clusterLocation;
+let test = true;
+
+// create a new cluster to test the delete sample on
+before(async () => {
+  projectId = await client.getProjectId();
+  clusterLocation = `projects/${projectId}/locations/${randomZone}`;
+  const request = {
+    parent: clusterLocation,
+    cluster: {
+      name: randomClusterName,
+      network: ciNetwork,
+      initialNodeCount: 2,
+      nodeConfig: {machineType: 'e2-standard-2'},
+    },
+  };
+  let createOperation;
+  let opIdentifier;
+  try {
+    [createOperation] = await client.createCluster(request);
+    opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+    await untilDone(client, opIdentifier);
+  } catch (err) {
+    if (
+      err
+        .toString()
+        .includes('7 PERMISSION_DENIED: Insufficient regional quota')
+    ) {
+      test = false;
+    } else {
+      throw err;
+    }
+  }
+});
+
+// clean up the cluster regardless of whether the test passed or not
+after(async () => {
+  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+  try {
+    const [deleteOperation] = await client.deleteCluster(request);
+    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+    await untilDone(client, opIdentifier);
+  } catch (ex) {
+    // Error code 5 is NOT_FOUND meaning the cluster was deleted during the test
+    if (ex.code === 5) {
+      return;
+    }
+  }
+});
+
+// run the tests
+describe('container samples - delete cluster long running op', () => {
+  it('should delete cluster and wait for completion', async () => {
+    if (test) {
+      const stdout = execSync(
+        `node delete_cluster.js ${randomClusterName} ${randomZone}`
+      );
+      assert.match(
+        stdout,
+        /Cluster deletion not complete. will try after .* delay/
+      );
+      assert.match(stdout, /Cluster deletion completed./);
+    }
+  });
+
+  it('should not see the deleted cluster in the list', async () => {
+    if (test) {
+      const [response] = await client.listClusters({
+        projectId: projectId,
+        zone: randomZone,
+      });
+      const clustersList = response.clusters.reduce(
+        (acc, curr) => [curr.name, ...acc],
+        []
+      );
+      expect(clustersList).to.not.include(randomClusterName);
+    }
+  });
+});

--- a/container/snippets/system-test/quicktest.test.js
+++ b/container/snippets/system-test/quicktest.test.js
@@ -1,0 +1,28 @@
+// Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert} = require('chai');
+const {describe, it} = require('mocha');
+const cp = require('child_process');
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+describe('container samples - quickstart', () => {
+  it('should run the quickstart', async () => {
+    const stdout = execSync('node quickstart');
+    assert.match(stdout, /Clusters:/);
+  });
+});

--- a/container/snippets/system-test/test_util.js
+++ b/container/snippets/system-test/test_util.js
@@ -1,0 +1,66 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const container = require('@google-cloud/container');
+const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const maxRetries = 20;
+let retryCount;
+let prevDelay;
+let currDelay;
+
+/**
+ * We use a custom wait and retry method for the test cases, which is different
+ * from the approach we have for the samples itself. The samples use an async
+ * function with delayed setIntervals. Since, the last function call of the
+ * samples is the wait for the long running operation to complete, the program
+ * waits until the delayed setInterval async functions resolve.
+ *
+ * However, when running the tests we have certain setup to be done in the
+ * before() hook which are also long running operations. We would want to block
+ * until these setup steps are fully complete before allowing for the tests to
+ * start. If we use the same approach used in the samples (with an async
+ * function scheduled on setIntervals), the before() hook will not block. Rather
+ * it will return and the tests will start running.
+ *
+ * To prevent this scenario, we have employed a sleep based retry and wait
+ * method below to be used only for the test cases.
+ *
+ * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} opIdentifier the unique identifier of the operation we want to check
+ */
+async function retryUntilDone(client, opIdentifier) {
+  retryCount = 0;
+  prevDelay = 0;
+  currDelay = 1000;
+
+  while (retryCount <= maxRetries) {
+    const [longRunningOp] = await client.getOperation({name: opIdentifier});
+    const status = longRunningOp.status;
+    if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+      const fibonacciDelay = prevDelay + currDelay;
+      prevDelay = currDelay;
+      currDelay = fibonacciDelay;
+      await sleep(fibonacciDelay);
+    } else {
+      break;
+    }
+    retryCount += 1;
+  }
+}
+
+module.exports = retryUntilDone;


### PR DESCRIPTION
- new generated code, updating version to 0.8.0
- Better readme and quickstart (#4)
- Upgrade repo-tools and regenerate scaffolding. (#19)
- v0.2.0 (#20)
- chore: lock files maintenance (#24)
- chore: lock files maintenance (#26)
- chore: lock files maintenance (#29)
- chore: update sample lockfiles (#38)
- chore(deps): update dependency @google-cloud/nodejs-repo-tools to v2.3.0 (#41)
- chore(deps): lock file maintenance (#44)
- chore(deps): lock file maintenance (#47)
- fix: drop support for node.js 4.x and 9.x (#46)
- chore(deps): lock file maintenance (#48)
- chore(deps): lock file maintenance (#49)
- chore(deps): lock file maintenance (#51)
- chore(deps): lock file maintenance (#54)
- chore: require node 8 for samples (#56)
- chore(deps): lock file maintenance (#57)
- chore(deps): lock file maintenance (#61)
- chore: ignore package-lock.json (#63)
- Remove unused dependencies (#72)
- chore(deps): update dependency @google-cloud/nodejs-repo-tools to v3 (#113)
- docs(samples): updated samples code to use async await (#122)
- Release v0.3.0 (#141)
- test: add sample tests (#143)
- chore(deps): update dependency mocha to v6
- Release v0.3.1 (#168)
- refactor: use execSync for tests (#176)
- refactor: wrap execSync with encoding: utf-8 (#177)
- chore: release 1.0.0 (#193)
- refactor: use repo-metadata to generate readme (#196)
- chore: release 1.1.0 (#204)
- chore: release 1.1.1 (#206)
- chore: release 1.1.2 (#209)
- chore: release 1.1.3 (#211)
- chore: release 1.1.4 (#222)
- chore: release 1.2.0 (#225)
- chore: release 1.3.1 (#241)
- chore: release 1.4.0 (#248)
- chore: update license headers
- refactor: use explicit mocha imports
- chore(deps): update dependency mocha to v7 (#269)
- chore: release 1.5.0
- chore: release 1.6.0 (#274)
- chore: release 1.6.1 (#278)
- chore: release 1.6.2 (#287)
- chore: release 1.7.0 (#296)
- chore: release 2.0.0 (#319)
- chore(deps): update dependency mocha to v8 (#349)
- chore: release 2.1.0 (#348)
- chore: release 2.1.1 (#359)
- chore: release 2.1.2 (#399)
- chore: release 2.2.0 (#402)
- chore: release 2.2.1 (#432)
- chore: release 2.2.2 (#442)
- chore: release 2.3.0 (#447)
- chore: release 2.3.1 (#456)
- chore: release 2.3.2 (#461)
- chore: release 2.4.0 (#465)
- chore: release 2.4.1 (#467)
- chore: release 2.4.2 (#469)
- chore: release 2.4.3 (#478)
- chore: release 2.4.4 (#479)
- chore: release 2.5.0 (#481)
- docs(samples): add auto-generated Node samples (#488)
- chore: release 2.6.0 (#498)
- docs(samples): add usage samples to show handling of LRO response Operation (#519)
- chore(main): release 3.0.0 (#511)
- chore(main): release 3.0.1 (#529)
- build!: update library to use Node 12 (#539)
- chore(main): release 4.0.0 (#540)
- chore(main): release 4.0.1 (#542)
- chore(main): release 4.1.0 (#550)
- chore(main): release 4.1.1 (#559)
- chore(main): release 4.1.2 (#565)
- fix(deps): update dependency uuid to v9 (#564)
- build: skip flaky tests if flaky (#567)
- chore(main): release 4.1.3 (#566)
- chore(main): release 4.2.0 (#569)
- chore(main): release 4.3.0 (#579)
- chore(main): release 4.4.0 (#584)
