### PR TITLE
DLP: Added sample for inspect string with omitting custom matches

### DIFF
--- a/dlp/inspectStringCustomOmitOverlap.js
+++ b/dlp/inspectStringCustomOmitOverlap.js
@@ -1,0 +1,112 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspect a string for sensitive data, omitting custom matches.
+//  usage: node inspectStringCustomOmitOverlap.js my-project string
+
+function main(projectId, string) {
+  // [START dlp_inspect_string_custom_omit_overlap]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to inspect
+  // const string = 'Name: Jane Doe. Name: Larry Page.';
+
+  async function inspectStringCustomOmitOverlap() {
+    // Construct item to inspect
+    const item = {value: string};
+
+    // Construct a custom regex detector for names
+    const customInfoTypes = [
+      {
+        infoType: {name: 'VIP_DETECTOR'},
+        regex: {pattern: 'Larry Page|Sergey Brin'},
+        exclusionType:
+          DLP.protos.google.privacy.dlp.v2.CustomInfoType.ExclusionType
+            .EXCLUSION_TYPE_EXCLUDE,
+      },
+    ];
+
+    // Construct a exclusion rule
+    const exclusionRule = {
+      excludeInfoTypes: {
+        infoTypes: [{name: 'VIP_DETECTOR'}],
+      },
+      matchingType:
+        DLP.protos.google.privacy.dlp.v2.MatchingType.MATCHING_TYPE_FULL_MATCH,
+    };
+
+    // Construct a rule set that will only match if the match text does not
+    // contains Info type matches.
+    const ruleSet = [
+      {
+        infoTypes: [{name: 'PERSON_NAME'}],
+        rules: [
+          {
+            exclusionRule: exclusionRule,
+          },
+        ],
+      },
+    ];
+
+    // Construct the inspect configuration
+    const inspectConfig = {
+      infoTypes: [{name: 'PERSON_NAME'}],
+      customInfoTypes: customInfoTypes,
+      ruleSet: ruleSet,
+      includeQuote: true,
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Run request
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectStringCustomOmitOverlap();
+  // [END dlp_inspect_string_custom_omit_overlap]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/inspectStringCustomOmitOverlap.js
+++ b/dlp/inspectStringCustomOmitOverlap.js
@@ -17,7 +17,6 @@
 // sample-metadata:
 //  title: Inspect a string for sensitive data, omitting custom matches.
 //  usage: node inspectStringCustomOmitOverlap.js my-project string
-
 function main(projectId, string) {
   // [START dlp_inspect_string_custom_omit_overlap]
   // Imports the Google Cloud Data Loss Prevention library

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -413,4 +413,25 @@ describe('inspect', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_inspect_string_custom_omit_overlap
+  it('should omit overlapping findings between custom match and Person Name', () => {
+    const output = execSync(
+      `node inspectStringCustomOmitOverlap.js ${projectId} "Name: Jane Doe. Name: Larry Page."`
+    );
+    assert.match(output, /Quote: Jane Doe/);
+    assert.notMatch(output, /Quote: Larry Page/);
+  });
+
+  it('should report any errors while inspecting a string', () => {
+    let output;
+    try {
+      output = execSync(
+        'node inspectStringCustomOmitOverlap.js BAD_PROJECT_ID "Name: Jane Doe. Name: Larry Page."'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
## Description
Reference:- https://cloud.google.com/dlp/docs/creating-custom-infotypes-rules#omit_scan_matches_from_a_person_name_detector_scan_that_overlap_with_a_custom_detector

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
