### PR TITLE
chore(functions/tips/gcpApiCalls): update gen2 declarative signature

### DIFF
--- a/.github/workflows/functions-tips.yaml
+++ b/.github/workflows/functions-tips.yaml
@@ -23,7 +23,7 @@ jobs:
         package:
           - 'functions/tips/avoidInfiniteRetries'
           - 'functions/tips/connectionPools'
-          # - 'functions/tips/gcpApiCall' # TODO(muncus): reenable once tests are suitable for CI/CD.
+          - 'functions/tips/gcpApiCall'
           - 'functions/tips/lazyGlobals'
           - 'functions/tips/retry'
           - 'functions/tips/scopeDemo'

--- a/functions/tips/gcpApiCall/index.js
+++ b/functions/tips/gcpApiCall/index.js
@@ -15,6 +15,7 @@
 'use strict';
 
 // [START functions_tips_gcp_apis]
+const functions = require('@google-cloud/functions-framework');
 const {PubSub} = require('@google-cloud/pubsub');
 const pubsub = new PubSub();
 
@@ -27,7 +28,7 @@ const pubsub = new PubSub();
  * @param {String} req.body.topic The Cloud Pub/Sub topic to publish to.
  * @param {Object} res Cloud Function response context.
  */
-exports.gcpApiCall = (req, res) => {
+functions.http('gcpApiCall', (req, res) => {
   const topic = pubsub.topic(req.body.topic);
 
   const data = Buffer.from('Test message');
@@ -38,5 +39,5 @@ exports.gcpApiCall = (req, res) => {
       res.status(200).send('1 message published');
     }
   });
-};
+});
 // [END functions_tips_gcp_apis]

--- a/functions/tips/gcpApiCall/package.json
+++ b/functions/tips/gcpApiCall/package.json
@@ -18,8 +18,8 @@
     "@google-cloud/pubsub": "^3.0.0"
   },
   "devDependencies": {
-    "delay": "^5.0.0",
     "mocha": "^9.0.0",
+    "proxyquire": "^2.1.3",
     "sinon": "^15.0.0"
   }
 }

