### PR TITLE
DLP: Added sample for de-identify using time extract

### DIFF
--- a/dlp/deidentifyWithTimeExtraction.js
+++ b/dlp/deidentifyWithTimeExtraction.js
@@ -1,0 +1,78 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify with time extraction
+//  description: De-identify sensitive data in a string by replacing it with a given time config.
+//  usage: node deidentifyWithTimeExtraction.js my-project string
+function main(projectId, string) {
+  // [START dlp_deidentify_time_extract]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to de-identify
+  // const string = 'My BirthDay is on 9/21/1976';
+
+  async function deidentifyWithTimeExtraction() {
+    // Specify the content to be inspected.
+    const item = {value: string};
+
+    // Specify transformation to extract a portion of date.
+    const primitiveTransformation = {
+      timePartConfig: {
+        partToExtract: 'YEAR',
+      },
+    };
+
+    // Construct de-identification request to be sent by client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              primitiveTransformation,
+            },
+          ],
+        },
+      },
+      item: item,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.deidentifyContent(request);
+    const deidentifiedItem = response.item;
+
+    // Print results.
+    console.log(deidentifiedItem.value);
+  }
+
+  deidentifyWithTimeExtraction();
+  // [END dlp_deidentify_time_extract]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -333,4 +333,31 @@ describe('deid', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_deidentify_time_extract
+  it('should replace sensitive data in a string using time extraction', () => {
+    let output;
+    const string = 'My BirthDay is on 9/21/1976';
+    try {
+      output = execSync(
+        `node deidentifyWithTimeExtraction.js ${projectId} "${string}"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.match(output, /My BirthDay is on 1976/);
+  });
+
+  it('should handle deidentification errors', () => {
+    let output;
+    const string = 'My BirthDay is on 9/21/1976';
+    try {
+      output = execSync(
+        `node deidentifyWithTimeExtraction.js BAD_PROJECT_ID "${string}"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -337,24 +337,21 @@ describe('deid', () => {
   // dlp_deidentify_time_extract
   it('should replace sensitive data in a string using time extraction', () => {
     let output;
-    const string = 'My BirthDay is on 9/21/1976';
     try {
-      output = execSync(
-        `node deidentifyWithTimeExtraction.js ${projectId} "${string}"`
-      );
+      output = execSync(`node deidentifyWithTimeExtraction.js ${projectId}`);
     } catch (err) {
       output = err.message;
     }
-    assert.match(output, /My BirthDay is on 1976/);
+    assert.match(output, /"stringValue":"1970"/);
+    assert.match(output, /"stringValue":"1996"/);
+    assert.match(output, /"stringValue":"1988"/);
+    assert.match(output, /"stringValue":"2001"/);
   });
 
   it('should handle deidentification errors', () => {
     let output;
-    const string = 'My BirthDay is on 9/21/1976';
     try {
-      output = execSync(
-        `node deidentifyWithTimeExtraction.js BAD_PROJECT_ID "${string}"`
-      );
+      output = execSync('node deidentifyWithTimeExtraction.js BAD_PROJECT_ID');
     } catch (err) {
       output = err.message;
     }


### PR DESCRIPTION
DLP: Added sample for de-identify using time extract
Added unit test cases for the same

## Description

Reference:- https://cloud.google.com/dlp/docs/transformations-reference#time-extract

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
