### PR TITLE
test: use dynamic import for ESM dependency

### DIFF
--- a/document-ai/.eslintrc.yml
+++ b/document-ai/.eslintrc.yml
@@ -1,4 +1,7 @@
 ---
 rules:
   no-console: off
+  node/no-unsupported-features/es-syntax: off
   node/no-unsupported-features/node-builtins: off
+parserOptions:
+  ecmaVersion: 11

--- a/document-ai/.eslintrc.yml
+++ b/document-ai/.eslintrc.yml
@@ -1,6 +1,9 @@
 ---
 rules:
   no-console: off
+  node/no-missing-import:
+    allowModules:
+      - p-queue
   node/no-unsupported-features/es-syntax: off
   node/no-unsupported-features/node-builtins: off
 parserOptions:

--- a/document-ai/.eslintrc.yml
+++ b/document-ai/.eslintrc.yml
@@ -1,9 +1,7 @@
 ---
 rules:
   no-console: off
-  node/no-missing-import:
-    allowModules:
-      - p-queue
+  node/no-missing-import: off
   node/no-unsupported-features/es-syntax: off
   node/no-unsupported-features/node-builtins: off
 parserOptions:

--- a/document-ai/batch-process-document.js
+++ b/document-ai/batch-process-document.js
@@ -45,7 +45,7 @@ async function main(
   const client = new DocumentProcessorServiceClient();
   const storage = new Storage();
 
-  const PQueue = await import('p-queue');
+  const {default: PQueue} = await import('p-queue');
 
   async function batchProcessDocument() {
     const name = `projects/${projectId}/locations/${location}/processors/${processorId}`;
@@ -91,7 +91,7 @@ async function main(
     const [files] = await storage.bucket(gcsOutputUri).getFiles(query);
 
     // Add all asynchronous downloads to queue for execution.
-    const queue = new PQueue.default({concurrency: 15});
+    const queue = new PQueue({concurrency: 15});
     const tasks = files.map((fileInfo, index) => async () => {
       // Get the file as a buffer
       const [file] = await fileInfo.download();

--- a/document-ai/batch-process-document.js
+++ b/document-ai/batch-process-document.js
@@ -45,8 +45,8 @@ async function main(
   const client = new DocumentProcessorServiceClient();
   const storage = new Storage();
 
-  const {default: PQueue} = require('p-queue');
-
+  const PQueue = await import('p-queue');
+  
   async function batchProcessDocument() {
     const name = `projects/${projectId}/locations/${location}/processors/${processorId}`;
 

--- a/document-ai/batch-process-document.js
+++ b/document-ai/batch-process-document.js
@@ -46,7 +46,7 @@ async function main(
   const storage = new Storage();
 
   const PQueue = await import('p-queue');
-  
+
   async function batchProcessDocument() {
     const name = `projects/${projectId}/locations/${location}/processors/${processorId}`;
 
@@ -91,7 +91,7 @@ async function main(
     const [files] = await storage.bucket(gcsOutputUri).getFiles(query);
 
     // Add all asynchronous downloads to queue for execution.
-    const queue = new PQueue.default(({concurrency: 15}));
+    const queue = new PQueue.default({concurrency: 15});
     const tasks = files.map((fileInfo, index) => async () => {
       // Get the file as a buffer
       const [file] = await fileInfo.download();

--- a/document-ai/batch-process-document.js
+++ b/document-ai/batch-process-document.js
@@ -91,7 +91,7 @@ async function main(
     const [files] = await storage.bucket(gcsOutputUri).getFiles(query);
 
     // Add all asynchronous downloads to queue for execution.
-    const queue = new PQueue({concurrency: 15});
+    const queue = new PQueue.default(({concurrency: 15}));
     const tasks = files.map((fileInfo, index) => async () => {
       // Get the file as a buffer
       const [file] = await fileInfo.download();

--- a/document-ai/package.json
+++ b/document-ai/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "*.js"


### PR DESCRIPTION
The `document-ai` samples are using a dependency `p-queue`, which has moved to a pure ESM implementation. This PR aims to enable us to continue using new versions of this dependency.