### PR TITLE
chore(functions/concepts): Migrate afterResponse sample to gen2

### DIFF
--- a/functions/concepts/afterResponse/index.js
+++ b/functions/concepts/afterResponse/index.js
@@ -15,6 +15,8 @@
 'use strict';
 
 // [START functions_concepts_after_response]
+const functions = require('@google-cloud/functions-framework');
+
 /**
  * HTTP Cloud Function that may not completely
  * execute due to early HTTP response
@@ -22,10 +24,10 @@
  * @param {Object} req Cloud Function request context.
  * @param {Object} res Cloud Function response context.
  */
-exports.afterResponse = (req, res) => {
+functions.http('afterResponse', (req, res) => {
   res.end();
 
   // This statement may not execute
   console.log('Function complete!');
-};
+});
 // [END functions_concepts_after_response]

--- a/functions/concepts/afterResponse/package.json
+++ b/functions/concepts/afterResponse/package.json
@@ -10,5 +10,8 @@
   },
   "engines": {
     "node": ">=12.0.0"
+  },
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.3"
   }
 }


### PR DESCRIPTION
Updated afterResponse sample using gen2 signature. 
Successfully tested on GCP.