### PR TITLE
fix: delete test DLP jobs created in snippets

### DIFF
--- a/dlp/categoricalRiskAnalysis.js
+++ b/dlp/categoricalRiskAnalysis.js
@@ -98,6 +98,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    console.log(`Job created. Job name: ${jobName}`)
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/categoricalRiskAnalysis.js
+++ b/dlp/categoricalRiskAnalysis.js
@@ -98,7 +98,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
-    console.log(`Job created. Job name: ${jobName}`)
+    console.log(`Job created. Job name: ${jobName}`);
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/kAnonymityAnalysis.js
+++ b/dlp/kAnonymityAnalysis.js
@@ -96,7 +96,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
-    console.log(`Job created. Job name: ${jobName}`)
+    console.log(`Job created. Job name: ${jobName}`);
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/kAnonymityAnalysis.js
+++ b/dlp/kAnonymityAnalysis.js
@@ -96,6 +96,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    console.log(`Job created. Job name: ${jobName}`)
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/kMapEstimationAnalysis.js
+++ b/dlp/kMapEstimationAnalysis.js
@@ -103,6 +103,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    console.log(`Job created. Job name: ${jobName}`)
 
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {

--- a/dlp/kMapEstimationAnalysis.js
+++ b/dlp/kMapEstimationAnalysis.js
@@ -103,7 +103,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
-    console.log(`Job created. Job name: ${jobName}`)
+    console.log(`Job created. Job name: ${jobName}`);
 
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {

--- a/dlp/lDiversityAnalysis.js
+++ b/dlp/lDiversityAnalysis.js
@@ -103,7 +103,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
-    console.log(`Job created. Job name: ${jobName}`)
+    console.log(`Job created. Job name: ${jobName}`);
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/lDiversityAnalysis.js
+++ b/dlp/lDiversityAnalysis.js
@@ -103,6 +103,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    console.log(`Job created. Job name: ${jobName}`)
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/numericalRiskAnalysis.js
+++ b/dlp/numericalRiskAnalysis.js
@@ -100,7 +100,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
-    console.log(`Job created. Job name: ${jobName}`)
+    console.log(`Job created. Job name: ${jobName}`);
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/numericalRiskAnalysis.js
+++ b/dlp/numericalRiskAnalysis.js
@@ -100,6 +100,7 @@ function main(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    console.log(`Job created. Job name: ${jobName}`)
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -22,8 +22,8 @@ const pubsub = new PubSub();
 const uuid = require('uuid');
 const DLP = require('@google-cloud/dlp');
 
-const bucket = 'nodejs-docs-samples-dlp';
-const dataProject = 'nodejs-docs-samples';
+const bucket = 'nodejs-dlp-test-bucket';
+const dataProject = 'long-door-651';
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
@@ -192,8 +192,6 @@ describe('inspect', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // inspect_datastore
@@ -225,8 +223,6 @@ describe('inspect', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // inspect_bigquery
@@ -258,8 +254,6 @@ describe('inspect', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // CLI options

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -54,14 +54,14 @@ describe('inspect', () => {
       name: jobName,
     };
 
-    dlp
-        .deleteDlpJob(request)
-        .then(() => {
-          console.log(`Successfully deleted job ${jobName}.`);
-        })
-        .catch(err => {
-          throw (`Error in deleteJob: ${err.message || err}`);
-        });
+    client
+      .deleteDlpJob(request)
+      .then(() => {
+        console.log(`Successfully deleted job ${jobName}.`);
+      })
+      .catch(err => {
+        throw `Error in deleteJob: ${err.message || err}`;
+      });
   });
 
   // inspect_string

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -159,7 +159,7 @@ describe('inspect', () => {
     );
     assert.match(output, /Found \d instance\(s\) of infoType PHONE_NUMBER/);
     assert.match(output, /Found \d instance\(s\) of infoType EMAIL_ADDRESS/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -169,7 +169,7 @@ describe('inspect', () => {
     );
     assert.match(output, /Found \d instance\(s\) of infoType PHONE_NUMBER/);
     assert.match(output, /Found \d instance\(s\) of infoType EMAIL_ADDRESS/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -178,7 +178,7 @@ describe('inspect', () => {
       `node inspectGCSFile.js ${projectId} ${bucket} harmless.txt ${topicName} ${subscriptionName}`
     );
     assert.match(output, /No findings/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -192,7 +192,7 @@ describe('inspect', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -202,7 +202,7 @@ describe('inspect', () => {
       `node inspectDatastore.js ${projectId} Person ${topicName} ${subscriptionName} --namespaceId DLP -p ${dataProject}`
     );
     assert.match(output, /Found \d instance\(s\) of infoType EMAIL_ADDRESS/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -211,7 +211,7 @@ describe('inspect', () => {
       `node inspectDatastore.js ${projectId} Harmless ${topicName} ${subscriptionName} --namespaceId DLP -p ${dataProject}`
     );
     assert.match(output, /No findings/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -225,7 +225,7 @@ describe('inspect', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -235,7 +235,7 @@ describe('inspect', () => {
       `node inspectBigQuery.js ${projectId} integration_tests_dlp harmful ${topicName} ${subscriptionName} -p ${dataProject}`
     );
     assert.match(output, /Found \d instance\(s\) of infoType PHONE_NUMBER/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -244,7 +244,7 @@ describe('inspect', () => {
       `node inspectBigQuery.js ${projectId} integration_tests_dlp harmless ${topicName} ${subscriptionName} -p ${dataProject}`
     );
     assert.match(output, /No findings/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -258,7 +258,7 @@ describe('inspect', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 

--- a/dlp/system-test/risk.test.js
+++ b/dlp/system-test/risk.test.js
@@ -107,7 +107,7 @@ describe('risk', () => {
     );
     assert.match(output, /Value at 0% quantile:/);
     assert.match(output, /Value at \d+% quantile:/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -121,7 +121,7 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'NOT_FOUND');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -131,7 +131,7 @@ describe('risk', () => {
       `node categoricalRiskAnalysis.js ${projectId} ${projectId} ${dataset} harmful ${uniqueField} ${topicName} ${subscriptionName}`
     );
     assert.match(output, /Most common value occurs \d time\(s\)/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -140,7 +140,7 @@ describe('risk', () => {
       `node categoricalRiskAnalysis.js ${projectId} ${projectId} ${dataset} harmful ${numericField} ${topicName} ${subscriptionName}`
     );
     assert.match(output, /Most common value occurs \d time\(s\)/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -154,7 +154,7 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -166,7 +166,7 @@ describe('risk', () => {
     console.log(output);
     assert.include(output, 'Quasi-ID values:');
     assert.include(output, 'Class size:');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -180,7 +180,7 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -192,7 +192,7 @@ describe('risk', () => {
     assert.match(output, /Anonymity range: \[\d+, \d+\]/);
     assert.match(output, /Size: \d/);
     assert.match(output, /Values: \d{2}/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -206,7 +206,7 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -217,7 +217,7 @@ describe('risk', () => {
         `node kMapEstimationAnalysis.js ${projectId} ${projectId} ${dataset} harmful ${topicName} ${subscriptionName} 'US' 'Age,Gender' AGE`
       );
     }, /3 INVALID_ARGUMENT: InfoType name cannot be empty of a TaggedField/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -229,7 +229,7 @@ describe('risk', () => {
     assert.match(output, /Quasi-ID values:/);
     assert.match(output, /Class size: \d/);
     assert.match(output, /Sensitive value/);
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 
@@ -243,7 +243,7 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, 'Job created. Job name: ');
+    assert.match(output, /Job created. Job name: /);
     jobName = output.split(':')[1].trim();
   });
 });

--- a/dlp/system-test/risk.test.js
+++ b/dlp/system-test/risk.test.js
@@ -90,14 +90,14 @@ describe('risk', () => {
       name: jobName,
     };
 
-    dlp
-        .deleteDlpJob(request)
-        .then(() => {
-          console.log(`Successfully deleted job ${jobName}.`);
-        })
-        .catch(err => {
-          throw (`Error in deleteJob: ${err.message || err}`);
-        });
+    client
+      .deleteDlpJob(request)
+      .then(() => {
+        console.log(`Successfully deleted job ${jobName}.`);
+      })
+      .catch(err => {
+        throw `Error in deleteJob: ${err.message || err}`;
+      });
   });
 
   // numericalRiskAnalysis
@@ -211,8 +211,9 @@ describe('risk', () => {
   });
 
   it('should check that numbers of quasi-ids and info types are equal', () => {
+    let output;
     assert.throws(() => {
-      execSync(
+      output = execSync(
         `node kMapEstimationAnalysis.js ${projectId} ${projectId} ${dataset} harmful ${topicName} ${subscriptionName} 'US' 'Age,Gender' AGE`
       );
     }, /3 INVALID_ARGUMENT: InfoType name cannot be empty of a TaggedField/);

--- a/dlp/system-test/risk.test.js
+++ b/dlp/system-test/risk.test.js
@@ -121,8 +121,6 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'NOT_FOUND');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // categoricalRiskAnalysis
@@ -154,8 +152,6 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // kAnonymityAnalysis
@@ -180,8 +176,6 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // kMapAnalysis
@@ -206,8 +200,6 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   it('should check that numbers of quasi-ids and info types are equal', () => {
@@ -217,8 +209,6 @@ describe('risk', () => {
         `node kMapEstimationAnalysis.js ${projectId} ${projectId} ${dataset} harmful ${topicName} ${subscriptionName} 'US' 'Age,Gender' AGE`
       );
     }, /3 INVALID_ARGUMENT: InfoType name cannot be empty of a TaggedField/);
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 
   // lDiversityAnalysis
@@ -243,7 +233,5 @@ describe('risk', () => {
       output = err.message;
     }
     assert.include(output, 'fail');
-    assert.match(output, /Job created. Job name: /);
-    jobName = output.split(':')[1].trim();
   });
 });

--- a/dlp/system-test/risk.test.js
+++ b/dlp/system-test/risk.test.js
@@ -203,9 +203,8 @@ describe('risk', () => {
   });
 
   it('should check that numbers of quasi-ids and info types are equal', () => {
-    let output;
     assert.throws(() => {
-      output = execSync(
+      execSync(
         `node kMapEstimationAnalysis.js ${projectId} ${projectId} ${dataset} harmful ${topicName} ${subscriptionName} 'US' 'Age,Gender' AGE`
       );
     }, /3 INVALID_ARGUMENT: InfoType name cannot be empty of a TaggedField/);


### PR DESCRIPTION
Few DLP jobs were undeleted in snippets hence causing resource leakage in the projects. Fixed the issue by deleting the jobs in tests.