### PR TITLE
fix: only trigger CI on path changes

### DIFF
--- a/.github/workflows/appengine-analytics.yaml
+++ b/.github/workflows/appengine-analytics.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/analytics/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/analytics/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-building-an-app-build.yaml
+++ b/.github/workflows/appengine-building-an-app-build.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/building-an-app/build/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/building-an-app/build/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-building-an-app-update.yaml
+++ b/.github/workflows/appengine-building-an-app-update.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/building-an-app/update/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/building-an-app/update/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-datastore.yaml
+++ b/.github/workflows/appengine-datastore.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/datastore/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/datastore/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-endpoints.yaml
+++ b/.github/workflows/appengine-endpoints.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/endpoints/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/endpoints/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-hello-world-flexible.yaml
+++ b/.github/workflows/appengine-hello-world-flexible.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/hello-world/flexible/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/hello-world/flexible/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-hello-world-standard.yaml
+++ b/.github/workflows/appengine-hello-world-standard.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/hello-world/standard/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/hello-world/standard/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-memcached.yaml
+++ b/.github/workflows/appengine-memcached.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/memcached/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/memcached/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-metadata-flexible.yaml
+++ b/.github/workflows/appengine-metadata-flexible.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/metadata/flexible/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/metadata/flexible/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-metadata-standard.yaml
+++ b/.github/workflows/appengine-metadata-standard.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/metadata/standard/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/metadata/standard/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-pubsub.yaml
+++ b/.github/workflows/appengine-pubsub.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/pubsub/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/pubsub/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-static-files.yaml
+++ b/.github/workflows/appengine-static-files.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/static-files/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/static-files/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-storage-flexible.yaml
+++ b/.github/workflows/appengine-storage-flexible.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/storage/flexible/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/storage/flexible/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-storage-standard.yaml
+++ b/.github/workflows/appengine-storage-standard.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/storage/standard/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/storage/standard/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-twilio.yaml
+++ b/.github/workflows/appengine-twilio.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/twilio/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/twilio/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-typescript.yaml
+++ b/.github/workflows/appengine-typescript.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/typescript/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/typescript/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/appengine-websockets.yaml
+++ b/.github/workflows/appengine-websockets.yaml
@@ -10,6 +10,8 @@ on:
     - 'appengine/websockets/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'appengine/websockets/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/auth.yaml
+++ b/.github/workflows/auth.yaml
@@ -10,6 +10,8 @@ on:
     - 'auth/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'auth/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/automl.yaml
+++ b/.github/workflows/automl.yaml
@@ -10,6 +10,8 @@ on:
     - 'automl/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'automl/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/batch.yaml
+++ b/.github/workflows/batch.yaml
@@ -10,6 +10,8 @@ on:
     - 'batch/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'batch/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/cloud-language.yaml
+++ b/.github/workflows/cloud-language.yaml
@@ -10,6 +10,8 @@ on:
     - 'cloud-language/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'cloud-language/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/cloud-tasks-app.yaml
+++ b/.github/workflows/cloud-tasks-app.yaml
@@ -10,6 +10,8 @@ on:
     - 'cloud-tasks/tutorial-gcf/app/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'cloud-tasks/tutorial-gcf/app/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/cloud-tasks-function.yaml
+++ b/.github/workflows/cloud-tasks-function.yaml
@@ -10,6 +10,8 @@ on:
     - 'cloud-tasks/tutorial-gcf/function/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'cloud-tasks/tutorial-gcf/function/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/cloud-tasks.yaml
+++ b/.github/workflows/cloud-tasks.yaml
@@ -10,6 +10,8 @@ on:
     - 'cloud-tasks/snippets/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'cloud-tasks/snippets/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/cloudbuild.yaml
+++ b/.github/workflows/cloudbuild.yaml
@@ -10,6 +10,8 @@ on:
     - 'cloudbuild/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'cloudbuild/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/composer-functions-composer-storage-trigger.yaml
+++ b/.github/workflows/composer-functions-composer-storage-trigger.yaml
@@ -10,6 +10,8 @@ on:
     - 'composer/functions/composer-storage-trigger/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'composer/functions/composer-storage-trigger/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -10,6 +10,8 @@ on:
     - 'composer/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'composer/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/contact-center-insights.yaml
+++ b/.github/workflows/contact-center-insights.yaml
@@ -10,6 +10,8 @@ on:
     - 'contact-center-insights/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'contact-center-insights/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/container-analysis-snippets.yaml
