### PR TITLE
Re-enable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "extends": [
-    "config:base",
-    ":disableDependencyDashboard"
+    "config:base"
   ],
+  "dependencyDashboardAutoclose": true,  
   "pinVersions": false,
   "rebaseStalePrs": false
 }


### PR DESCRIPTION
Re-enable dependency dashboard (at least temporarily), to provide visibility into outstanding updates.

Also enabled setting to auto-close the dashboard when there are no open PRs.