### PR TITLE
ci: Add header checker

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+allowedCopyrightHolders:
+  - 'Google LLC'
+  - 'Google, Inc'
+allowedLicenses:
+  - 'Apache-2.0'
+  - 'MIT'
+  - 'BSD-3'
+sourceFileExtensions:
+  - 'ts'
+  - 'js'
+  - 'html'
+  - 'yaml'
+  - 'yml'
+  - 'sh'
+ignoreFiles:
+  - "packages/*/webpack.config.js"
+  - "packages/*/__snapshots__/**/*.js"
+  - "packages/typeless-sample-bot/test/fixtures/**/*.ts"
+  - "packages/typeless-sample-bot/test/fixtures/**/*.js"

--- a/.github/workflows/ci.yaml.njk
+++ b/.github/workflows/ci.yaml.njk
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: {{name}}
 on:
   push:


### PR DESCRIPTION
Adds the [License Header bot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint) configuration based on [Google Cloud Node](https://github.com/googleapis/google-cloud-node/blob/main/.github/header-checker-lint.yml) and [Python Docs Samples](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/header-checker-lint.yml).

Also, added a header to the workflow generation template, so new workflows are compliant. We can address adding missing headers as we go or in a separate PR.