### PR TITLE
feat: text classification sample for Vertex LLMs

### DIFF
--- a/ai-platform/snippets/predict-text-news-classification.js
+++ b/ai-platform/snippets/predict-text-news-classification.js
@@ -61,16 +61,16 @@ async function main(project, location = 'us-central1') {
     Text: Quit smoking?
     The answer is: health
     
-    Text: Roger Federer reveals why he touched Rafael Nadals hand while they were crying
+    Text: Best soccer game of the season?
     The answer is: sports
     
-    Text: Business relief from Arizona minimum-wage hike looking more remote
+    Text: This stock continues to soar.
     The answer is: business
     
-    Text: #TomCruise has arrived in Bari, Italy for #MissionImpossible.
+    Text: What movie should I watch this week?
     The answer is: entertainment
     
-    Text: CNBC Reports Rising Digital Profit as Print Advertising Falls
+    Text: Airlines expect to make $10 billion this year despite economic slowdown
     The answer is:
     `,
     };

--- a/ai-platform/snippets/predict-text-news-classification.js
+++ b/ai-platform/snippets/predict-text-news-classification.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+async function main(project, location = 'us-central1') {
+  // [START aiplatform_sdk_classify_news_items]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.\
+   * (Not necessary if passing values as arguments)
+   */
+  // const project = 'YOUR_PROJECT_ID';
+  // const location = 'YOUR_PROJECT_LOCATION';
+  const aiplatform = require('@google-cloud/aiplatform');
+
+  // Imports the Google Cloud Prediction service client
+  const {PredictionServiceClient} = aiplatform.v1;
+
+  // Import the helper module for converting arbitrary protobuf.Value objects.
+  const {helpers} = aiplatform;
+
+  // Specifies the location of the api endpoint
+  const clientOptions = {
+    apiEndpoint: 'us-central1-aiplatform.googleapis.com',
+  };
+
+  const publisher = 'google';
+  const model = 'text-bison@001';
+
+  // Instantiates a client
+  const predictionServiceClient = new PredictionServiceClient(clientOptions);
+
+  async function callPredict() {
+    // Configure the parent resource
+    const endpoint = `projects/${project}/locations/${location}/publishers/${publisher}/models/${model}`;
+
+    const instance = {
+      content: `What is the topic for a given news headline?
+    - business
+    - entertainment
+    - health
+    - sports
+    - technology
+    
+    Text: Pixel 7 Pro Expert Hands On Review, the Most Helpful Google Phones.
+    The answer is: technology
+    
+    Text: Quit smoking?
+    The answer is: health
+    
+    Text: Roger Federer reveals why he touched Rafael Nadals hand while they were crying
+    The answer is: sports
+    
+    Text: Business relief from Arizona minimum-wage hike looking more remote
+    The answer is: business
+    
+    Text: #TomCruise has arrived in Bari, Italy for #MissionImpossible.
+    The answer is: entertainment
+    
+    Text: CNBC Reports Rising Digital Profit as Print Advertising Falls
+    The answer is:
+    `,
+    };
+    const instanceValue = helpers.toValue(instance);
+    const instances = [instanceValue];
+
+    const parameter = {
+      temperature: 0.2,
+      maxOutputTokens: 5,
+      topP: 0,
+      topK: 1,
+    };
+    const parameters = helpers.toValue(parameter);
+
+    const request = {
+      endpoint,
+      instances,
+      parameters,
+    };
+
+    // Predict request
+    const [response] = await predictionServiceClient.predict(request);
+    console.log('Get text classification response');
+    const predictions = response.predictions;
+    console.log('\tPredictions :');
+    for (const prediction of predictions) {
+      console.log(`\t\tPrediction : ${JSON.stringify(prediction)}`);
+    }
+  }
+
+  callPredict();
+  // [END aiplatform_sdk_classify_news_items]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/ai-platform/snippets/test/predict-text-news-classification.test.js
+++ b/ai-platform/snippets/test/predict-text-news-classification.test.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require('path');
+const {assert} = require('chai');
+const {describe, it} = require('mocha');
+
+const cp = require('child_process');
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const cwd = path.join(__dirname, '..');
+
+const project = process.env.CAIP_PROJECT_ID;
+const location = 'us-central1';
+
+describe('AI platform predict text classification', () => {
+  it('should make predictions using a large language model', async () => {
+    const stdout = execSync(
+      `node ./predict-text-news-classification.js ${project} ${location}`,
+      {
+        cwd,
+      }
+    );
+    assert.match(stdout, /Get text classification response/);
+  });
+});


### PR DESCRIPTION
## Description

Fixes b/281562687

Add a text classification sample for Vertex LLMs.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
