### PR TITLE
DLP: Added sample for inspect GCS file

### DIFF
--- a/dlp/inspectGcsFileWithSampling.js
+++ b/dlp/inspectGcsFileWithSampling.js
@@ -1,0 +1,167 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// sample-metadata:
+//  title: Inspect GCS file with sampling
+//  description: Inspects a text file stored on Google Cloud Storage with sampling, using Pub/Sub for job notifications.
+//  usage: node inspectGcsFileWithSampling.js.js my-project gcsUri topicId subscriptionId infoTypes
+async function main(projectId, gcsUri, topicId, subscriptionId, infoTypes) {
+  infoTypes = transformCLI(infoTypes);
+
+  // [START dlp_inspect_gcs_with_sampling]
+  // Import the Google Cloud client libraries
+  const DLP = require('@google-cloud/dlp');
+  const {PubSub} = require('@google-cloud/pubsub');
+
+  // Instantiates clients
+  const dlp = new DLP.DlpServiceClient();
+  const pubsub = new PubSub();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The gcs file path
+  // const gcsUri = 'gs://" + "your-bucket-name" + "/path/to/your/file.txt';
+
+  // Specify the type of info the inspection will look for.
+  // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
+  // const infoTypes = [{ name: 'PERSON_NAME' }];
+
+  // The name of the Pub/Sub topic to notify once the job completes
+  // TODO(developer): create a Pub/Sub topic to use for this
+  // const topicId = 'MY-PUBSUB-TOPIC'
+
+  // The name of the Pub/Sub subscription to use when listening for job
+  // completion notifications
+  // TODO(developer): create a Pub/Sub subscription to use for this
+  // const subscriptionId = 'MY-PUBSUB-SUBSCRIPTION'
+
+  // DLP Job max time (in milliseconds)
+  const DLP_JOB_WAIT_TIME = 15 * 1000 * 60;
+
+  async function inspectGcsFileSampling() {
+    // Specify the GCS file to be inspected and sampling configuration
+    const storageItemConfig = {
+      cloudStorageOptions: {
+        fileSet: {url: gcsUri},
+        bytesLimitPerFile: 200,
+        filesLimitPercent: 90,
+        fileTypes: [DLP.protos.google.privacy.dlp.v2.FileType.TEXT_FILE],
+        sampleMethod:
+          DLP.protos.google.privacy.dlp.v2.CloudStorageOptions.SampleMethod
+            .RANDOM_START,
+      },
+    };
+
+    // Specify how the content should be inspected.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.POSSIBLE,
+      includeQuote: true,
+      excludeInfoTypes: true,
+    };
+
+    // Specify the action that is triggered when the job completes.
+    const actions = [
+      {
+        pubSub: {
+          topic: `projects/${projectId}/topics/${topicId}`,
+        },
+      },
+    ];
+
+    // Create the request for the job configured above.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: {
+        inspectConfig: inspectConfig,
+        storageConfig: storageItemConfig,
+        actions: actions,
+      },
+    };
+
+    // Use the client to send the request.
+    const [topicResponse] = await pubsub.topic(topicId).get();
+
+    // Verify the Pub/Sub topic and listen for job notifications via an
+    // existing subscription.
+    const subscription = await topicResponse.subscription(subscriptionId);
+
+    const [jobsResponse] = await dlp.createDlpJob(request);
+    const jobName = jobsResponse.name;
+    // Watch the Pub/Sub topic until the DLP job finishes
+    await new Promise((resolve, reject) => {
+      // Set up the timeout
+      const timer = setTimeout(() => {
+        reject(new Error('Timeout'));
+      }, DLP_JOB_WAIT_TIME);
+
+      const messageHandler = message => {
+        if (message.attributes && message.attributes.DlpJobName === jobName) {
+          message.ack();
+          subscription.removeListener('message', messageHandler);
+          subscription.removeListener('error', errorHandler);
+          clearTimeout(timer);
+          resolve(jobName);
+        } else {
+          message.nack();
+        }
+      };
+
+      const errorHandler = err => {
+        subscription.removeListener('message', messageHandler);
+        subscription.removeListener('error', errorHandler);
+        clearTimeout(timer);
+        reject(err);
+      };
+
+      subscription.on('message', messageHandler);
+      subscription.on('error', errorHandler);
+    });
+    const [job] = await dlp.getDlpJob({name: jobName});
+    console.log(`Job ${job.name} status: ${job.state}`);
+
+    const infoTypeStats = job.inspectDetails.result.infoTypeStats;
+    if (infoTypeStats.length > 0) {
+      infoTypeStats.forEach(infoTypeStat => {
+        console.log(
+          `  Found ${infoTypeStat.count} instance(s) of infoType ${infoTypeStat.infoType.name}.`
+        );
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+
+  await inspectGcsFileSampling();
+  // [END dlp_inspect_gcs_with_sampling]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+function transformCLI(infoTypes) {
+  return infoTypes
+    ? infoTypes.split(',').map(type => {
+        return {name: type};
+      })
+    : undefined;
+}
+
+module.exports = main;

--- a/dlp/inspectImageFileAllInfoTypes.js
+++ b/dlp/inspectImageFileAllInfoTypes.js
@@ -1,0 +1,94 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspects a image file.
+//  description: Inspect a image without info type, this will search for most common infotype by default.
+//  usage: node inspectImageFileAllInfoTypes.js.js.js my-project imagePath
+function main(projectId, imagePath) {
+  // [START dlp_inspect_image_all_infotypes]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+  const mime = require('mime');
+  const fs = require('fs');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // Image Path
+  // const imagePath = './test.jpeg';
+
+  async function inspectImageFileAllType() {
+    let fileBytes = null;
+    let fileTypeConstant = null;
+    try {
+      // Load Image
+      fileTypeConstant =
+        ['image/jpeg', 'image/bmp', 'image/png', 'image/svg'].indexOf(
+          mime.getType(imagePath)
+        ) + 1;
+      fileBytes = Buffer.from(fs.readFileSync(imagePath)).toString('base64');
+    } catch (error) {
+      console.error(error.message);
+      return;
+    }
+    // Specify the content to be inspected.
+    const item = {
+      byteItem: {
+        type: fileTypeConstant,
+        data: fileBytes,
+      },
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    // Do not specify the type of info to inspect.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      item: item,
+      inspectConfig: {
+        includeQuote: true,
+      },
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print findings.
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectImageFileAllType();
+  // [END dlp_inspect_image_all_infotypes]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -143,6 +143,67 @@ const MOCK_DATA = {
     },
     RESPONSE_DEIDENTIFY_CONTENT: [{item: {table: {}}}],
   }),
+  INSPECT_GCS_WITH_SAMPLING: (
+    projectId,
+    gcsUri,
+    topicId,
+    infoTypes,
+    jobName
+  ) => ({
+    REQUEST_CREATE_DLP_JOB: {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: {
+        inspectConfig: {
+          infoTypes: infoTypes,
+          minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.POSSIBLE,
+          includeQuote: true,
+          excludeInfoTypes: true,
+        },
+        storageConfig: {
+          cloudStorageOptions: {
+            fileSet: {url: gcsUri},
+            bytesLimitPerFile: 200,
+            filesLimitPercent: 90,
+            fileTypes: [DLP.protos.google.privacy.dlp.v2.FileType.TEXT_FILE],
+            sampleMethod:
+              DLP.protos.google.privacy.dlp.v2.CloudStorageOptions.SampleMethod
+                .RANDOM_START,
+          },
+        },
+        actions: [
+          {
+            pubSub: {
+              topic: `projects/${projectId}/topics/${topicId}`,
+            },
+          },
+        ],
+      },
+    },
+    RESPONSE_GET_DLP_JOB: [
+      {
+        name: jobName,
+        inspectDetails: {
+          result: {
+            infoTypeStats: [
+              {
+                count: 1,
+                infoType: {
+                  name: 'PERSON_NAME',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+    MOCK_MESSAGE: {
+      attributes: {
+        DlpJobName: jobName,
+      },
+      ack: sinon.stub(),
+      nack: sinon.stub(),
+    },
+  }),
 };
 
 module.exports = {MOCK_DATA};


### PR DESCRIPTION
-Added sample for inspect image file
-Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/inspecting-images.md#dlp-inspect-image-all-infotypes-java
https://cloud.google.com/dlp/docs/inspecting-storage.md#dlp_inspect_gcs_with_sampling-java

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
