### PR TITLE
DLP: Added sample for inspect string with custom hotword

### DIFF
--- a/dlp/inspectStringCustomExcludingSubstring.js
+++ b/dlp/inspectStringCustomExcludingSubstring.js
@@ -1,0 +1,111 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspects strings by using Custom exclusion list
+//  description: Inspect a string for sensitive data using custom info type excluding list of words.
+//  usage: node inspectStringCustomExcludingSubstring.js my-project string excludedWords
+function main(projectId, string, excludedWords) {
+  excludedWords = excludedWords ? excludedWords.split(',') : [];
+  // [START dlp_inspect_string_custom_excluding_substring]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to inspect
+  // const string = 'Name: Doe, John. Name: Example, Jimmy';
+
+  // Words to exclude
+  // const excludedWords = ['Jimmy'];
+
+  async function inspectStringCustomExclusionDict() {
+    // Specify the content to be inspected.
+    const item = {value: string};
+
+    // Specify the type of info the inspection will look for.
+    const customInfoTypes = [
+      {
+        infoType: {name: 'CUSTOM_NAME_DETECTOR'},
+        regex: {pattern: '[A-Z][a-z]{1,15}, [A-Z][a-z]{1,15}'},
+      },
+    ];
+
+    // Exclude partial matches from the specified excludedSubstringList.
+    const exclusionRUle = {
+      dictionary: {wordList: {words: excludedWords}},
+      matchingType:
+        DLP.protos.google.privacy.dlp.v2.MatchingType
+          .MATCHING_TYPE_PARTIAL_MATCH,
+    };
+
+    // Construct a rule set that will only match if the match text does not
+    // contains tokens from the exclusion list.
+    const ruleSet = [
+      {
+        infoTypes: [{name: 'CUSTOM_NAME_DETECTOR'}],
+        rules: [
+          {
+            exclusionRule: exclusionRUle,
+          },
+        ],
+      },
+    ];
+
+    // Construct the configuration for the Inspect request, including the ruleset.
+    const inspectConfig = {
+      customInfoTypes: customInfoTypes,
+      ruleSet: ruleSet,
+      includeQuote: true,
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print findings.
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectStringCustomExclusionDict();
+  // [END dlp_inspect_string_custom_excluding_substring]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/inspectStringCustomHotword.js
+++ b/dlp/inspectStringCustomHotword.js
@@ -1,0 +1,113 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspects a string for sensitive data.
+//  description: Inspect a string for sensitive data using a custom hotword and increase the likelihood of match
+//  usage: node inspectStringCustomHotword.js my-project string customHotword
+function main(projectId, string, customHotword) {
+  // [START dlp_inspect_string_custom_hotword]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to inspect
+  // const string = 'patient name: John Doe';
+
+  // Custom hotward
+  // const customHotword = 'patient';
+
+  async function inspectStringCustomHotword() {
+    // Specify the type and content to be inspected.
+    const item = {
+      byteItem: {
+        type: DLP.protos.google.privacy.dlp.v2.ByteContentItem.BytesType
+          .TEXT_UTF8,
+        data: Buffer.from(string, 'utf-8'),
+      },
+    };
+
+    // Increase likelihood of matches that have customHotword nearby.
+    const hotwordRule = {
+      hotwordRegex: {
+        pattern: customHotword,
+      },
+      proximity: {
+        windowBefore: 50,
+      },
+      likelihoodAdjustment: {
+        fixedLikelihood:
+          DLP.protos.google.privacy.dlp.v2.Likelihood.VERY_LIKELY,
+      },
+    };
+
+    // Construct a ruleset that applies the hotword rule to the PERSON_NAME infotype.
+    const ruleSet = [
+      {
+        infoTypes: [{name: 'PERSON_NAME'}],
+        rules: [
+          {
+            hotwordRule: hotwordRule,
+          },
+        ],
+      },
+    ];
+
+    // Construct the configuration for the Inspect request.
+    const inspectConfig = {
+      infoTypes: [{name: 'PERSON_NAME'}],
+      ruleSet: ruleSet,
+      includeQuote: true,
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print findings.
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectStringCustomHotword();
+  // [END dlp_inspect_string_custom_hotword]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -843,4 +843,46 @@ describe('inspect', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_inspect_string_custom_excluding_substring
+  it('should inspect using custom regex pattern excluding list of words', () => {
+    const output = execSync(
+      `node inspectStringCustomExcludingSubstring.js ${projectId} "Name: Doe, John. Name: Example, Jimmy" Jimmy`
+    );
+    assert.notMatch(output, /Quote: Jimmy/);
+    assert.match(output, /Quote: Doe, John/);
+  });
+
+  it('should report any errors while inspecting a string', () => {
+    let output;
+    try {
+      output = execSync(
+        'node inspectStringCustomExcludingSubstring.js BAD_PROJECT_ID "Name: Doe, John. Name: Example, Jimmy" Jimmy'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
+
+  // dlp_inspect_string_custom_hotword
+  it('should inspect using custom regex pattern excluding list of words', () => {
+    const output = execSync(
+      `node inspectStringCustomHotword.js ${projectId} "patient name: John Doe" "patient"`
+    );
+    assert.match(output, /Likelihood: VERY_LIKELY/);
+    assert.match(output, /Quote: John Doe/);
+  });
+
+  it('should report any errors while inspecting a string', () => {
+    let output;
+    try {
+      output = execSync(
+        'node inspectStringCustomHotword.js BAD_PROJECT_ID "patient name: John Doe" "patient"'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added sample for inspect string with custom substring exclusion Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/creating-custom-infotypes-rules#omit_scan_matches_that_include_the_substring_jimmy_from_a_custom_infotype_detector_scan
https://cloud.google.com/dlp/docs/creating-custom-infotypes-rules#increase_the_likelihood_of_a_person_name_match_if_there_is_the_hotword_patient_nearby

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
