### PR TITLE
DLP: Add response streaming sample in nodejs

### DIFF
--- a/functions/v2/responseStreaming/index.js
+++ b/functions/v2/responseStreaming/index.js
@@ -1,0 +1,57 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// [START functions_response_streaming]
+
+// Import the Google Cloud client library
+const {BigQuery} = require('@google-cloud/bigquery');
+const bigquery = new BigQuery();
+const functions = require('@google-cloud/functions-framework');
+
+/**
+ * HTTP Cloud Function that streams BigQuery query results
+ *
+ * @param {Object} req Cloud Function request context.
+ * @param {Object} res Cloud Function response context.
+ */
+functions.http('streamBigQuery', async (req, res) => {
+  // Define the SQL query
+  const sqlQuery = `
+      SELECT abstract 
+            FROM \`bigquery-public-data.breathe.bioasq\` 
+            LIMIT 1000`;
+  const options = {
+    query: sqlQuery,
+    location: 'US', // Location must match that of the dataset(s) referenced in the query.
+  };
+
+  try {
+    // Execute the query
+    const [rows] = await bigquery.query(options);
+    async function processRows() {
+      for (const row of rows) {
+        res.write(row["abstract"] + "\n");
+      }
+    }
+    await processRows();
+    res.status(200).end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).send(`Error querying BigQuery: ${err}`);
+  }
+});
+
+// [END functions_response_streaming]

--- a/functions/v2/responseStreaming/index.js
+++ b/functions/v2/responseStreaming/index.js
@@ -20,7 +20,11 @@
 const {BigQuery} = require('@google-cloud/bigquery');
 const bigquery = new BigQuery();
 const functions = require('@google-cloud/functions-framework');
-
+async function processRows(rows, res) {
+  for (const row of rows) {
+    res.write(row['abstract'] + '\n');
+  }
+}
 /**
  * HTTP Cloud Function that streams BigQuery query results
  *
@@ -41,12 +45,7 @@ functions.http('streamBigQuery', async (req, res) => {
   try {
     // Execute the query
     const [rows] = await bigquery.query(options);
-    async function processRows() {
-      for (const row of rows) {
-        res.write(row["abstract"] + "\n");
-      }
-    }
-    await processRows();
+    await processRows(rows, res);
     res.status(200).end();
   } catch (err) {
     console.error(err);

--- a/functions/v2/responseStreaming/index.js
+++ b/functions/v2/responseStreaming/index.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-// [START functions_response_streaming]
+// [START functions_stream_bigquery]
 
 // Import the Google Cloud client library
 const {BigQuery} = require('@google-cloud/bigquery');
@@ -53,4 +53,4 @@ functions.http('streamBigQuery', async (req, res) => {
   }
 });
 
-// [END functions_response_streaming]
+// [END functions_stream_bigquery]

--- a/functions/v2/responseStreaming/package.json
+++ b/functions/v2/responseStreaming/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "nodejs-docs-samples-functions-response-streaming",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google Inc.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "scripts": {
+    "test": "c8 mocha test/*.test.js --timeout=20000"
+  },
+  "dependencies": {
+    "@google-cloud/bigquery": "^6.1.0",
+    "@google-cloud/functions-framework": "^3.1.3"
+  },
+  "devDependencies": {
+    "c8": "^7.13.0",
+    "mocha": "^10.0.0",
+    "sinon": "^15.0.0",
+    "supertest": "^6.0.0"
+  }
+}

--- a/functions/v2/responseStreaming/test/index.test.js
+++ b/functions/v2/responseStreaming/test/index.test.js
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const supertest = require('supertest');
+const {getTestServer} = require('@google-cloud/functions-framework/testing');
+require('../index');
+
+describe('functions_stream_bigquery', () => {
+  it('streamBigQuery: returns results', async () => {
+    const server = getTestServer('streamBigQuery');
+    await supertest(server).get('/').expect(200);
+  });
+});


### PR DESCRIPTION
## Description
Add response streaming sample in nodejs

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
