### PR TITLE
chore(functions/v2): migrate CORS enabled function sample to gen2

### DIFF
--- a/functions/http/corsEnabledFunction/index.js
+++ b/functions/http/corsEnabledFunction/index.js
@@ -15,13 +15,15 @@
 'use strict';
 
 // [START functions_http_cors]
+const functions = require('@google-cloud/functions-framework');
+
 /**
  * HTTP function that supports CORS requests.
  *
  * @param {Object} req Cloud Function request context.
  * @param {Object} res Cloud Function response context.
  */
-exports.corsEnabledFunction = (req, res) => {
+functions.http('corsEnabledFunction', (req, res) => {
   // Set CORS headers for preflight requests
   // Allows GETs from any origin with the Content-Type header
   // and caches preflight response for 3600s
@@ -37,5 +39,5 @@ exports.corsEnabledFunction = (req, res) => {
   } else {
     res.send('Hello World!');
   }
-};
+});
 // [END functions_http_cors]

--- a/functions/http/corsEnabledFunction/package.json
+++ b/functions/http/corsEnabledFunction/package.json
@@ -18,5 +18,8 @@
     "mocha": "^9.0.0",
     "proxyquire": "^2.1.0",
     "sinon": "^15.0.0"
+  },
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.2"
   }
 }

--- a/functions/http/corsEnabledFunction/test/index.test.js
+++ b/functions/http/corsEnabledFunction/test/index.test.js
@@ -17,21 +17,7 @@
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const assert = require('assert');
-
-const getSample = () => {
-  const requestPromise = sinon
-    .stub()
-    .returns(new Promise(resolve => resolve('test')));
-
-  return {
-    sample: proxyquire('../', {
-      'request-promise': requestPromise,
-    }),
-    mocks: {
-      requestPromise: requestPromise,
-    },
-  };
-};
+const {getFunction} = require('@google-cloud/functions-framework/testing');
 
 const getMocks = () => {
   const req = {
@@ -75,12 +61,22 @@ const restoreConsole = function () {
 beforeEach(stubConsole);
 afterEach(restoreConsole);
 
+beforeEach(() => {
+  const requestPromise = sinon
+    .stub()
+    .returns(new Promise(resolve => resolve('test')));
+
+  proxyquire('../', {
+    'request-promise': requestPromise,
+  });
+});
+
 describe('functions_http_cors', () => {
   it('http:cors: should respond to preflight request (no auth)', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
+    const corsEnabledFunction = getFunction('corsEnabledFunction');
 
-    httpSample.sample.corsEnabledFunction(mocks.corsPreflightReq, mocks.res);
+    corsEnabledFunction(mocks.corsPreflightReq, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnceWith(204), true);
     assert.strictEqual(mocks.res.send.called, true);
@@ -88,9 +84,9 @@ describe('functions_http_cors', () => {
 
   it('http:cors: should respond to main request (no auth)', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
+    const corsEnabledFunction = getFunction('corsEnabledFunction');
 
-    httpSample.sample.corsEnabledFunction(mocks.corsMainReq, mocks.res);
+    corsEnabledFunction(mocks.corsMainReq, mocks.res);
 
     assert.strictEqual(mocks.res.send.calledOnceWith('Hello World!'), true);
   });


### PR DESCRIPTION
Migrate https://cloud.google.com/functions/docs/samples/functions-http-cors example to gen2 signature using functions framework. 

Tested, executes successfully with the command:
```
curl -m 70 -X POST https://garethgeorge-http-function-sehddnhvmq-uc.a.run.app -H "Authorization: bearer $(gcloud auth print-identity-token)" -H "Content-Type: application/json" -d '{  "name": "Hello World" }'
```