### PR TITLE
test: recreating github actions failure [testing - do not merge]

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -33,18 +33,27 @@ on:
   - cron:  '0 0 * * 0'
 jobs:
   test:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.event.action != 'labeled' || github.event.label.name == 'actions:force-run'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'container'
       path: 'container'
   remove_label:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: |
       github.event.action == 'labeled' &&
       github.event.label.name == 'actions:force-run' &&
       always()
     uses: ./.github/workflows/remove-label.yaml
   flakybot:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.event_name == 'schedule' && always() # always() submits logs even if tests fail
     uses: ./.github/workflows/flakybot.yaml
     needs: [test]

--- a/.github/workflows/utils/workflows.json
+++ b/.github/workflows/utils/workflows.json
@@ -92,5 +92,6 @@
   "translate",
   "video-intelligence",
   "vision/productSearch",
-  "workflows"
+  "workflows",
+  "workflows/quickstart"
 ]

--- a/.github/workflows/workflows-quickstart.yaml
+++ b/.github/workflows/workflows-quickstart.yaml
@@ -33,18 +33,27 @@ on:
   - cron:  '0 0 * * 0'
 jobs:
   test:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.event.action != 'labeled' || github.event.label.name == 'actions:force-run'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'workflows-quickstart'
       path: 'workflows/quickstart'
   remove_label:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: |
       github.event.action == 'labeled' &&
       github.event.label.name == 'actions:force-run' &&
       always()
     uses: ./.github/workflows/remove-label.yaml
   flakybot:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.event_name == 'schedule' && always() # always() submits logs even if tests fail
     uses: ./.github/workflows/flakybot.yaml
     needs: [test]

--- a/.github/workflows/workflows-quickstart.yaml
+++ b/.github/workflows/workflows-quickstart.yaml
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: container
+name: workflows-quickstart
 on:
   push:
     branches:
     - main
     paths:
-    - 'container/**'
-    - '.github/workflows/container.yaml'
+    - 'workflows/quickstart/**'
+    - '.github/workflows/workflows-quickstart.yaml'
   pull_request:
     paths:
-    - 'container/**'
-    - '.github/workflows/container.yaml'
+    - 'workflows/quickstart/**'
+    - '.github/workflows/workflows-quickstart.yaml'
   pull_request_target:
     types: [labeled]
     paths:
-    - 'container/**'
-    - '.github/workflows/container.yaml'
+    - 'workflows/quickstart/**'
+    - '.github/workflows/workflows-quickstart.yaml'
   schedule:
   - cron:  '0 0 * * 0'
 jobs:
@@ -36,8 +36,8 @@ jobs:
     if: github.event.action != 'labeled' || github.event.label.name == 'actions:force-run'
     uses: ./.github/workflows/test.yaml
     with:
-      name: 'container'
-      path: 'container'
+      name: 'workflows-quickstart'
+      path: 'workflows/quickstart'
   remove_label:
     if: |
       github.event.action == 'labeled' &&

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "gts check",
     "fix": "gts fix",
     "test": "echo 'Please run tests in each sample directory.' && exit 1",
-    "generate-ci": "node .github/workflows/generate.js"
+    "generate-ci": "node .github/workflows/utils/generate.js"
   },
   "devDependencies": {    
     "c8": "^7.13.0",  


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
