### PR TITLE
DLP: Added sample for de-identify with table bucketing

### DIFF
--- a/dlp/deIdentifyTableBucketing.js
+++ b/dlp/deIdentifyTableBucketing.js
@@ -1,0 +1,114 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify data using table bucketing
+//  description: Transforms specified field using table bucketing.
+//  usage: node deIdentifyTableBucketing.js my-project
+
+function main(projectId) {
+  // [START dlp_deidentify_table_bucketing]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Initialize google DLP Client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // Construct the tabular data
+  const tablularData = {
+    headers: [{name: 'AGE'}, {name: 'PATIENT'}, {name: 'HAPPINESS SCORE'}],
+    rows: [
+      {
+        values: [
+          {integerValue: 101},
+          {stringValue: 'Charles Dickens'},
+          {integerValue: 95},
+        ],
+      },
+      {
+        values: [
+          {integerValue: 22},
+          {stringValue: 'Jane Austen'},
+          {integerValue: 21},
+        ],
+      },
+      {
+        values: [
+          {integerValue: 55},
+          {stringValue: 'Mark Twain'},
+          {integerValue: 75},
+        ],
+      },
+    ],
+  };
+  async function deIdentifyTableBucketing() {
+    // Specify field to be de-identified.
+    const targetColumn = {name: 'HAPPINESS SCORE'};
+
+    // Specify how the content should be de-identified.
+    const bucketingConfig = {
+      bucketSize: 10,
+      lowerBound: {
+        integerValue: 0,
+      },
+      upperBound: {
+        integerValue: 100,
+      },
+    };
+
+    const primitiveTransformation = {
+      fixedSizeBucketingConfig: bucketingConfig,
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      item: {
+        table: tablularData,
+      },
+      deidentifyConfig: {
+        recordTransformations: {
+          fieldTransformations: [
+            {
+              fields: [targetColumn],
+              primitiveTransformation,
+            },
+          ],
+        },
+      },
+    };
+    // Send the request and receive response from the service
+    const [response] = await dlp.deidentifyContent(request);
+
+    // Print the results.
+    console.log(
+      `Table after de-identification: ${JSON.stringify(response.item.table)}`
+    );
+  }
+
+  deIdentifyTableBucketing();
+  // [END dlp_deidentify_table_bucketing]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -310,4 +310,27 @@ describe('deid', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_deidentify_table_bucketing
+  it('should transform column HAPPINESS SCORE using table bucketing configs', () => {
+    let output;
+    try {
+      output = execSync(`node deIdentifyTableBucketing.js ${projectId}`);
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, '90:100');
+    assert.include(output, '20:30');
+    assert.include(output, '70:80');
+  });
+
+  it('should handle deidentification errors', () => {
+    let output;
+    try {
+      output = execSync('node deIdentifyTableBucketing.js BAD_PROJECT_ID');
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added sample for de-identify with table bucketing
Added unit test cases for same

## Description

Reference:- https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_a_column_without_inspection

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
