### PR TITLE
test: update older node versions to 12

### DIFF
--- a/.kokoro/appengine/node10/common.cfg
+++ b/.kokoro/appengine/node10/common.cfg
@@ -18,5 +18,5 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-user"
 }

--- a/.kokoro/run/websockets.cfg
+++ b/.kokoro/run/websockets.cfg
@@ -16,5 +16,5 @@ env_vars: {
 # Override common.cfg to include puppeteer
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-puppeteer"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-puppeteer"
 }

--- a/cloud-tasks/snippets/Dockerfile
+++ b/cloud-tasks/snippets/Dockerfile
@@ -1,6 +1,6 @@
-# Use the official Node.js 10 image.
+# Use the official Node.js 12 image.
 # https://hub.docker.com/_/node
-FROM node:10
+FROM node:12
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/containerengine/hello-world/Dockerfile
+++ b/containerengine/hello-world/Dockerfile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # [START all]
-FROM node:6-alpine
+FROM node:12-alpine
 EXPOSE 8080
 COPY server.js .
 CMD node server.js

--- a/run/system-package/Dockerfile
+++ b/run/system-package/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official super-lightweight Node image.
 # https://hub.docker.com/_/node
-FROM node:10-alpine
+FROM node:12-alpine
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app


### PR DESCRIPTION
There are several samples running on quite old Node.js versions. I believe that in one case, this is preventing upgrading dependencies (Puppeteer). This PR gradually upgrades these <12 dependencies up to 12. We can then upgrade further in additional PRs across the repo.