### PR TITLE
DLP: Added sample for create stored infotype

### DIFF
--- a/dlp/createStoredInfoType.js
+++ b/dlp/createStoredInfoType.js
@@ -1,0 +1,111 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+// title: Create stored infotype.
+// description: Uses the Data Loss Prevention API to create a stored infotype.
+// usage: node createStoredInfoType.js projectId  infoTypeId, outputPath, dataProjectId, datasetId, tableId, fieldName
+function main(
+  projectId,
+  infoTypeId,
+  outputPath,
+  dataProjectId,
+  datasetId,
+  tableId,
+  fieldName
+) {
+  // [START dlp_create_stored_infotype]
+  // Import the required libraries
+  const dlp = require('@google-cloud/dlp');
+
+  // Create a DLP client
+  const dlpClient = new dlp.DlpServiceClient();
+
+  // The project ID to run the API call under.
+  // const projectId = "your-project-id";
+
+  // The identifier for the stored infoType
+  // const infoTypeId = 'github-usernames';
+
+  // The path to the location in a Cloud Storage bucket to store the created dictionary
+  // const outputPath = 'cloud-bucket-path';
+
+  // The project ID the table is stored under
+  // This may or (for public datasets) may not equal the calling project ID
+  // const dataProjectId = 'my-project';
+
+  // The ID of the dataset to inspect, e.g. 'my_dataset'
+  // const datasetId = 'my_dataset';
+
+  // The ID of the table to inspect, e.g. 'my_table'
+  // const tableId = 'my_table';
+
+  // Field ID to be used for constructing dictionary
+  // const fieldName = 'field_name';
+
+  async function createStoredInfoType() {
+    // The name you want to give the dictionary.
+    const displayName = 'GitHub usernames';
+    // A description of the dictionary.
+    const description = 'Dictionary of GitHub usernames used in commits';
+
+    // Specify configuration for the large custom dictionary
+    const largeCustomDictionaryConfig = {
+      outputPath: {
+        path: outputPath,
+      },
+      bigQueryField: {
+        table: {
+          datasetId: datasetId,
+          projectId: dataProjectId,
+          tableId: tableId,
+        },
+        field: {
+          name: fieldName,
+        },
+      },
+    };
+
+    // Stored infoType configuration that uses large custom dictionary.
+    const storedInfoTypeConfig = {
+      displayName: displayName,
+      description: description,
+      largeCustomDictionary: largeCustomDictionaryConfig,
+    };
+
+    // Construct the job creation request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      config: storedInfoTypeConfig,
+      storedInfoTypeId: infoTypeId,
+    };
+
+    // Send the job creation request and process the response.
+    const [response] = await dlpClient.createStoredInfoType(request);
+
+    // Print results
+    console.log(`InfoType stored successfully: ${response.name}`);
+  }
+  createStoredInfoType();
+  // [END dlp_create_stored_infotype]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/metadata.test.js
+++ b/dlp/system-test/metadata.test.js
@@ -17,17 +17,40 @@
 const {assert} = require('chai');
 const {describe, it, before} = require('mocha');
 const cp = require('child_process');
+const uuid = require('uuid');
 const DLP = require('@google-cloud/dlp');
