### PR TITLE
chore(functions/httpContent): using gen2 declarative signature

### DIFF
--- a/functions/http/httpContent/index.js
+++ b/functions/http/httpContent/index.js
@@ -16,6 +16,7 @@
 
 // [START functions_http_content]
 const escapeHtml = require('escape-html');
+const functions = require('@google-cloud/functions-framework');
 
 /**
  * Responds to an HTTP request using data from the request body parsed according
@@ -24,7 +25,7 @@ const escapeHtml = require('escape-html');
  * @param {Object} req Cloud Function request context.
  * @param {Object} res Cloud Function response context.
  */
-exports.helloContent = (req, res) => {
+functions.http('helloContent', (req, res) => {
   let name;
 
   switch (req.get('content-type')) {
@@ -50,5 +51,5 @@ exports.helloContent = (req, res) => {
   }
 
   res.status(200).send(`Hello ${escapeHtml(name || 'World')}!`);
-};
+});
 // [END functions_http_content]

--- a/functions/http/httpContent/package.json
+++ b/functions/http/httpContent/package.json
@@ -16,10 +16,10 @@
   },
   "devDependencies": {
     "mocha": "^9.0.0",
-    "proxyquire": "^2.1.0",
     "sinon": "^15.0.0"
   },
   "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.2",
     "escape-html": "^1.0.3"
   }
 }

--- a/functions/http/httpContent/test/index.test.js
+++ b/functions/http/httpContent/test/index.test.js
@@ -15,23 +15,8 @@
 'use strict';
 
 const sinon = require('sinon');
-const proxyquire = require('proxyquire').noCallThru();
 const assert = require('assert');
-
-const getSample = () => {
-  const requestPromise = sinon
-    .stub()
-    .returns(new Promise(resolve => resolve('test')));
-
-  return {
-    sample: proxyquire('../', {
-      'request-promise': requestPromise,
-    }),
-    mocks: {
-      requestPromise: requestPromise,
-    },
-  };
-};
+const {getFunction} = require('@google-cloud/functions-framework/testing');
 
 const getMocks = () => {
   const req = {
@@ -76,12 +61,14 @@ beforeEach(stubConsole);
 afterEach(restoreConsole);
 
 describe('functions_http_content', () => {
+  require('..');
+  const helloContent = getFunction('helloContent');
+
   it('http:helloContent: should handle application/json', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
     mocks.req.headers['content-type'] = 'application/json';
     mocks.req.body = {name: 'John'};
-    httpSample.sample.helloContent(mocks.req, mocks.res);
+    helloContent(mocks.req, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnce, true);
     assert.strictEqual(mocks.res.status.firstCall.args[0], 200);
@@ -91,10 +78,9 @@ describe('functions_http_content', () => {
 
   it('http:helloContent: should handle application/octet-stream', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
     mocks.req.headers['content-type'] = 'application/octet-stream';
     mocks.req.body = Buffer.from('John');
-    httpSample.sample.helloContent(mocks.req, mocks.res);
+    helloContent(mocks.req, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnce, true);
     assert.strictEqual(mocks.res.status.firstCall.args[0], 200);
@@ -104,10 +90,9 @@ describe('functions_http_content', () => {
 
   it('http:helloContent: should handle text/plain', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
     mocks.req.headers['content-type'] = 'text/plain';
     mocks.req.body = 'John';
-    httpSample.sample.helloContent(mocks.req, mocks.res);
+    helloContent(mocks.req, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnce, true);
     assert.strictEqual(mocks.res.status.firstCall.args[0], 200);
@@ -117,10 +102,9 @@ describe('functions_http_content', () => {
 
   it('http:helloContent: should handle application/x-www-form-urlencoded', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
     mocks.req.headers['content-type'] = 'application/x-www-form-urlencoded';
     mocks.req.body = {name: 'John'};
-    httpSample.sample.helloContent(mocks.req, mocks.res);
+    helloContent(mocks.req, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnce, true);
     assert.strictEqual(mocks.res.status.firstCall.args[0], 200);
@@ -130,8 +114,7 @@ describe('functions_http_content', () => {
 
   it('http:helloContent: should handle other', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
-    httpSample.sample.helloContent(mocks.req, mocks.res);
+    helloContent(mocks.req, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnce, true);
     assert.strictEqual(mocks.res.status.firstCall.args[0], 200);
@@ -141,10 +124,9 @@ describe('functions_http_content', () => {
 
   it('http:helloContent: should escape XSS', () => {
     const mocks = getMocks();
-    const httpSample = getSample();
     mocks.req.headers['content-type'] = 'text/plain';
     mocks.req.body = {name: '<script>alert(1)</script>'};
-    httpSample.sample.helloContent(mocks.req, mocks.res);
+    helloContent(mocks.req, mocks.res);
 
     assert.strictEqual(mocks.res.status.calledOnce, true);
     assert.strictEqual(mocks.res.status.firstCall.args[0], 200);


### PR DESCRIPTION
Update [HTTP request body](https://cloud.google.com/functions/docs/samples/functions-http-content) to use gen2 signature with functions framework.

