### PR TITLE
fix: deployment fails without resource requests

### DIFF
--- a/cloud-sql/postgres/knex/deployment.yaml
+++ b/cloud-sql/postgres/knex/deployment.yaml
@@ -57,6 +57,11 @@ spec:
             secretKeyRef:
               name: <YOUR-DB-SECRET>
               key: database
+        resources:  
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+            ephemeral-storage: "500Mi"
       - name: cloud-sql-proxy
         # This uses the latest version of the Cloud SQL proxy
         # It is recommended to use a specific version for production environments.


### PR DESCRIPTION
I was following this tutorial: https://cloud.google.com/sql/docs/postgres/connect-instance-kubernetes#node.js_1

I was getting an error saying: `Not enough CPU`. I added these resource request lines and the project started working.