### PR TITLE
Fix datastore/functions test timing out

### DIFF
--- a/datastore/functions/package.json
+++ b/datastore/functions/package.json
@@ -14,8 +14,7 @@
     "test": "mocha test/*.test.js --timeout=5000"
   },
   "dependencies": {
-    "@google-cloud/datastore": "^7.0.0",
-    "is-reachable": "^5.0.0"
+    "@google-cloud/datastore": "^7.0.0"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^3.0.0",
@@ -24,6 +23,7 @@
     "node-fetch": "^2.6.1",
     "proxyquire": "^2.1.0",
     "sinon": "^15.0.0",
-    "uuid": "^8.0.0"
+    "uuid": "^8.0.0",
+    "wait-port": "^1.0.4"
   }
 }

--- a/datastore/functions/test/index.test.js
+++ b/datastore/functions/test/index.test.js
@@ -20,7 +20,7 @@ const path = require('path');
 const uuid = require('uuid');
 const sinon = require('sinon');
 const fetch = require('node-fetch');
-const isReachable = require('is-reachable');
+const waitPort = require('wait-port');
 const {Datastore} = require('@google-cloud/datastore');
 
 const datastore = new Datastore();
@@ -49,16 +49,7 @@ const handleLinuxFailures = async proc => {
   }
 };
 
-// Wait for the HTTP server to start listening
-const waitForReady = async baseUrl => {
-  let ready = false;
-  while (!ready) {
-    await new Promise(r => setTimeout(r, 500));
-    ready = await isReachable(baseUrl);
-  }
-};
-
-describe.skip('functions/datastore', () => {
+describe('functions/datastore', () => {
   describe('set', () => {
     let ffProc;
     const PORT = 8080;
@@ -69,7 +60,7 @@ describe.skip('functions/datastore', () => {
         `functions-framework --target=set --signature-type=http --port=${PORT}`,
         {timeout: FF_TIMEOUT, shell: true, cwd}
       );
-      await waitForReady(BASE_URL);
+      await waitPort({port: PORT});
     });
 
     after(async () => {
@@ -150,7 +141,7 @@ describe.skip('functions/datastore', () => {
         `functions-framework --target=get --signature-type=http --port=${PORT}`,
         {timeout: FF_TIMEOUT, shell: true, cwd}
       );
-      await waitForReady(BASE_URL);
+      await waitPort({port: PORT});
     });
 
     after(async () => {
@@ -236,7 +227,7 @@ describe.skip('functions/datastore', () => {
         `functions-framework --target=del --signature-type=http --port=${PORT}`,
         {timeout: FF_TIMEOUT, shell: true, cwd}
       );
-      await waitForReady(BASE_URL);
+      await waitPort({port: PORT});
     });
 
     after(async () => {


### PR DESCRIPTION
Fixes #2755 + reverts #2761

This swaps a homebrew `waitForReady` function (that was continuously stalling) with the `wait-port` NPM module.