+
+const dataProject = 'DATA_PROJECT';
+const dataSetId = 'DATASET_ID';
+const tableId = 'TABLE_ID';
+const fieldId = 'FIELD_ID';
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const client = new DLP.DlpServiceClient();
 describe('metadata', () => {
-  let projectId;
+  let projectId, storedInfoTypeId;
 
   before(async () => {
     projectId = await client.getProjectId();
   });
+
+  // Delete stored infotypes created in the snippets.
+  afterEach(async () => {
+    if (!storedInfoTypeId) {
+      return;
+    }
+    const request = {
+      name: storedInfoTypeId,
+    };
+    try {
+      await client.deleteStoredInfoType(request);
+      storedInfoTypeId = '';
+    } catch (err) {
+      throw `Error in deleting store infoType: ${err.message || err}`;
+    }
+  });
+
   it('should list info types', () => {
     const output = execSync(`node metadata.js ${projectId} infoTypes`);
     assert.match(output, /US_DRIVERS_LICENSE_NUMBER/);
@@ -38,5 +61,30 @@ describe('metadata', () => {
       `node metadata.js ${projectId} infoTypes "supported_by=RISK_ANALYSIS"`
     );
     assert.notMatch(output, /US_DRIVERS_LICENSE_NUMBER/);
+  });
+
+  // dlp_create_stored_infotype
+  it.skip('should create a stored infotype', () => {
+    const infoTypeId = `stored-infoType-${uuid.v4()}`;
+    const infoTypeOutputPath = 'INFOTYPE_OUTPUT_PATH';
+    const output = execSync(
+      `node createStoredInfoType.js ${projectId} ${infoTypeId} ${infoTypeOutputPath} ${dataProject} ${dataSetId} ${tableId} ${fieldId}`
+    );
+    assert.match(output, /InfoType stored successfully:/);
+    storedInfoTypeId = output.split(':')[1].trim();
+  });
+
+  it.skip('should handle stored infotype creation errors', () => {
+    let output;
+    const infoTypeId = `stored-infoType-${uuid.v4()}`;
+    const infoTypeOutputPath = 'INFOTYPE_OUTPUT_PATH';
+    try {
+      output = execSync(
+        `node createStoredInfoType.js BAD_PROJECT_ID ${infoTypeId} ${infoTypeOutputPath} ${dataProject} ${dataSetId} ${tableId} ${fieldId}`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
   });
 });

--- a/dlp/system-test/metadata.test.js
+++ b/dlp/system-test/metadata.test.js
@@ -25,6 +25,8 @@ const dataSetId = 'samples';
 const tableId = 'github_nested';
 const fieldId = 'url';
 
+const bucketName = process.env.BUCKET_NAME;
+
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const client = new DLP.DlpServiceClient();
@@ -64,9 +66,9 @@ describe('metadata', () => {
   });
 
   // dlp_create_stored_infotype
-  it.skip('should create a stored infotype', () => {
+  it('should create a stored infotype', () => {
     const infoTypeId = `stored-infoType-${uuid.v4()}`;
-    const infoTypeOutputPath = 'INFOTYPE_OUTPUT_PATH';
+    const infoTypeOutputPath = bucketName;
     const output = execSync(
       `node createStoredInfoType.js ${projectId} ${infoTypeId} ${infoTypeOutputPath} ${dataProject} ${dataSetId} ${tableId} ${fieldId}`
     );
@@ -74,7 +76,7 @@ describe('metadata', () => {
     storedInfoTypeId = output.split(':')[1].trim();
   });
 
-  it.skip('should handle stored infotype creation errors', () => {
+  it('should handle stored infotype creation errors', () => {
     let output;
     const infoTypeId = `stored-infoType-${uuid.v4()}`;
     const infoTypeOutputPath = 'INFOTYPE_OUTPUT_PATH';

--- a/dlp/system-test/metadata.test.js
+++ b/dlp/system-test/metadata.test.js
@@ -20,10 +20,10 @@ const cp = require('child_process');
 const uuid = require('uuid');
 const DLP = require('@google-cloud/dlp');
 
-const dataProject = 'DATA_PROJECT';
-const dataSetId = 'DATASET_ID';
-const tableId = 'TABLE_ID';
-const fieldId = 'FIELD_ID';
+const dataProject = 'bigquery-public-data';
+const dataSetId = 'samples';
+const tableId = 'github_nested';
+const fieldId = 'url';
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 

--- a/dlp/system-test/metadata.test.js
+++ b/dlp/system-test/metadata.test.js
@@ -68,7 +68,7 @@ describe('metadata', () => {
   // dlp_create_stored_infotype
   it('should create a stored infotype', () => {
     const infoTypeId = `stored-infoType-${uuid.v4()}`;
-    const infoTypeOutputPath = bucketName;
+    const infoTypeOutputPath = `gs://${bucketName}`;
     const output = execSync(
       `node createStoredInfoType.js ${projectId} ${infoTypeId} ${infoTypeOutputPath} ${dataProject} ${dataSetId} ${tableId} ${fieldId}`
     );


### PR DESCRIPTION
DLP: Added sample for create stored infotype
Added unit test cases for the same

PS:- I have marked the test cases to skip as the required resources are not available. I have verified locally and the test cases seem to be working fine if resources are provided.

## Description

Reference:- https://cloud.google.com/dlp/docs/creating-stored-infotypes#create-storedinfotye

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
