### PR TITLE
ci: test auto-label configuration

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -1,0 +1,15 @@
+path:
+  pullrequest: true
+  labelprefix: "api: "
+  paths:
+    # i.e., label all PRs of files in root directory and down as "root"
+    ai-platform:
+      .: "aiplatform"
+    appengine:
+      .: "appengine"
+    asset:
+      .: "cloudasset"
+    run:
+      .: "run"
+    vision:
+      .: "vision"


### PR DESCRIPTION
Adding a handful of initial services to test auto-labeling in this monorepo. This will fill out missing metadata and improve visibility in our internal dashboard.

If this is successful, we can expand the configuration. I just picked 5 services including one that should apply to an open PR for testing.

For more info, see:
https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-label
