### PR TITLE
fix(run/logging): throw error if stdout is empty

### DIFF
--- a/run/logging-manual/test/system.test.js
+++ b/run/logging-manual/test/system.test.js
@@ -74,6 +74,12 @@ async function runShellCmd(cmd, opts = {}) {
     try {
       console.log('Running command:', cmd);
       const result = await exec(cmd, opts);
+      
+      // Ensure that `stdout` isn't empty
+      if (!result.stdout) {
+        throw new Error(result.stderr);
+      }
+      
       return result;
     } catch (err) {
       console.log('Shell command failed!');

--- a/run/logging-manual/test/system.test.js
+++ b/run/logging-manual/test/system.test.js
@@ -74,12 +74,12 @@ async function runShellCmd(cmd, opts = {}) {
     try {
       console.log('Running command:', cmd);
       const result = await exec(cmd, opts);
-      
+
       // Ensure that `stdout` isn't empty
       if (!result.stdout) {
         throw new Error(result.stderr);
       }
-      
+
       return result;
     } catch (err) {
       console.log('Shell command failed!');


### PR DESCRIPTION
The `run/logging-manual` sample may occasionally fail to retrieve the underlying Cloud Run service's URL ([example](https://source.cloud.google.com/results/invocations/9cb9b126-dffa-4e29-8b45-cbfd0bd59ac2/targets/github%2Fnodejs-docs-samples%2Frun%2Flogging-manual%2Frun/tests)). _(The URL read from `gcloud run services describe` appears to be the empty string.)_

I'm _guessing_ we can fix this by retrying the command if its `stdout` is empty. To ensure we log `stderr` (in case an actual error occurs) during each try, we can _raise an error_ containing the command's `stderr`.

--------
_Fixes #2915_