### PR TITLE
fix: replace deprecated repo with active docker repo for trampoline image

### DIFF
--- a/.kokoro/appengine/test-deployment/common.cfg
+++ b/.kokoro/appengine/test-deployment/common.cfg
@@ -12,7 +12,7 @@ build_file: "nodejs-docs-samples/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-docs-samples/nodejs"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node"
 }
 
 # Tell the trampoline which build file to use.


### PR DESCRIPTION
## Description

Fixes long running kokoro failure, which was referencing deprecated cloud doc samples repo.

For example see: https://fusion2.corp.google.com/ci/kokoro/prod:cloud-devrel%2Fnodejs-docs-samples%2Frelease%2Fappengine%2Ftest-deployment%2Fstorage-flex/activity/2b3554f5-618f-431f-8b1e-6de79b777bf1/summary

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
