### PR TITLE
chore: update timeout for gae websocket test

### DIFF
--- a/appengine/websockets/package.json
+++ b/appengine/websockets/package.json
@@ -6,22 +6,22 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": "16.x.x"
+    "node": ">=16.x.x"
   },
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "test": "mocha --exit test/*.test.js",
+    "test": "mocha --timeout 10000 --exit test/*.test.js",
     "e2e-test": "samples test deploy"
   },
   "dependencies": {
     "express": "^4.15.4",
     "pug": "^3.0.0",
-    "socket.io": "^4.0.0",
+    "socket.io": "^4.6.1",
     "supertest": "^6.0.0"
   },
   "devDependencies": {
     "mocha": "^10.0.0",
-    "puppeteer": "^19.0.0"
+    "puppeteer": "^19.7.2"
   }
 }


### PR DESCRIPTION
## Description

Fixes #3152

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
