### PR TITLE
chore(functions/tips/scopeDemo): use gen2 declarative signature, add tests

### DIFF
--- a/functions/tips/scopeDemo/computations.js
+++ b/functions/tips/scopeDemo/computations.js
@@ -1,0 +1,27 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+exports.lightComputation = () => {
+  // Addition is a "simple" calculation
+  const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  return numbers.reduce((t, x) => t + x);
+};
+
+exports.heavyComputation = () => {
+  // Multiplication is "more computationally expensive" than addition
+  const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  return numbers.reduce((t, x) => t * x);
+};

--- a/functions/tips/scopeDemo/index.js
+++ b/functions/tips/scopeDemo/index.js
@@ -14,22 +14,16 @@
 
 'use strict';
 
-const lightComputation = () => {
-  const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-  return numbers.reduce((t, x) => t + x);
-};
-
-const heavyComputation = () => {
-  // Multiplication is more computationally expensive than addition
-  const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-  return numbers.reduce((t, x) => t * x);
-};
-
 // [START functions_tips_scopes]
 // [START cloudrun_tips_global_scope]
 // [START run_tips_global_scope]
+const functions = require('@google-cloud/functions-framework');
+
+// TODO(developer): Define your own computations
+const {lightComputation, heavyComputation} = require('./computations');
+
 // Global (instance-wide) scope
-// This computation runs at instance cold-start
+// This computation runs once (at instance cold-start)
 const instanceVar = heavyComputation();
 
 /**
@@ -38,13 +32,13 @@ const instanceVar = heavyComputation();
  * @param {Object} req request context.
  * @param {Object} res response context.
  */
-exports.scopeDemo = (req, res) => {
+functions.http('scopeDemo', (req, res) => {
   // Per-function scope
   // This computation runs every time this function is called
   const functionVar = lightComputation();
 
   res.send(`Per instance: ${instanceVar}, per function: ${functionVar}`);
-};
+});
 // [END run_tips_global_scope]
 // [END cloudrun_tips_global_scope]
 // [END functions_tips_scopes]

--- a/functions/tips/scopeDemo/package.json
+++ b/functions/tips/scopeDemo/package.json
@@ -10,5 +10,15 @@
   },
   "engines": {
     "node": ">=12.0.0"
+  },
+  "scripts": {
+    "test": "mocha test/*.test.js --timeout=60000"
+  },
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.2"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "sinon": "^15.0.1"
   }
 }

--- a/functions/tips/scopeDemo/test/index.test.js
+++ b/functions/tips/scopeDemo/test/index.test.js
@@ -1,0 +1,87 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('assert');
+const {getFunction} = require('@google-cloud/functions-framework/testing');
+
+const getMocks = () => {
+  const req = {
+    headers: {},
+    get: function (header) {
+      return this.headers[header];
+    },
+  };
+  sinon.spy(req, 'get');
+
+  const corsPreflightReq = {
+    method: 'OPTIONS',
+  };
+
+  const corsMainReq = {
+    method: 'GET',
+  };
+
+  return {
+    req: req,
+    corsPreflightReq: corsPreflightReq,
+    corsMainReq: corsMainReq,
+    res: {
+      set: sinon.stub().returnsThis(),
+      send: sinon.stub().returnsThis(),
+    },
+  };
+};
+
+const stubConsole = function () {
+  sinon.stub(console, 'error');
+};
+
+const restoreConsole = function () {
+  console.error.restore();
+};
+
+beforeEach(stubConsole);
+afterEach(restoreConsole);
+
+describe('functions_tips_scope_demo', () => {
+  const computations = sinon.spy(require('../computations'));
+
+  require('..');
+  const scopeDemo = getFunction('scopeDemo');
+  it('tips:scopeDemo: should perform the heavy computation once', () => {
+    const mocks = getMocks();
+
+    const numRequests = 25;
+    for (let i = 0; i < numRequests; i++) {
+      scopeDemo(mocks.req, mocks.res);
+    }
+
+    assert.strictEqual(computations.heavyComputation.calledOnce, true);
+  });
+
+  it('tips:scopeDemo: should perform the light computation repeatedly', () => {
+    const mocks = getMocks();
+    computations.lightComputation.resetHistory();
+
+    const numRequests = 25;
+    for (let i = 0; i < numRequests; i++) {
+      scopeDemo(mocks.req, mocks.res);
+    }
+
+    assert.strictEqual(computations.lightComputation.callCount, numRequests);
+  });
+});


### PR DESCRIPTION
Using gen2 declarative signature in the [Global versus function scope](https://cloud.google.com/functions/docs/samples/functions-tips-scopes) docs.

Added unit-tests. From my inspection of [.github/workflows/functions-tips.yaml](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/workflows/functions-tips.yaml), this will likely/possibly "just work". (But honestly, I'm not sure why it was "working" before -- without any tests to begin with.)