### PR TITLE
chore(functions/v2): Migrate parseXML sample to gen2

### DIFF
--- a/functions/http/parseXML/index.js
+++ b/functions/http/parseXML/index.js
@@ -15,13 +15,15 @@
 'use strict';
 
 // [START functions_http_xml]
+const functions = require('@google-cloud/functions-framework');
+
 /**
  * Parses a document of type 'text/xml'
  *
  * @param {Object} req Cloud Function request context.
  * @param {Object} res Cloud Function response context.
  */
-exports.parseXML = (req, res) => {
+functions.http('parseXML', (req, res) => {
   // Convert the request to a Buffer and a string
   // Use whichever one is accepted by your XML parser
   const data = req.rawBody;
@@ -37,5 +39,5 @@ exports.parseXML = (req, res) => {
     }
     res.send(result);
   });
-};
+});
 // [END functions_http_xml]

--- a/functions/http/parseXML/package.json
+++ b/functions/http/parseXML/package.json
@@ -10,5 +10,9 @@
   },
   "engines": {
     "node": ">=12.0.0"
+  },
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.2",
+    "xml2js": "^0.4.23"
   }
 }


### PR DESCRIPTION
Tested using the following commands:

```
gcloud functions deploy $USER-http-function \
--allow-unauthenticated \
--entry-point parseXML \
--runtime nodejs16 \
--gen2 \
--trigger-http \
--source . \
--region us-central1


curl -i $(gcloud functions describe --gen2 $USER-http-function --format "value(serviceConfig.uri)")
```