### PR TITLE
chore(cloud-sql): cleanup pg/knex example comments

### DIFF
--- a/cloud-sql/postgres/knex/connect-connector-with-iam-authn.js
+++ b/cloud-sql/postgres/knex/connect-connector-with-iam-authn.js
@@ -42,7 +42,7 @@ const connectWithConnectorAutoIAMAuthn = async config => {
     client: 'pg',
     connection: {
       ...clientOpts,
-      user: process.env.IAM_DB_USER, // e.g. 'service-account-name'
+      user: process.env.IAM_DB_USER, // e.g. 'sa-name@project-id.iam'
       database: process.env.DB_NAME, // e.g. 'my-database'
     },
     // ... Specify additional properties here.

--- a/cloud-sql/postgres/knex/index.js
+++ b/cloud-sql/postgres/knex/index.js
@@ -119,7 +119,8 @@ const createPool = async () => {
     }
   }
   if (process.env.INSTANCE_CONNECTION_NAME) {
-    // Uses the Cloud SQL Node.js Connector (e.g., project:region:instance) is defined
+    // Uses the Cloud SQL Node.js Connector when INSTANCE_CONNECTION_NAME
+    // (e.g., project:region:instance) is defined
     return createConnectorPool(config);
   } else if (process.env.INSTANCE_HOST) {
     // Use a TCP socket when INSTANCE_HOST (e.g., 127.0.0.1) is defined


### PR DESCRIPTION
Just cleaning up a couple of the sample comments to make sure it propertly mentions the `INSTANCE_CONNECTION_NAME` environment variable name and uses an IAM username in examples that is similar to the usernames used by Posgtres Cloud SQL Instances.

Ref: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3266
cc @jackwotherspoon 