+++ b/.github/workflows/container-analysis-snippets.yaml
@@ -10,6 +10,8 @@ on:
     - 'container-analysis/snippets/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'container-analysis/snippets/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/containerengine-hello-world.yaml
+++ b/.github/workflows/containerengine-hello-world.yaml
@@ -10,6 +10,8 @@ on:
     - 'containerengine/hello-world/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'containerengine/hello-world/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/datacatalog-cloud-client.yaml
+++ b/.github/workflows/datacatalog-cloud-client.yaml
@@ -10,6 +10,8 @@ on:
     - 'datacatalog/cloud-client/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'datacatalog/cloud-client/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/datacatalog-quickstart.yaml
+++ b/.github/workflows/datacatalog-quickstart.yaml
@@ -10,6 +10,8 @@ on:
     - 'datacatalog/quickstart/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'datacatalog/quickstart/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/datalabeling.yaml
+++ b/.github/workflows/datalabeling.yaml
@@ -10,6 +10,8 @@ on:
       - "datalabeling/**"
   pull_request_target:
     types: [labeled]
+    paths:
+      - "datalabeling/**"
   schedule:
     - cron: "0 0 * * 0"
 jobs:

--- a/.github/workflows/datastore-functions.yaml
+++ b/.github/workflows/datastore-functions.yaml
@@ -10,6 +10,8 @@ on:
     - 'datastore/functions/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'datastore/functions/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/endpoints-getting-started-grpc.yaml
+++ b/.github/workflows/endpoints-getting-started-grpc.yaml
@@ -10,6 +10,8 @@ on:
     - 'endpoints/getting-started-grpc/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'endpoints/getting-started-grpc/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/endpoints-getting-started.yaml
+++ b/.github/workflows/endpoints-getting-started.yaml
@@ -10,6 +10,8 @@ on:
     - 'endpoints/getting-started/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'endpoints/getting-started/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/error-reporting.yaml
+++ b/.github/workflows/error-reporting.yaml
@@ -10,6 +10,8 @@ on:
       - "error-reporting/**"
   pull_request_target:
     types: [labeled]
+    paths:
+      - "error-reporting/**"
   schedule:
     - cron: "0 0 * * 0"
 jobs:

--- a/.github/workflows/functions-concepts.yaml
+++ b/.github/workflows/functions-concepts.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/concepts/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/concepts/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-firebase.yaml
+++ b/.github/workflows/functions-firebase.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/firebase/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/firebase/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-helloworld.yaml
+++ b/.github/workflows/functions-helloworld.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/helloworld/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/helloworld/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-http.yaml
+++ b/.github/workflows/functions-http.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/http/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/http/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-log.yaml
+++ b/.github/workflows/functions-log.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/log/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/log/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-memorystore.yaml
+++ b/.github/workflows/functions-memorystore.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/memorystore/redis/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/memorystore/redis/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-pubsub.yaml
+++ b/.github/workflows/functions-pubsub.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/pubsub/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/pubsub/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-scheduleinstance.yaml
+++ b/.github/workflows/functions-scheduleinstance.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/scheduleinstance/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/scheduleinstance/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-security.yaml
+++ b/.github/workflows/functions-security.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/security/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/security/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/slack/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/slack/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-spanner.yaml
+++ b/.github/workflows/functions-spanner.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/spanner/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/spanner/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-speech-to-speech-functions.yaml
+++ b/.github/workflows/functions-speech-to-speech-functions.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/speech-to-speech/functions/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/speech-to-speech/functions/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-tips.yaml
+++ b/.github/workflows/functions-tips.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/tips/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/tips/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-autolabelinstance.yaml
+++ b/.github/workflows/functions-v2-autolabelinstance.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/autoLabelInstance/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/autoLabelInstance/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-cloudeventlogging.yaml
+++ b/.github/workflows/functions-v2-cloudeventlogging.yaml
@@ -12,6 +12,8 @@ on:
     - 'functions/v2/cloudEventLogging/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/cloudEventLogging/**'
 jobs:
   test:
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}

--- a/.github/workflows/functions-v2-helloauditlog.yaml
+++ b/.github/workflows/functions-v2-helloauditlog.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/helloAuditLog/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/helloAuditLog/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-hellobigquery.yaml
+++ b/.github/workflows/functions-v2-hellobigquery.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/helloBigQuery/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/helloBigQuery/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-hellogcs.yaml
+++ b/.github/workflows/functions-v2-hellogcs.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/helloGCS/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/helloGCS/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-hellopubsub.yaml
+++ b/.github/workflows/functions-v2-hellopubsub.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/helloPubSub/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/helloPubSub/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-httplogging.yaml
+++ b/.github/workflows/functions-v2-httplogging.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/httpLogging/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/httpLogging/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/functions-v2-imagemagick.yaml
+++ b/.github/workflows/functions-v2-imagemagick.yaml
@@ -10,6 +10,8 @@ on:
     - 'functions/v2/imagemagick/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'functions/v2/imagemagick/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/healthcare-datasets.yaml
