### PR TITLE
DLP: Added sample for inspect string with exclusion dict

### DIFF
--- a/dlp/inspectStringWithExclusionDict.js
+++ b/dlp/inspectStringWithExclusionDict.js
@@ -1,0 +1,127 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspects strings omit overlapping.
+//  description: Inspect a string for sensitive data excluding a list of words.
+//  usage: node inspectStringWithExclusionDict.js my-project string infoTypes excludedWords
+
+function main(projectId, string, infoTypes, excludedWords) {
+  [infoTypes, excludedWords] = transformCLI(infoTypes, excludedWords);
+  // [START dlp_inspect_string_with_exclusion_dict]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to inspect
+  // const string = 'Some email addresses: gary@example.com, example@example.com';
+
+  // The infoTypes of information to match
+  // const infoTypes = [{ name: 'EMAIL_ADDRESS' }];
+
+  // Words to exclude
+  // const excludedWords = ['gary@example.com'];
+
+  async function inspectStringWithExclusionDict() {
+    // Specify the type and content to be inspected.
+    const item = {
+      byteItem: {
+        type: DLP.protos.google.privacy.dlp.v2.ByteContentItem.BytesType
+          .TEXT_UTF8,
+        data: Buffer.from(string, 'utf-8'),
+      },
+    };
+
+    // Exclude matches from the specified excludedWords.
+    const exclusionRule = {
+      dictionary: {
+        wordList: {
+          words: excludedWords,
+        },
+      },
+      matchingType:
+        DLP.protos.google.privacy.dlp.v2.MatchingType.MATCHING_TYPE_FULL_MATCH,
+    };
+
+    // Construct a ruleset that applies the exclusion rule to the specified infotype.
+    const ruleSet = [
+      {
+        infoTypes: infoTypes,
+        rules: [
+          {
+            exclusionRule: exclusionRule,
+          },
+        ],
+      },
+    ];
+
+    // Construct the configuration for the Inspect request, including the ruleset.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      ruleSet: ruleSet,
+      includeQuote: true,
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectStringWithExclusionDict();
+  // [END dlp_inspect_string_with_exclusion_dict]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));
+
+function transformCLI(infoTypes, excludedWords) {
+  infoTypes = infoTypes
+    ? infoTypes.split(',').map(type => {
+        return {name: type};
+      })
+    : undefined;
+
+  excludedWords = excludedWords ? excludedWords.split(',') : [];
+
+  return [infoTypes, excludedWords];
+}

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -478,4 +478,25 @@ describe('inspect', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_inspect_string_with_exclusion_dict
+  it('should inspect using exclusion word list', () => {
+    const output = execSync(
+      `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" EMAIL_ADDRESS "gary@example.com"`
+    );
+    assert.notMatch(output, /Quote: gary@example.com/);
+    assert.match(output, /Quote: example@example.com/);
+  });
+
+  it('should report any errors while inspecting a string', () => {
+    let output;
+    try {
+      output = execSync(
+        `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" BAD_TYPE "gary@example.com"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -482,17 +482,17 @@ describe('inspect', () => {
   // dlp_inspect_string_with_exclusion_dict
   it('should inspect using exclusion word list', () => {
     const output = execSync(
-      `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" EMAIL_ADDRESS "example@example.com"`
+      `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" EMAIL_ADDRESS "gary@example.com"`
     );
-    assert.match(output, /Quote: gary@example.com/);
-    assert.notMatch(output, /Quote: example@example.com/);
+    assert.notMatch(output, /Quote: gary@example.com/);
+    assert.match(output, /Quote: example@example.com/);
   });
 
   it('should report any errors while inspecting a string', () => {
     let output;
     try {
       output = execSync(
-        `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" BAD_TYPE "example@example.com"`
+        `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" BAD_TYPE "gary@example.com"`
       );
     } catch (err) {
       output = err.message;

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -482,17 +482,17 @@ describe('inspect', () => {
   // dlp_inspect_string_with_exclusion_dict
   it('should inspect using exclusion word list', () => {
     const output = execSync(
-      `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" EMAIL_ADDRESS "gary@example.com"`
+      `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" EMAIL_ADDRESS "example@example.com"`
     );
-    assert.notMatch(output, /Quote: gary@example.com/);
-    assert.match(output, /Quote: example@example.com/);
+    assert.match(output, /Quote: gary@example.com/);
+    assert.notMatch(output, /Quote: example@example.com/);
   });
 
   it('should report any errors while inspecting a string', () => {
     let output;
     try {
       output = execSync(
-        `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" BAD_TYPE "gary@example.com"`
+        `node inspectStringWithExclusionDict.js ${projectId} "Some email addresses: gary@example.com, example@example.com" BAD_TYPE "example@example.com"`
       );
     } catch (err) {
       output = err.message;


### PR DESCRIPTION
Added test cases for same

## Description

Reference:- https://cloud.google.com/dlp/docs/creating-custom-infotypes-rules#omit_specific_email_address_from_email_address_detector_scan

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
