### PR TITLE
Fix: unsupported yaml network argument

### DIFF
--- a/memorystore/redis/gae_flex_deployment/app.yaml
+++ b/memorystore/redis/gae_flex_deployment/app.yaml
@@ -20,6 +20,6 @@ env_variables:
   REDISPORT: '6379'
 
 # Update with Redis instance network name
-network:
+vpc_access_connector:
   name: default
 # [END memorystore_app_yaml_flex]


### PR DESCRIPTION
Possible fix to `ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Network parameter is not supported in App Engine Standard. Please, use vpc_access_connector instead.`