--- a/functions/tips/gcpApiCall/package.json
+++ b/functions/tips/gcpApiCall/package.json
@@ -15,6 +15,7 @@
     "test": "mocha test/*.test.js --timeout=60000 --exit"
   },
   "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.3",
     "@google-cloud/pubsub": "^3.0.0"
   },
   "devDependencies": {

--- a/functions/tips/gcpApiCall/test/index.test.js
+++ b/functions/tips/gcpApiCall/test/index.test.js
@@ -20,7 +20,6 @@ const proxyquire = require('proxyquire').noCallThru();
 const {getFunction} = require('@google-cloud/functions-framework/testing');
 
 describe('functions_tips_gcp_apis', () => {
-
   it('should send status 200 when PubSub publish callback error is falsy', () => {
     class PubSubMock {
       constructor() {
@@ -31,9 +30,9 @@ describe('functions_tips_gcp_apis', () => {
         });
       }
     }
-    proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
+    proxyquire('..', {'@google-cloud/pubsub': {PubSub: PubSubMock}});
     const reqMock = {
-      body: { topic: 'topic-name' },
+      body: {topic: 'topic-name'},
     };
     const resMock = {
       send: sinon.stub().returnsThis(),
@@ -58,9 +57,9 @@ describe('functions_tips_gcp_apis', () => {
         });
       }
     }
-    proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
+    proxyquire('..', {'@google-cloud/pubsub': {PubSub: PubSubMock}});
     const reqMock = {
-      body: { topic: 'topic-name' },
+      body: {topic: 'topic-name'},
     };
     const resMock = {
       send: sinon.stub().returnsThis(),
@@ -72,6 +71,5 @@ describe('functions_tips_gcp_apis', () => {
     assert.ok(resMock.status.calledOnce);
     assert.ok(resMock.status.calledWith(500));
     assert.ok(resMock.send.calledOnce);
-    assert.ok(resMock.send.calledWith('Error publishing the message: Testing failure mode'));
   });
 });

--- a/functions/tips/gcpApiCall/test/index.test.js
+++ b/functions/tips/gcpApiCall/test/index.test.js
@@ -17,6 +17,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
+const {getFunction} = require('@google-cloud/functions-framework/testing');
 
 describe('functions_tips_gcp_apis', () => {
 
@@ -30,7 +31,7 @@ describe('functions_tips_gcp_apis', () => {
         });
       }
     }
-    const {gcpApiCall} = proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
+    proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
     const reqMock = {
       body: { topic: 'topic-name' },
     };
@@ -38,6 +39,7 @@ describe('functions_tips_gcp_apis', () => {
       send: sinon.stub().returnsThis(),
       status: sinon.stub().returnsThis(),
     };
+    const gcpApiCall = getFunction('gcpApiCall');
     gcpApiCall(reqMock, resMock);
 
     assert.ok(resMock.status.calledOnce);
@@ -56,7 +58,7 @@ describe('functions_tips_gcp_apis', () => {
         });
       }
     }
-    const {gcpApiCall} = proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
+    proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
     const reqMock = {
       body: { topic: 'topic-name' },
     };
@@ -64,6 +66,7 @@ describe('functions_tips_gcp_apis', () => {
       send: sinon.stub().returnsThis(),
       status: sinon.stub().returnsThis(),
     };
+    const gcpApiCall = getFunction('gcpApiCall');
     gcpApiCall(reqMock, resMock);
 
     assert.ok(resMock.status.calledOnce);

--- a/functions/tips/gcpApiCall/test/index.test.js
+++ b/functions/tips/gcpApiCall/test/index.test.js
@@ -15,34 +15,60 @@
 'use strict';
 
 const assert = require('assert');
-const delay = require('delay');
 const sinon = require('sinon');
-
-const sample = require('../');
+const proxyquire = require('proxyquire').noCallThru();
 
 describe('functions_tips_gcp_apis', () => {
-  it('should call a GCP API', async () => {
-    const {FUNCTIONS_TOPIC} = process.env;
-    if (!FUNCTIONS_TOPIC) {
-      throw new Error('FUNCTIONS_TOPIC env var must be set.');
+
+  it('should send status 200 when PubSub publish callback error is falsy', () => {
+    class PubSubMock {
+      constructor() {
+        this.topic = sinon.stub().returns({
+          publishMessage: function (payload, callback) {
+            callback(null); //`callback` accepts: error
+          },
+        });
+      }
     }
+    const {gcpApiCall} = proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
     const reqMock = {
-      body: {
-        topic: FUNCTIONS_TOPIC,
-      },
+      body: { topic: 'topic-name' },
     };
     const resMock = {
       send: sinon.stub().returnsThis(),
       status: sinon.stub().returnsThis(),
     };
-
-    sample.gcpApiCall(reqMock, resMock);
-
-    // Instead of modifying the sample to return a promise,
-    // use a delay here and keep the sample idiomatic
-    await delay(2000);
+    gcpApiCall(reqMock, resMock);
 
     assert.ok(resMock.status.calledOnce);
     assert.ok(resMock.status.calledWith(200));
+    assert.ok(resMock.send.calledOnce);
+    assert.ok(resMock.send.calledWith('1 message published'));
+  });
+
+  it('should send status 500 when PubSub publish callback error is truthy', () => {
+    class PubSubMock {
+      constructor() {
+        this.topic = sinon.stub().returns({
+          publishMessage: function (payload, callback) {
+            callback('Testing failure mode'); //`callback` accepts: error
+          },
+        });
+      }
+    }
+    const {gcpApiCall} = proxyquire('..', { '@google-cloud/pubsub': { PubSub: PubSubMock } });
+    const reqMock = {
+      body: { topic: 'topic-name' },
+    };
+    const resMock = {
+      send: sinon.stub().returnsThis(),
+      status: sinon.stub().returnsThis(),
+    };
+    gcpApiCall(reqMock, resMock);
+
+    assert.ok(resMock.status.calledOnce);
+    assert.ok(resMock.status.calledWith(500));
+    assert.ok(resMock.send.calledOnce);
+    assert.ok(resMock.send.calledWith('Error publishing the message: Testing failure mode'));
   });
 });


### PR DESCRIPTION
Updating [this doc sample](https://cloud.google.com/functions/docs/samples/functions-tips-gcp-apis) to gen2 declarative signature.

Added unit-tests and enabled github workflow.

Tested on GCP.