### PR TITLE
chore: Set ignore year flag in header check

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -31,3 +31,4 @@ ignoreFiles:
   - "packages/*/__snapshots__/**/*.js"
   - "packages/typeless-sample-bot/test/fixtures/**/*.ts"
   - "packages/typeless-sample-bot/test/fixtures/**/*.js"
+ignoreLicenseYear: true


### PR DESCRIPTION
We are still doing migrations, and this setting is unnecessarily flagging valid files. This setting matches the current setting in python-docs-samples.