### PR TITLE
DLP: Added sample for redact image with info types

### DIFF
--- a/dlp/redactImageFileListedInfoTypes.js
+++ b/dlp/redactImageFileListedInfoTypes.js
@@ -1,0 +1,89 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// sample-metadata:
+//  title: Redact Image with info types
+//  description: Redact sensitive data from an image with certain info types only.
+//  usage: node redactImageFileListedInfoTypes.js my-project filepath infoTypes outputPath
+function main(projectId, filepath, infoTypes, outputPath) {
+  infoTypes = transformCLI(infoTypes);
+  // [START dlp_redact_image_listed_infotypes]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Imports required Node.js libraries
+  const mime = require('mime');
+  const fs = require('fs');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The path to a local file to inspect. Can be a JPG or PNG image file.
+  // const filepath = 'path/to/image.png';
+
+  // The infoTypes of information to redact
+  // const infoTypes = [{ name: 'EMAIL_ADDRESS' }, { name: 'PHONE_NUMBER' }];
+
+  // The local path to save the resulting image to.
+  // const outputPath = 'result.png';
+
+  async function redactImageWithInfoTypes() {
+    // Load image
+    const fileTypeConstant =
+      ['image/jpeg', 'image/bmp', 'image/png', 'image/svg'].indexOf(
+        mime.getType(filepath)
+      ) + 1;
+    const fileBytes = Buffer.from(fs.readFileSync(filepath)).toString('base64');
+
+    // Construct image redaction request
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      byteItem: {
+        type: fileTypeConstant,
+        data: fileBytes,
+      },
+      inspectConfig: {
+        infoTypes: infoTypes,
+      },
+      imageRedactionConfigs: infoTypes.map(infoType => ({infoType: infoType})),
+    };
+
+    // Run image redaction request
+    const [response] = await dlp.redactImage(request);
+    const image = response.redactedImage;
+    fs.writeFileSync(outputPath, image);
+    console.log(`Saved image redaction results to path: ${outputPath}`);
+  }
+  redactImageWithInfoTypes();
+  // [END dlp_redact_image_listed_infotypes]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));
+
+function transformCLI(infoTypes) {
+  infoTypes = infoTypes
+    ? infoTypes.split(',').map(type => {
+        return {name: type};
+      })
+    : undefined;
+  return infoTypes;
+}

--- a/dlp/system-test/redact.test.js
+++ b/dlp/system-test/redact.test.js
@@ -132,4 +132,31 @@ describe('redact', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_redact_image_listed_infotypes
+  it('should redact sensitive data type from an image', async () => {
+    const testName = 'redact-multiple-types';
+    const output = execSync(
+      `node redactImageFileListedInfoTypes.js ${projectId} ${testImage} "PHONE_NUMBER,EMAIL_ADDRESS" ${testName}.actual.png`
+    );
+    assert.match(output, /Saved image redaction results to path/);
+    const difference = await getImageDiffPercentage(
+      `${testName}.actual.png`,
+      `${testResourcePath}/${testName}.expected.png`
+    );
+    assert.isBelow(difference, 0.1);
+  });
+
+  it('should report info type errors', () => {
+    const testName = 'redact-multiple-type';
+    let output;
+    try {
+      output = execSync(
+        `node redactImageFileListedInfoTypes.js ${projectId} ${testImage} BAD_TYPE ${testName}.actual.png`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added sample for redact image with info types
Added unit test cases for same

Reference:- https://cloud.google.com/dlp/docs/redacting-sensitive-data-images#dlp-redact-image-listed-infotypes-java

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
