### PR TITLE
ci: Cleanup dependencies

### DIFF
--- a/appengine/endpoints/package.json
+++ b/appengine/endpoints/package.json
@@ -19,14 +19,14 @@
     "test": "npm run unit-test"
   },
   "dependencies": {
-    "chai": "^4.2.0",
-    "express": "^4.16.4",
-    "wait-port": "^0.3.0"
+    "express": "^4.16.4"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "mocha": "^9.0.0",
     "proxyquire": "^2.1.0",
     "sinon": "^14.0.0",
-    "supertest": "^6.0.0"
+    "supertest": "^6.0.0",
+    "wait-port": "^0.3.0"
   }
 }

--- a/appengine/typescript/package.json
+++ b/appengine/typescript/package.json
@@ -19,7 +19,6 @@
     "deploy": "gcloud app deploy"
   },
   "dependencies": {
-    "@types/node": "^14.14.7",
     "express": "^4.16.3",
     "typescript": "^4.0.0"
   },
@@ -27,6 +26,7 @@
     "mocha": "^9.0.0",
     "wait-port": "^0.3.0",
     "@types/express": "^4.16.0",
+    "@types/node": "^14.14.7",
     "chai": "^4.2.0",
     "tslint": "^6.0.0",
     "typescript": "^4.0.0"

--- a/asset/snippets/package.json
+++ b/asset/snippets/package.json
@@ -19,11 +19,11 @@
     "@google-cloud/bigquery": "^6.0.0",
     "@google-cloud/compute": "^3.0.0",
     "@google-cloud/storage": "^6.0.0",
-    "uuid": "^9.0.0",
     "yargs": "^16.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/cloud-language/package.json
+++ b/cloud-language/package.json
@@ -15,13 +15,13 @@
     "test": "mocha --timeout 60000"
   },
   "dependencies": {
-    "@google-cloud/automl": "^3.0.0",
     "mathjs": "^11.0.0",
     "@google-cloud/language": "^5.1.0",
     "@google-cloud/storage": "^6.0.0",
     "yargs": "^16.0.0"
   },
   "devDependencies": {
+    "@google-cloud/automl": "^3.0.0",
     "chai": "^4.2.0",
     "mocha": "^8.0.0",
     "uuid": "^9.0.0"

--- a/cloud-sql/mysql/mysql/package.json
+++ b/cloud-sql/mysql/mysql/package.json
@@ -22,7 +22,6 @@
     "@google-cloud/secret-manager": "^4.0.0",
     "express": "^4.17.1",
     "promise-mysql": "^5.0.0",
-    "prompt": "^1.0.0",
     "pug": "^3.0.0",
     "winston": "^3.1.0"
   },

--- a/cloud-sql/sqlserver/mssql/package.json
+++ b/cloud-sql/sqlserver/mssql/package.json
@@ -21,7 +21,6 @@
     "@google-cloud/secret-manager": "^4.0.0",
     "express": "^4.17.1",
     "mssql": "^8.0.0",
-    "prompt": "^1.0.0",
     "pug": "^3.0.0",
     "winston": "^3.1.0"
   },

--- a/container/snippets/package.json
+++ b/container/snippets/package.json
@@ -14,11 +14,11 @@
     "test": "mocha system-test --timeout 1000000"
   },
   "dependencies": {
-    "@google-cloud/container": "^4.4.0",
-    "uuid": "^9.0.0"
+    "@google-cloud/container": "^4.4.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/datacatalog/snippets/package.json
+++ b/datacatalog/snippets/package.json
@@ -16,12 +16,12 @@
   },
   "dependencies": {
     "@google-cloud/bigquery": "^6.0.0",
-    "@google-cloud/datacatalog": "^3.1.0",
-    "uuid": "^9.0.0"
+    "@google-cloud/datacatalog": "^3.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "execa": "^5.0.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/dialogflow-cx/package.json
+++ b/dialogflow-cx/package.json
@@ -13,12 +13,12 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/dialogflow-cx": "^3.1.2",
-    "uuid": "^9.0.0"
+    "@google-cloud/dialogflow-cx": "^3.1.2"
   },
   "devDependencies": {
     "c8": "^7.3.0",
     "chai": "^4.2.0",
-    "mocha": "^8.1.1"
+    "mocha": "^8.1.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/dialogflow/package.json
+++ b/dialogflow/package.json
@@ -17,11 +17,12 @@
   "dependencies": {
     "@google-cloud/dialogflow": "^5.3.0",
     "pb-util": "^1.0.0",
-    "uuid": "^9.0.0",
     "yargs": "^16.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "uuid": "^9.0.0"
+
   }
 }

