### PR TITLE
test: fix skipped datacatalog test

### DIFF
--- a/datacatalog/snippets/searchAssets.js
+++ b/datacatalog/snippets/searchAssets.js
@@ -29,7 +29,7 @@ async function main(projectId) {
     // const projectId = 'my_project'; // Google Cloud Platform project
 
     // Set custom query.
-    const query = 'type=dataset';
+    const query = 'type=lake';
 
     // Create request.
     const scope = {

--- a/datacatalog/snippets/test/samples.test.js
+++ b/datacatalog/snippets/test/samples.test.js
@@ -146,7 +146,7 @@ describe('Samples', async () => {
     assert.include(output, memberId);
   });
 
-  it.skip('should search data assets in project', async () => {
+  it('should search data assets in project', async () => {
     const output = execSync(`node searchAssets ${projectId}`);
     assert.match(output, /Found [0-9]+ datasets in project/);
   });


### PR DESCRIPTION
The search assets query can timeout due to a large number of `dataset` assets being searched. The fix in `java-docs-samples` was to use an asset type with a much smaller number of assets: `lake`.

This PR updates the sample asset type, and enables the test. 

Fixes #2884 