### PR TITLE
DLP: Added sample for de-identify table with FPE

### DIFF
--- a/dlp/deIdentifyTableWithFpe.js
+++ b/dlp/deIdentifyTableWithFpe.js
@@ -1,0 +1,129 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify with FPE
+//  description: De-identify sensitive data in a string using Format Preserving Encryption (FPE).
+//  usage: node deIdentifyTableWithFpe.js my-project alphabet keyName wrappedKey
+function main(projectId, alphabet, keyName, wrappedKey) {
+  // [START dlp_deidentify_table_fpe]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The set of characters to replace sensitive ones with
+  // For more information, see https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+  // const alphabet = 'NUMERIC';
+
+  // The name of the Cloud KMS key used to encrypt ('wrap') the AES-256 key
+  // const keyName = 'projects/YOUR_GCLOUD_PROJECT/locations/YOUR_LOCATION/keyRings/YOUR_KEYRING_NAME/cryptoKeys/YOUR_KEY_NAME';
+
+  // The encrypted ('wrapped') AES-256 key to use
+  // This key should be encrypted using the Cloud KMS key specified above
+  // const wrappedKey = 'YOUR_ENCRYPTED_AES_256_KEY'
+
+  // Table to de-identify
+  const tablularData = {
+    headers: [{name: 'Employee ID'}, {name: 'Date'}, {name: 'Compensation'}],
+    rows: [
+      {
+        values: [
+          {stringValue: '11111'},
+          {stringValue: '2015'},
+          {stringValue: '$10'},
+        ],
+      },
+      {
+        values: [
+          {stringValue: '11111'},
+          {stringValue: '2016'},
+          {stringValue: '$20'},
+        ],
+      },
+      {
+        values: [
+          {stringValue: '11111'},
+          {stringValue: '2016'},
+          {stringValue: '$15'},
+        ],
+      },
+    ],
+  };
+
+  async function deidentifyTableWithFpe() {
+    // Specify field to be encrypted.
+    const fieldIds = [{name: 'Employee ID'}];
+
+    // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it
+    const cryptoKeyConfig = {
+      kmsWrapped: {
+        wrappedKey: wrappedKey,
+        cryptoKeyName: keyName,
+      },
+    };
+
+    // Specify how the content should be encrypted.
+    const cryptoReplaceFfxFpeConfig = {
+      cryptoKey: cryptoKeyConfig,
+      commonAlphabet: alphabet,
+    };
+
+    // Associate the encryption with the specified field.
+    const fieldTransformations = [
+      {
+        fields: fieldIds,
+        primitiveTransformation: {
+          cryptoReplaceFfxFpeConfig,
+        },
+      },
+    ];
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        recordTransformations: {
+          fieldTransformations,
+        },
+      },
+      item: {
+        table: tablularData,
+      },
+    };
+
+    // Send the request and receive response from the service.
+    const [response] = await dlp.deidentifyContent(request);
+
+    // Print the results.
+    console.log(
+      `Table after de-identification: ${JSON.stringify(response.item.table)}`
+    );
+  }
+  deidentifyTableWithFpe();
+  // [END dlp_deidentify_table_fpe]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/deIdentifyTableWithFpe.js
+++ b/dlp/deIdentifyTableWithFpe.js
@@ -53,14 +53,14 @@ async function main(projectId, alphabet, keyName, wrappedKey) {
       },
       {
         values: [
-          {stringValue: '11111'},
+          {stringValue: '22222'},
           {stringValue: '2016'},
           {stringValue: '$20'},
         ],
       },
       {
         values: [
-          {stringValue: '11111'},
+          {stringValue: '33333'},
           {stringValue: '2016'},
           {stringValue: '$15'},
         ],

--- a/dlp/deIdentifyTableWithFpe.js
+++ b/dlp/deIdentifyTableWithFpe.js
@@ -18,7 +18,7 @@
 //  title: De-identify with FPE
 //  description: De-identify sensitive data in a string using Format Preserving Encryption (FPE).
 //  usage: node deIdentifyTableWithFpe.js my-project alphabet keyName wrappedKey
-function main(projectId, alphabet, keyName, wrappedKey) {
+async function main(projectId, alphabet, keyName, wrappedKey) {
   // [START dlp_deidentify_table_fpe]
   // Imports the Google Cloud Data Loss Prevention library
   const DLP = require('@google-cloud/dlp');
@@ -117,7 +117,7 @@ function main(projectId, alphabet, keyName, wrappedKey) {
       `Table after de-identification: ${JSON.stringify(response.item.table)}`
     );
   }
-  deidentifyTableWithFpe();
+  await deidentifyTableWithFpe();
   // [END dlp_deidentify_table_fpe]
 }
 
@@ -126,4 +126,7 @@ process.on('unhandledRejection', err => {
   process.exitCode = 1;
 });
 
-main(...process.argv.slice(2));
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -388,7 +388,7 @@ describe('deid', () => {
     );
     sinon.replace(console, 'log', () => sinon.stub());
 
-    const deIdentifyTableWithFpe = proxyquire('../deidentifyTableWithFpe', {
+    const deIdentifyTableWithFpe = proxyquire('../deIdentifyTableWithFpe', {
       '@google-cloud/dlp': {DLP: DLP},
     });
 
@@ -409,7 +409,7 @@ describe('deid', () => {
     );
     sinon.replace(console, 'log', () => sinon.stub());
 
-    const deIdentifyTableWithFpe = proxyquire('../deidentifyTableWithFpe', {
+    const deIdentifyTableWithFpe = proxyquire('../deIdentifyTableWithFpe', {
       '@google-cloud/dlp': {DLP: DLP},
     });
 

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -30,6 +30,8 @@ const csvFile = 'resources/dates.csv';
 const tempOutputFile = path.join(__dirname, 'temp.result.csv');
 const dateShiftAmount = 30;
 const dateFields = 'birth_date,register_date';
+const keyName = 'KEY_NAME';
+const wrappedKey = 'WRAPPED_KEY';
 
 const client = new DLP.DlpServiceClient();
 describe('deid', () => {
@@ -356,5 +358,30 @@ describe('deid', () => {
       output = err.message;
     }
     assert.include(output, 'INVALID_ARGUMENT');
+  });
+
+  // dlp_deidentify_table_fpe
+  it.skip('should de-identify table using Format Preserving Encryption (FPE)', () => {
+    let output;
+    try {
+      output = execSync(
+        `node deIdentifyTableWithFpe.js ${projectId} NUMERIC "${keyName}" "${wrappedKey}"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.notMatch(output, /"stringValue":"11111"/);
+  });
+
+  it.skip('should handle de-identification errors', () => {
+    let output;
+    try {
+      output = execSync(
+        `node deIdentifyTableWithFpe.js ${projectId} NUMERIC "BAD_KEY_NAME" "BAD_KEY_NAME NUMERIC"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'invalid encoding');
   });
 });

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -85,6 +85,67 @@ const MOCK_DATA = {
       nack: sinon.stub(),
     },
   }),
+  DEIDENTIFY_TABLE_WITH_FPE: (
+    projectId,
+    alphabet,
+    keyName,
+    wrappedKey
+  ) => ({
+    REQUEST_DEIDENTIFY_CONTENT: {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        recordTransformations: {
+          fieldTransformations: [
+            {
+              fields: [{name: 'Employee ID'}],
+              primitiveTransformation: {
+                cryptoReplaceFfxFpeConfig: {
+                  cryptoKey: {
+                    kmsWrapped: {
+                      wrappedKey: wrappedKey,
+                      cryptoKeyName: keyName,
+                    },
+                  },
+                  commonAlphabet: alphabet,
+                },
+              },
+            },
+          ],
+        },
+      },
+      item: {
+        table: {
+          headers: [{name: 'Employee ID'}, {name: 'Date'}, {name: 'Compensation'}],
+          rows: [
+            {
+              values: [
+                {stringValue: '11111'},
+                {stringValue: '2015'},
+                {stringValue: '$10'},
+              ],
+            },
+            {
+              values: [
+                {stringValue: '11111'},
+                {stringValue: '2016'},
+                {stringValue: '$20'},
+              ],
+            },
+            {
+              values: [
+                {stringValue: '11111'},
+                {stringValue: '2016'},
+                {stringValue: '$15'},
+              ],
+            },
+          ],
+        },
+      },
+    },
+    RESPONSE_DEIDENTIFY_CONTENT: [{item: {
+      table: {}
+    }}],
+  }),
 };
 
 module.exports = {MOCK_DATA};

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -85,12 +85,7 @@ const MOCK_DATA = {
       nack: sinon.stub(),
     },
   }),
-  DEIDENTIFY_TABLE_WITH_FPE: (
-    projectId,
-    alphabet,
-    keyName,
-    wrappedKey
-  ) => ({
+  DEIDENTIFY_TABLE_WITH_FPE: (projectId, alphabet, keyName, wrappedKey) => ({
     REQUEST_DEIDENTIFY_CONTENT: {
       parent: `projects/${projectId}/locations/global`,
       deidentifyConfig: {
@@ -115,7 +110,11 @@ const MOCK_DATA = {
       },
       item: {
         table: {
-          headers: [{name: 'Employee ID'}, {name: 'Date'}, {name: 'Compensation'}],
+          headers: [
+            {name: 'Employee ID'},
+            {name: 'Date'},
+            {name: 'Compensation'},
+          ],
           rows: [
             {
               values: [
@@ -142,9 +141,7 @@ const MOCK_DATA = {
         },
       },
     },
-    RESPONSE_DEIDENTIFY_CONTENT: [{item: {
-      table: {}
-    }}],
+    RESPONSE_DEIDENTIFY_CONTENT: [{item: {table: {}}}],
   }),
 };
 

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -125,14 +125,14 @@ const MOCK_DATA = {
             },
             {
               values: [
-                {stringValue: '11111'},
+                {stringValue: '22222'},
                 {stringValue: '2016'},
                 {stringValue: '$20'},
               ],
             },
             {
               values: [
-                {stringValue: '11111'},
+                {stringValue: '33333'},
                 {stringValue: '2016'},
                 {stringValue: '$15'},
               ],


### PR DESCRIPTION
DLP: Added sample for de-identify table with FPE
Added unit test cases for same

PS:- I have marked the test cases to skip as the required resources are not available. I have verified locally and the test cases seem to be working fine if resources are provided.

## Description

Reference:- https://cloud.google.com/dlp/docs/samples/dlp-deidentify-table-fpe

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
