### PR TITLE
DLP: Added sample for deidentify with FPE surrogate

### DIFF
--- a/dlp/deidentifyWithFpeSurrogate.js
+++ b/dlp/deidentifyWithFpeSurrogate.js
@@ -1,0 +1,120 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify with FPE
+//  description: De-identify sensitive data in a string using Format Preserving Encryption (FPE) with surrogate.
+//  usage: node deidentifyWithFpeSurrogate.js my-project string alphabet infoTypes surrogateType unwrappedKey
+function main(
+  projectId,
+  string,
+  alphabet,
+  infoTypes,
+  surrogateType,
+  unwrappedKey
+) {
+  infoTypes = transformCLI(infoTypes);
+  // [START dlp_deidentify_free_text_with_fpe_using_surrogate]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to de-identify
+  // const string = 'My phone number is 4359916732';
+
+  // The set of characters to replace sensitive ones with
+  // For more information, see https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+  // const alphabet = 'NUMERIC';
+
+  // InfoTypes
+  // const infoTypes = [{name: 'PHONE_NUMBER'}];
+
+  // Surrogate Type
+  // const surrogateType = 'PHONE_TOKEN';
+
+  // The base64-encoded AES-256 key to use
+  // const unwrappedKey = 'YWJjZGVmZ2hpamtsbW5vcA==';
+
+  async function deidentifyWithFpeSurrogate() {
+    // Specify an unwrapped crypto key.
+    unwrappedKey = Buffer.from(unwrappedKey, 'base64');
+
+    // Specify how the info from the inspection should be encrypted.
+    const cryptoReplaceFfxFpeConfig = {
+      cryptoKey: {
+        unwrapped: {
+          key: unwrappedKey,
+        },
+      },
+      commonAlphabet: alphabet,
+      surrogateInfoType: {name: surrogateType},
+    };
+
+    // Construct the inspect configuration.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+    };
+
+    // Set the text to be de-identified.
+    const item = {value: string};
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              primitiveTransformation: {
+                cryptoReplaceFfxFpeConfig: cryptoReplaceFfxFpeConfig,
+              },
+            },
+          ],
+        },
+      },
+      item: item,
+      inspectConfig: inspectConfig,
+    };
+    // Run de-identification request
+    const [response] = await dlp.deidentifyContent(request);
+    const deidentifiedItem = response.item;
+    // Print results
+    console.log(deidentifiedItem.value);
+  }
+  deidentifyWithFpeSurrogate();
+  // [END dlp_deidentify_free_text_with_fpe_using_surrogate]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));
+
+function transformCLI(infoTypes) {
+  return infoTypes
+    ? infoTypes.split(',').map(type => {
+        return {name: type};
+      })
+    : undefined;
+}

--- a/dlp/reidentifyWithFpeSurrogate.js
+++ b/dlp/reidentifyWithFpeSurrogate.js
@@ -1,0 +1,110 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Re-identify with FPE
+//  description: Re-identify sensitive data in a string using Format Preserving Encryption (FPE) with surrogate.
+//  usage: node reidentifyWithFpeSurrogate.js my-project string alphabet infoTypes surrogateType unwrappedKey
+function main(projectId, string, alphabet, surrogateType, unwrappedKey) {
+  // [START dlp_reidentify_free_text_with_fpe_using_surrogate]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to Re-identify
+  // const string = 'PHONE_TOKEN(10):########';
+
+  // The set of characters to replace sensitive ones with
+  // For more information, see https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+  // const alphabet = 'NUMERIC';
+
+  // InfoTypes
+  // const infoTypes = [{name: 'PHONE_NUMBER'}];
+
+  // Surrogate Type
+  // const surrogateType = 'PHONE_TOKEN';
+
+  // The base64-encoded AES-256 key to use
+  // const unwrappedKey = 'YWJjZGVmZ2hpamtsbW5vcA==';
+
+  async function reidentifyWithFpeSurrogate() {
+    // Specify an unwrapped crypto key.
+    unwrappedKey = Buffer.from(unwrappedKey, 'base64');
+
+    // Specify how the info from the inspection should be encrypted.
+    const cryptoReplaceFfxFpeConfig = {
+      cryptoKey: {
+        unwrapped: {
+          key: unwrappedKey,
+        },
+      },
+      commonAlphabet: alphabet,
+      surrogateInfoType: {name: surrogateType},
+    };
+
+    // Construct the inspect configuration.
+    const inspectConfig = {
+      customInfoTypes: [
+        {
+          infoType: {
+            name: surrogateType,
+          },
+          surrogateType: {},
+        },
+      ],
+    };
+
+    // Set the text to be re-identified.
+    const item = {value: string};
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              primitiveTransformation: {
+                cryptoReplaceFfxFpeConfig: cryptoReplaceFfxFpeConfig,
+              },
+            },
+          ],
+        },
+      },
+      item: item,
+      inspectConfig: inspectConfig,
+    };
+    // Run re-identification request
+    const [response] = await dlp.reidentifyContent(request);
+    const reidentifiedItem = response.item;
+    // Print results
+    console.log(reidentifiedItem.value);
+  }
+  reidentifyWithFpeSurrogate();
+  // [END dlp_reidentify_free_text_with_fpe_using_surrogate]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));


### PR DESCRIPTION
-Added sample for reidentify with FPE surrogate
-Added unit test cases for the same

## Description

Reference:- https://cloud.google.com/dlp/docs/samples/dlp-deidentify-free-text-with-fpe-using-surrogate
https://cloud.google.com/dlp/docs/samples/dlp-reidentify-free-text-with-fpe-using-surrogate

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