--- a/document-ai/package.json
+++ b/document-ai/package.json
@@ -15,11 +15,11 @@
   "dependencies": {
     "@google-cloud/documentai": "^6.1.0",
     "@google-cloud/storage": "^6.0.0",
-    "p-queue": "^6.6.2",
-    "uuid": "^9.0.0"
+    "p-queue": "^6.6.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/healthcare/datasets/package.json
+++ b/healthcare/datasets/package.json
@@ -12,11 +12,11 @@
     "test": "mocha system-test/*.test.js --timeout=60000"
   },
   "devDependencies": {
-    "mocha": "^9.0.0"
-  },
-  "dependencies": {
-    "@googleapis/healthcare": "^4.0.0",
+    "mocha": "^9.0.0",
     "mocha-test": "^2.0.4",
     "uuid": "^8.0.0"
+  },
+  "dependencies": {
+    "@googleapis/healthcare": "^4.0.0"
   }
 }

--- a/healthcare/dicom/package.json
+++ b/healthcare/dicom/package.json
@@ -14,10 +14,10 @@
   "devDependencies": {
     "@google-cloud/pubsub": "^3.0.0",
     "@google-cloud/storage": "^6.0.0",
-    "mocha": "^9.0.0"
+    "mocha": "^9.0.0",
+    "uuid": "^8.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^4.0.0",
-    "uuid": "^8.0.0"
+    "@googleapis/healthcare": "^4.0.0"
   }
 }

--- a/healthcare/fhir/package.json
+++ b/healthcare/fhir/package.json
@@ -14,10 +14,10 @@
   "devDependencies": {
     "@google-cloud/pubsub": "^3.0.0",
     "@google-cloud/storage": "^6.0.0",
-    "mocha": "^9.0.0"
+    "mocha": "^9.0.0",
+    "uuid": "^8.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^4.0.0",
-    "uuid": "^8.0.0"
+    "@googleapis/healthcare": "^4.0.0"
   }
 }

--- a/healthcare/hl7v2/package.json
+++ b/healthcare/hl7v2/package.json
@@ -13,10 +13,10 @@
   },
   "devDependencies": {
     "@google-cloud/pubsub": "^3.0.0",
-    "mocha": "^9.0.0"
+    "mocha": "^9.0.0",
+    "uuid": "^8.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^4.0.0",
-    "uuid": "^8.0.0"
+    "@googleapis/healthcare": "^4.0.0"
   }
 }

--- a/kms/package.json
+++ b/kms/package.json
@@ -15,8 +15,7 @@
   },
   "dependencies": {
     "@google-cloud/kms": "^3.1.0",
-    "fast-crc32c": "^2.0.0",
-    "jslint": "^0.12.1"
+    "fast-crc32c": "^2.0.0"
   },
   "devDependencies": {
     "c8": "^7.0.0",

--- a/monitoring/prometheus/package.json
+++ b/monitoring/prometheus/package.json
@@ -11,12 +11,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "express": "^4.17.1",
-    "node-stopwatch": "^0.0.1",
     "prom-client": "^14.0.0",
-    "sleep": "^6.3.0",
-    "supertest": "^6.1.3"
+    "sleep": "^6.3.0"
   },
   "devDependencies": {
-    "mocha": "^9.0.0"
+    "mocha": "^9.0.0",
+    "supertest": "^6.1.3"
+
   }
 }

--- a/service-directory/snippets/package.json
+++ b/service-directory/snippets/package.json
@@ -13,14 +13,12 @@
     "test": "c8 mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/service-directory": "^4.0.4",
-    "eslint": "^7.0.0",
-    "json-schema": "^0.4.0",
-    "uuid": "^9.0.0"
+    "@google-cloud/service-directory": "^4.0.4"
   },
   "devDependencies": {
     "c8": "^7.0.0",
     "chai": "^4.2.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/talent/package.json
+++ b/talent/package.json
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@google-cloud/talent": "^5.0.0",
-    "uuid": "^9.0.0",
     "yargs": "^16.0.3"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.0.0",
     "chai": "^4.2.0",
-    "mocha": "^8.1.3"
+    "mocha": "^8.1.3",
+    "uuid": "^9.0.0"
   }
 }


### PR DESCRIPTION
#2901 contains a dependency update for `eslint`. This is being included unnecessarily. CI is currently running `npm run lint` with pre-installed lint dependencies on the Docker image.

This PR:
* Removes any unused dependencies. Confirmed with inspecting code, running tests, and using `depcheck`.
* Moves any dependencies that are only used for tests our of `dependencies` into `devDependencies`.