### PR TITLE
fix: add back gcp-build script

### DIFF
--- a/appengine/typescript/package.json
+++ b/appengine/typescript/package.json
@@ -9,8 +9,8 @@
     "node": "16.x.x"
   },
   "scripts": {
-    "prepare": "npm run compile",
-    "pretest": "npm run compile",
+    "prepare": "npm run gcp-build",
+    "pretest": "npm run gcp-build",
     "test": "mocha test/*.test.js --exit",
     "lint": "gts lint",
     "start": "node ./index.js",
@@ -18,7 +18,8 @@
     "clean": "gts clean",
     "compile": "tsc -p .",
     "fix": "gts fix",
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "gcp-build": "tsc -p ."
   },
   "dependencies": {
     "express": "^4.16.3"


### PR DESCRIPTION
Adds script removed in #3029 that is referenced by: https://cloud.google.com/appengine/docs/standard/nodejs/running-custom-build-step#example