### PR TITLE
feat: sentiment analysis sample for Vertex LLMs

### DIFF
--- a/ai-platform/snippets/predict-text-sentiment.js
+++ b/ai-platform/snippets/predict-text-sentiment.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+async function main(project, location = 'us-central1') {
+  // [START aiplatform_sdk_sentiment_analysis]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.\
+   * (Not necessary if passing values as arguments)
+   */
+  // const project = 'YOUR_PROJECT_ID';
+  // const location = 'YOUR_PROJECT_LOCATION';
+
+  const aiplatform = require('@google-cloud/aiplatform');
+
+  // Imports the Google Cloud Prediction service client
+  const {PredictionServiceClient} = aiplatform.v1;
+
+  // Import the helper module for converting arbitrary protobuf.Value objects.
+  const {helpers} = aiplatform;
+
+  // Specifies the location of the api endpoint
+  const clientOptions = {
+    apiEndpoint: 'us-central1-aiplatform.googleapis.com',
+  };
+
+  const publisher = 'google';
+  const model = 'text-bison@001';
+
+  // Instantiates a client
+  const predictionServiceClient = new PredictionServiceClient(clientOptions);
+
+  async function callPredict() {
+    // Configure the parent resource
+    const endpoint = `projects/${project}/locations/${location}/publishers/${publisher}/models/${model}`;
+
+    const instance = {
+      content: `I had to compare two versions of Hamlet for my Shakespeare class and \
+    unfortunately I picked this version. Everything from the acting (the actors \
+    deliver most of their lines directly to the camera) to the camera shots (all \
+    medium or close up shots...no scenery shots and very little back ground in the \
+    shots) were absolutely terrible. I watched this over my spring break and it is \
+    very safe to say that I feel that I was gypped out of 114 minutes of my \
+    vacation. Not recommended by any stretch of the imagination.
+    Classify the sentiment of the message: negative
+    
+    Something surprised me about this movie - it was actually original. It was not \
+    the same old recycled crap that comes out of Hollywood every month. I saw this \
+    movie on video because I did not even know about it before I saw it at my \
+    local video store. If you see this movie available - rent it - you will not \
+    regret it.
+    Classify the sentiment of the message: positive
+    
+    My family has watched Arthur Bach stumble and stammer since the movie first \
+    came out. We have most lines memorized. I watched it two weeks ago and still \
+    get tickled at the simple humor and view-at-life that Dudley Moore portrays. \
+    Liza Minelli did a wonderful job as the side kick - though I'm not her \
+    biggest fan. This movie makes me just enjoy watching movies. My favorite scene \
+    is when Arthur is visiting his fiancée's house. His conversation with the \
+    butler and Susan's father is side-spitting. The line from the butler, \
+    "Would you care to wait in the Library" followed by Arthur's reply, \
+    "Yes I would, the bathroom is out of the question", is my NEWMAIL \
+    notification on my computer.
+    Classify the sentiment of the message: positive
+    
+    This Charles outing is decent but this is a pretty low-key performance. Marlon \
+    Brando stands out. There's a subplot with Mira Sorvino and Donald Sutherland \
+    that forgets to develop and it hurts the film a little. I'm still trying to \
+    figure out why Charlie want to change his name.
+    Classify the sentiment of the message: negative
+    
+    Tweet: The Pixel 7 Pro, is too big to fit in my jeans pocket, so I bought \
+    new jeans.
+    Classify the sentiment of the message: 
+    `,
+    };
+    const instanceValue = helpers.toValue(instance);
+    const instances = [instanceValue];
+
+    const parameter = {
+      temperature: 0.2,
+      maxOutputTokens: 5,
+      topP: 0,
+      topK: 1,
+    };
+    const parameters = helpers.toValue(parameter);
+
+    const request = {
+      endpoint,
+      instances,
+      parameters,
+    };
+
+    // Predict request
+    const [response] = await predictionServiceClient.predict(request);
+    console.log('Get text sentiment response');
+    const predictions = response.predictions;
+    console.log('\tPredictions :');
+    for (const prediction of predictions) {
+      console.log(`\t\tPrediction : ${JSON.stringify(prediction)}`);
+    }
+  }
+
+  callPredict();
+  // [END aiplatform_sdk_sentiment_analysis]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/ai-platform/snippets/predict-text-sentiment.js
+++ b/ai-platform/snippets/predict-text-sentiment.js
@@ -67,9 +67,8 @@ async function main(project, location = 'us-central1') {
     
     My family has watched Arthur Bach stumble and stammer since the movie first \
     came out. We have most lines memorized. I watched it two weeks ago and still \
-    get tickled at the simple humor and view-at-life that Dudley Moore portrays. \
-    Liza Minelli did a wonderful job as the side kick - though I'm not her \
-    biggest fan. This movie makes me just enjoy watching movies. My favorite scene \
+    get tickled at the simple humor and view-at-life. \
+    This movie makes me just enjoy watching movies. My favorite scene \
     is when Arthur is visiting his fiancée's house. His conversation with the \
     butler and Susan's father is side-spitting. The line from the butler, \
     "Would you care to wait in the Library" followed by Arthur's reply, \
@@ -77,11 +76,6 @@ async function main(project, location = 'us-central1') {
     notification on my computer.
     Classify the sentiment of the message: positive
     
-    This Charles outing is decent but this is a pretty low-key performance. Marlon \
-    Brando stands out. There's a subplot with Mira Sorvino and Donald Sutherland \
-    that forgets to develop and it hurts the film a little. I'm still trying to \
-    figure out why Charlie want to change his name.
-    Classify the sentiment of the message: negative
     
     Tweet: The Pixel 7 Pro, is too big to fit in my jeans pocket, so I bought \
     new jeans.

--- a/ai-platform/snippets/test/predict-text-sentiment.test.js
+++ b/ai-platform/snippets/test/predict-text-sentiment.test.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require('path');
+const {assert} = require('chai');
+const {describe, it} = require('mocha');
+
+const cp = require('child_process');
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const cwd = path.join(__dirname, '..');
+
+const project = process.env.CAIP_PROJECT_ID;
+const location = 'us-central1';
+
+describe('AI platform predict text sentiment', () => {
+  it('should make predictions using a large language model', async () => {
+    const stdout = execSync(
+      `node ./predict-text-sentiment.js ${project} ${location}`,
+      {
+        cwd,
+      }
+    );
+    assert.match(stdout, /Get text sentiment response/);
+  });
+});


### PR DESCRIPTION
## Description

Fixes b/281562687

Add a sentiment analysis sample for Vertex LLMs.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
