### PR TITLE
DLP: Added sample for deidentify table using conditional logic

### DIFF
--- a/dlp/deIdentifyTableConditionInfoTypes.js
+++ b/dlp/deIdentifyTableConditionInfoTypes.js
@@ -69,10 +69,10 @@ function main(projectId) {
   };
 
   async function deIdentifyTableConditionalInfoType() {
-    // Column that needs to be transformed
+    // Specify fields to be de-identified.
     const fieldIds = [{name: 'PATIENT'}, {name: 'FACTOID'}];
 
-    // Contruct InfoTypeTransformations configurations
+    // Associate info type with the replacement strategy
     const infoTypeTransformations = {
       transformations: [
         {
@@ -84,7 +84,7 @@ function main(projectId) {
       ],
     };
 
-    // Construct condition
+    // Specify when the above fields should be de-identified.
     const condition = {
       expressions: {
         conditions: {
@@ -99,7 +99,7 @@ function main(projectId) {
       },
     };
 
-    // Contruct RecordTransformations configurations
+    // Apply the condition to records.
     const recordTransformations = {
       fieldTransformations: [
         {
@@ -120,10 +120,10 @@ function main(projectId) {
         recordTransformations,
       },
     };
-    // Send the request and receive response from the service
+    // Send the request and receive response from the service.
     const [response] = await dlp.deidentifyContent(request);
 
-    // Print the results
+    // Print the results.
     console.log(
       `Table after de-identification: ${JSON.stringify(response.item.table)}`
     );

--- a/dlp/deIdentifyTableConditionInfoTypes.js
+++ b/dlp/deIdentifyTableConditionInfoTypes.js
@@ -1,0 +1,141 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify table data using conditional logic
+//  description: Redact PERSON_NAME findings when specific conditions are met.
+//  usage: node deIdentifyTableConditionInfoTypes.js my-project
+function main(projectId) {
+  // [START dlp_deidentify_table_condition_infotypes]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Initialize google DLP Client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // Construct the tabular data
+  const tablularData = {
+    headers: [
+      {name: 'AGE'},
+      {name: 'PATIENT'},
+      {name: 'HAPPINESS SCORE'},
+      {name: 'FACTOID'},
+    ],
+    rows: [
+      {
+        values: [
+          {integerValue: 101},
+          {stringValue: 'Charles Dickens'},
+          {integerValue: 95},
+          {
+            stringValue:
+              'Charles Dickens name was a curse invented by Shakespeare.',
+          },
+        ],
+      },
+      {
+        values: [
+          {integerValue: 22},
+          {stringValue: 'Jane Austen'},
+          {integerValue: 21},
+          {stringValue: "There are 14 kisses in Jane Austen's novels."},
+        ],
+      },
+      {
+        values: [
+          {integerValue: 55},
+          {stringValue: 'Mark Twain'},
+          {integerValue: 75},
+          {stringValue: 'Mark Twain loved cats.'},
+        ],
+      },
+    ],
+  };
+
+  async function deIdentifyTableConditionalInfoType() {
+    // Column that needs to be transformed
+    const fieldIds = [{name: 'PATIENT'}, {name: 'FACTOID'}];
+
+    // Contruct InfoTypeTransformations configurations
+    const infoTypeTransformations = {
+      transformations: [
+        {
+          infoTypes: [{name: 'PERSON_NAME'}],
+          primitiveTransformation: {
+            replaceWithInfoTypeConfig: {},
+          },
+        },
+      ],
+    };
+
+    // Construct condition
+    const condition = {
+      expressions: {
+        conditions: {
+          conditions: [
+            {
+              field: {name: 'AGE'},
+              operator: 'GREATER_THAN',
+              value: {integerValue: 89},
+            },
+          ],
+        },
+      },
+    };
+
+    // Contruct RecordTransformations configurations
+    const recordTransformations = {
+      fieldTransformations: [
+        {
+          infoTypeTransformations,
+          fields: fieldIds,
+          condition: condition,
+        },
+      ],
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      item: {
+        table: tablularData,
+      },
+      deidentifyConfig: {
+        recordTransformations,
+      },
+    };
+    // Send the request and receive response from the service
+    const [response] = await dlp.deidentifyContent(request);
+
+    // Print the results
+    console.log(
+      `Table after de-identification: ${JSON.stringify(response.item.table)}`
+    );
+  }
+
+  deIdentifyTableConditionalInfoType();
+  // [END dlp_deidentify_table_condition_infotypes]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -260,4 +260,31 @@ describe('deid', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_deidentify_table_condition_infotypes
+  it('should redact PERSON_NAME findings when conditions are met', () => {
+    let output;
+    try {
+      output = execSync(
+        `node deIdentifyTableConditionInfoTypes.js ${projectId}`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.notInclude(output, 'Charles Dickens');
+    assert.include(output, 'Jane Austen');
+    assert.include(output, 'Mark Twain');
+  });
+
+  it('should handle deidentification errors', () => {
+    let output;
+    try {
+      output = execSync(
+        'node deIdentifyTableConditionInfoTypes.js BAD_PROJECT_ID'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added sample for deidentify table using conditional logic
Added unit test cases for same

## Description

Reference:- https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_findings_only_when_specific_conditions_are_met_on_another_field

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
