### PR TITLE
chore(functions/connectionPooling): Update connectionPool sample to use gen 2 signature

### DIFF
--- a/functions/tips/connectionPools/index.js
+++ b/functions/tips/connectionPools/index.js
@@ -20,6 +20,8 @@ const fetch = require('node-fetch');
 const http = require('http');
 const https = require('https');
 
+const functions = require('@google-cloud/functions-framework');
+
 const httpAgent = new http.Agent({keepAlive: true});
 const httpsAgent = new https.Agent({keepAlive: true});
 
@@ -29,7 +31,7 @@ const httpsAgent = new https.Agent({keepAlive: true});
  * @param {Object} req Cloud Function request context.
  * @param {Object} res Cloud Function response context.
  */
-exports.connectionPooling = async (req, res) => {
+functions.http('connectionPooling', async (req, res) => {
   try {
     // TODO(optional): replace this with your own URL.
     const url = 'https://www.example.com/';
@@ -37,12 +39,12 @@ exports.connectionPooling = async (req, res) => {
     // Select the appropriate agent to use based on the URL.
     const agent = url.includes('https') ? httpsAgent : httpAgent;
 
-    const {data} = await fetch(url, {agent});
-    const text = await data.text();
+    const fetchResponse = await fetch(url, {agent});
+    const text = await fetchResponse.text();
 
     res.status(200).send(`Data: ${text}`);
   } catch (err) {
     res.status(500).send(`Error: ${err.message}`);
   }
-};
+});
 // [END functions_tips_connection_pooling]

--- a/functions/tips/connectionPools/package.json
+++ b/functions/tips/connectionPools/package.json
@@ -12,6 +12,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.2",
     "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
Update https://cloud.google.com/functions/docs/samples/functions-tips-connection-pooling to use gen2 signature with functions framework.

Had to modify the result of fetch since I was getting an error as though data was undefined.
Used https://www.npmjs.com/package/node-fetch for reference.

Tested by:
* Running locally using functions framework
* Deploying and invoking with curl
stdout:
```
Data: <!doctype html>
<html>
<head>
    <title>Example Domain</title>

    <meta charset="utf-8" />
    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style type="text/css">
    body {
        background-color: #f0f0f2;
        margin: 0;
        padding: 0;
        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
        
    }
    div {
        width: 600px;
        margin: 5em auto;
        padding: 2em;
        background-color: #fdfdff;
        border-radius: 0.5em;
        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
    }
    a:link, a:visited {
        color: #38488f;
        text-decoration: none;
    }
    @media (max-width: 700px) {
        div {
            margin: 0 auto;
            width: auto;
        }
    }
    </style>    
</head>

<body>
<div>
    <h1>Example Domain</h1>
    <p>This domain is for use in illustrative examples in documents. You may use this
    domain in literature without prior coordination or asking for permission.</p>
    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
</div>
</body>
</html>
```