+++ b/.github/workflows/healthcare-datasets.yaml
@@ -10,6 +10,8 @@ on:
     - 'healthcare/datasets/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'healthcare/datasets/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/healthcare-dicom.yaml
+++ b/.github/workflows/healthcare-dicom.yaml
@@ -10,6 +10,8 @@ on:
     - 'healthcare/dicom/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'healthcare/dicom/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/healthcare-fhir.yaml
+++ b/.github/workflows/healthcare-fhir.yaml
@@ -10,6 +10,8 @@ on:
     - 'healthcare/fhir/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'healthcare/fhir/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/healthcare-hl7v2.yaml
+++ b/.github/workflows/healthcare-hl7v2.yaml
@@ -10,6 +10,8 @@ on:
     - 'healthcare/hl7v2/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'healthcare/hl7v2/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/mediatranslation.yaml
+++ b/.github/workflows/mediatranslation.yaml
@@ -10,6 +10,8 @@ on:
     - 'mediatranslation/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'mediatranslation/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/monitoring-opencensus.yaml
+++ b/.github/workflows/monitoring-opencensus.yaml
@@ -10,6 +10,8 @@ on:
     - 'monitoring/opencensus/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'monitoring/opencensus/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/monitoring-prometheus.yaml
+++ b/.github/workflows/monitoring-prometheus.yaml
@@ -10,6 +10,8 @@ on:
     - 'monitoring/prometheus/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'monitoring/prometheus/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/monitoring-snippets.yaml
+++ b/.github/workflows/monitoring-snippets.yaml
@@ -10,6 +10,8 @@ on:
     - 'monitoring/snippets/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'monitoring/snippets/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/opencensus.yaml
+++ b/.github/workflows/opencensus.yaml
@@ -10,6 +10,8 @@ on:
     - 'opencensus/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'opencensus/**'
   schedule:
   - cron:  '0 2 * * *'
 jobs:

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -10,6 +10,8 @@ on:
     - 'scheduler/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'scheduler/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/speech.yaml
+++ b/.github/workflows/speech.yaml
@@ -10,6 +10,8 @@ on:
     - 'speech/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'speech/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/talent.yaml
+++ b/.github/workflows/talent.yaml
@@ -10,6 +10,8 @@ on:
     - 'talent/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'talent/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -10,6 +10,8 @@ on:
     - 'translate/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'translate/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/video-intelligence.yaml
+++ b/.github/workflows/video-intelligence.yaml
@@ -10,6 +10,8 @@ on:
     - 'video-intelligence/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'video-intelligence/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -10,6 +10,8 @@ on:
     - 'workflows/**'
   pull_request_target:
     types: [labeled]
+    paths:
+    - 'workflows/**'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:


### PR DESCRIPTION
Based on [this change](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/commit/424670437acf41a840f71efe5b6404e25dcc658d).

Script used:
```
from os import walk

root_path = "~/nodejs-docs-samples/.github/workflows"

# Get files
files = []
for (dirpath, dirnames, filenames) in walk(root_path):
    files.extend(filenames)
    break

files = [root_path + "/" + fx for fx in files]

# Update files
for fx in files:
    lines = []
    rewrite = False

    with open(fx, "r") as f:
        lines = f.readlines()
        strip_lines = [l.strip() for l in lines]
        text = "\n".join(lines)
 
        if 'pull_request_target:' not in strip_lines:
            continue
        elif 'pull_request:' not in strip_lines:
            continue

        inject_idx = strip_lines.index('types: [labeled]')
        if inject_idx < 0:
            continue

        path_idx = strip_lines.index('paths:')
        if path_idx < 0:
            print("MISSING PATH: ", fx)
            continue

        path = lines[path_idx + 1].strip()
        if text.count(path) == 3:
            continue  # Already has all required paths

        rewrite = True
        lines.insert(inject_idx + 1, lines[path_idx + 1])
        lines.insert(inject_idx + 1, lines[path_idx])

    if rewrite:
        with open(fx, "w") as f:
            f.writelines(lines)

```