### PR TITLE
chore(aiplatform): temporarily skip featurestore tests

### DIFF
--- a/ai-platform/snippets/test/create-featurestore-fixed-nodes-sample.test.js
+++ b/ai-platform/snippets/test/create-featurestore-fixed-nodes-sample.test.js
@@ -53,7 +53,8 @@ const deleteFeaturestore = async () => {
   await operation.promise();
 };
 
-describe('AI platform create featurestore with fixed nodes', async function () {
+// TODO (#3302): Investigate Featurestore stability issue
+describe.skip('AI platform create featurestore with fixed nodes', async function () {
   this.retries(2);
   it('should create a featurestore', async () => {
     const stdout = execSync(

--- a/ai-platform/snippets/test/create-featurestore-sample.test.js
+++ b/ai-platform/snippets/test/create-featurestore-sample.test.js
@@ -54,7 +54,8 @@ const deleteFeaturestore = async () => {
   await operation.promise();
 };
 
-describe('AI platform create featurestore', async function () {
+// TODO (#3302): Investigate Featurestore stability issue
+describe.skip('AI platform create featurestore', async function () {
   this.retries(2);
   it('should create a featurestore', async () => {
     const stdout = execSync(


### PR DESCRIPTION
## Description

Fixes #3300 
Temporarily skip featurestore tests as there may be a service stability issue that causes CI tests to stall.
Tracking bug #3302