### PR TITLE
DLP: Added sample for de-identify and re-identify with deterministic encryption

### DIFF
--- a/dlp/deidentifyWithDeterministic.js
+++ b/dlp/deidentifyWithDeterministic.js
@@ -1,0 +1,128 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify content through deterministic encryption
+//  description: De-identify sensitive data in a string using deterministic encryption, which is a reversible cryptographic method.
+//  usage: node deidentifyWithDeterministic.js my-project string infoTypes keyName wrappedKey surrogateType
+async function main(
+  projectId,
+  string,
+  infoTypes,
+  keyName,
+  wrappedKey,
+  surrogateType
+) {
+  infoTypes = transformCLI(infoTypes);
+  // [START dlp_deidentify_deterministic]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to deidentify
+  // const string = 'My name is Alicia Abernathy, and my email address is aabernathy@example.com.';
+
+  // The infoTypes of information to match
+  // const infoTypes = [{ name: 'EMAIL_ADDRESS' }];
+
+  // The name of the Cloud KMS key used to encrypt ('wrap') the AES-256 key
+  // const keyName = 'projects/YOUR_GCLOUD_PROJECT/locations/YOUR_LOCATION/keyRings/YOUR_KEYRING_NAME/cryptoKeys/YOUR_KEY_NAME';
+
+  // The encrypted ('wrapped') AES-256 key to use
+  // This key should be encrypted using the Cloud KMS key specified above
+  // const wrappedKey = 'YOUR_ENCRYPTED_AES_256_KEY'
+
+  // The name of the surrogate custom info type to use
+  // Only necessary if you want to reverse the deidentification process
+  // Can be essentially any arbitrary string, as long as it doesn't appear
+  // in your dataset otherwise.
+  // const surrogateType = 'EMAIL_ADDRESS_TOKEN';
+
+  async function deidentifyDeterministic() {
+    // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it
+    const cryptoDeterministicEncryption = {
+      cryptoKey: {
+        kmsWrapped: {
+          wrappedKey: wrappedKey,
+          cryptoKeyName: keyName,
+        },
+      },
+      surrogateInfoType: {name: surrogateType},
+    };
+
+    // Construct inspect configuration to match information
+    const inspectConfig = {
+      infoTypes,
+    };
+
+    // Associate the encryption with the infotype transformation.
+    const infoTypeTransformations = {
+      transformations: [
+        {
+          infoTypes,
+          primitiveTransformation: {
+            cryptoDeterministicConfig: cryptoDeterministicEncryption,
+          },
+        },
+      ],
+    };
+
+    // Construct item to inspect
+    const item = {value: string};
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        infoTypeTransformations: infoTypeTransformations,
+      },
+      inspectConfig,
+      item: item,
+    };
+
+    // Run de-identification request
+    const [response] = await dlp.deidentifyContent(request);
+    const deidentifiedItem = response.item;
+
+    // Print results
+    console.log(deidentifiedItem.value);
+  }
+  await deidentifyDeterministic();
+  // [END dlp_deidentify_deterministic]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+function transformCLI(infoTypes) {
+  return infoTypes
+    ? infoTypes.split(',').map(type => {
+        return {name: type};
+      })
+    : undefined;
+}
+
+module.exports = main;

--- a/dlp/reidentifyWithDeterministic.js
+++ b/dlp/reidentifyWithDeterministic.js
@@ -1,0 +1,114 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Re-identify content through deterministic encryption
+//  description: Re-identify sensitive data in a string using deterministic encryption, which is a reversible cryptographic method.
+//  usage: node reidentifyWithFpe.js my-project string keyName wrappedKey surrogateType
+async function main(projectId, string, keyName, wrappedKey, surrogateType) {
+  // [START dlp_reidentify_deterministic]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to deidentify
+  // const string = 'My name is Alicia Abernathy, and my email address is EMAIL_ADDRESS_TOKEN(52):XXXXXX';
+
+  // The name of the Cloud KMS key used to encrypt ('wrap') the AES-256 key
+  // const keyName = 'projects/YOUR_GCLOUD_PROJECT/locations/YOUR_LOCATION/keyRings/YOUR_KEYRING_NAME/cryptoKeys/YOUR_KEY_NAME';
+
+  // The encrypted ('wrapped') AES-256 key to use
+  // This key should be encrypted using the Cloud KMS key specified above
+  // const wrappedKey = 'YOUR_ENCRYPTED_AES_256_KEY'
+
+  // The name of the surrogate custom info type to use
+  // Only necessary if you want to reverse the de-identification process
+  // Can be essentially any arbitrary string, as long as it doesn't appear
+  // in your dataset otherwise.
+  // const surrogateType = 'EMAIL_ADDRESS_TOKEN';
+
+  async function reidentifyDeterministic() {
+    // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it
+    const cryptoDeterministicEncryption = {
+      cryptoKey: {
+        kmsWrapped: {
+          wrappedKey: wrappedKey,
+          cryptoKeyName: keyName,
+        },
+      },
+      surrogateInfoType: {name: surrogateType},
+    };
+
+    // Construct custom infotype to match information
+    const customInfoTypes = [
+      {
+        infoType: {
+          name: surrogateType,
+        },
+        surrogateType: {},
+      },
+    ];
+
+    // Associate the encryption with the infotype transformation.
+    const infoTypeTransformations = {
+      transformations: [
+        {
+          infoTypes: [{name: surrogateType}],
+          primitiveTransformation: {
+            cryptoDeterministicConfig: cryptoDeterministicEncryption,
+          },
+        },
+      ],
+    };
+
+    // Construct item to inspect
+    const item = {value: string};
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        infoTypeTransformations: infoTypeTransformations,
+      },
+      inspectConfig: {customInfoTypes},
+      item,
+    };
+
+    // Run re-identification request
+    const [response] = await dlp.reidentifyContent(request);
+    const deidentifiedItem = response.item;
+
+    // Print results
+    console.log(deidentifiedItem.value);
+  }
+  await reidentifyDeterministic();
+  // [END dlp_reidentify_deterministic]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -470,4 +470,162 @@ describe('deid', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_deidentify_deterministic
+  it('should de-identify string using deterministic encryption', async () => {
+    const infoTypes = [{name: 'EMAIL_ADDRESS'}];
+    const string =
+      'My name is Alicia Abernathy, and my email address is aabernathy@example.com.';
+    const CONSTANT_DATA = MOCK_DATA.DEIDENTIFY_WITH_DETEMINISTIC(
+      projectId,
+      string,
+      infoTypes,
+      keyName,
+      wrappedKey,
+      'EMAIL_ADDRESS_TOKEN'
+    );
+
+    const mockDeidentifyContent = sinon
+      .stub()
+      .resolves(CONSTANT_DATA.RESPONSE_DEIDENTIFY_CONTENT);
+
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'deidentifyContent',
+      mockDeidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const deIdentifyWithDeterministic = proxyquire(
+      '../deidentifyWithDeterministic.js',
+      {
+        '@google-cloud/dlp': {DLP: DLP},
+      }
+    );
+
+    await deIdentifyWithDeterministic(
+      projectId,
+      string,
+      'EMAIL_ADDRESS',
+      keyName,
+      wrappedKey,
+      'EMAIL_ADDRESS_TOKEN'
+    );
+
+    sinon.assert.calledOnceWithExactly(
+      mockDeidentifyContent,
+      CONSTANT_DATA.REQUEST_DEIDENTIFY_CONTENT
+    );
+  });
+
+  it('should handle de-identification errors', async () => {
+    const string =
+      'My name is Alicia Abernathy, and my email address is aabernathy@example.com.';
+
+    const mockDeidentifyContent = sinon.stub().rejects(new Error('Failed'));
+
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'deidentifyContent',
+      mockDeidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const deIdentifyWithDeterministic = proxyquire(
+      '../deidentifyWithDeterministic.js',
+      {
+        '@google-cloud/dlp': {DLP: DLP},
+      }
+    );
+
+    try {
+      await deIdentifyWithDeterministic(
+        projectId,
+        string,
+        'EMAIL_ADDRESS',
+        keyName,
+        wrappedKey,
+        'EMAIL_ADDRESS_TOKEN'
+      );
+    } catch (error) {
+      assert.equal(error.message, 'Failed');
+    }
+  });
+
+  // dlp_reidentify_deterministic
+  it('should re-identify string using deterministic encryption', async () => {
+    const string =
+      'My name is Alicia Abernathy, and my email address is EMAIL_ADDRESS_TOKEN';
+    const CONSTANT_DATA = MOCK_DATA.REIDENTIFY_WITH_DETEMINISTIC(
+      projectId,
+      string,
+      keyName,
+      wrappedKey,
+      'EMAIL_ADDRESS_TOKEN'
+    );
+
+    const mockReidentifyContent = sinon
+      .stub()
+      .resolves(CONSTANT_DATA.RESPONSE_REIDENTIFY_CONTENT);
+
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'reidentifyContent',
+      mockReidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const reIdentifyWithDeterministic = proxyquire(
+      '../reidentifyWithDeterministic.js',
+      {
+        '@google-cloud/dlp': {DLP: DLP},
+      }
+    );
+
+    await reIdentifyWithDeterministic(
+      projectId,
+      string,
+      keyName,
+      wrappedKey,
+      'EMAIL_ADDRESS_TOKEN'
+    );
+
+    sinon.assert.calledOnceWithExactly(
+      mockReidentifyContent,
+      CONSTANT_DATA.REQUEST_REIDENTIFY_CONTENT
+    );
+  });
+
+  it('should handle re-identification errors', async () => {
+    const string =
+      'My name is Alicia Abernathy, and my email address is EMAIL_ADDRESS_TOKEN';
+
+    const mockReidentifyContent = sinon.stub().rejects(new Error('Failed'));
+
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'reidentifyContent',
+      mockReidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const reIdentifyWithDeterministic = proxyquire(
+      '../reidentifyWithDeterministic.js',
+      {
+        '@google-cloud/dlp': {DLP: DLP},
+      }
+    );
+
+    try {
+      await reIdentifyWithDeterministic(
+        projectId,
+        string,
+        keyName,
+        wrappedKey,
+        'EMAIL_ADDRESS_TOKEN'
+      );
+    } catch (error) {
+      assert.equal(error.message, 'Failed');
+    }
+  });
 });

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -204,6 +204,88 @@ const MOCK_DATA = {
       nack: sinon.stub(),
     },
   }),
+  DEIDENTIFY_WITH_DETEMINISTIC: (
+    projectId,
+    string,
+    infoTypes,
+    keyName,
+    wrappedKey,
+    surrogateType
+  ) => ({
+    REQUEST_DEIDENTIFY_CONTENT: {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              infoTypes,
+              primitiveTransformation: {
+                cryptoDeterministicConfig: {
+                  cryptoKey: {
+                    kmsWrapped: {
+                      wrappedKey: wrappedKey,
+                      cryptoKeyName: keyName,
+                    },
+                  },
+                  surrogateInfoType: {name: surrogateType},
+                },
+              },
+            },
+          ],
+        },
+      },
+      inspectConfig: {
+        infoTypes,
+      },
+      item: {
+        value: string,
+      },
+    },
+    RESPONSE_DEIDENTIFY_CONTENT: [{item: {value: ''}}],
+  }),
+  REIDENTIFY_WITH_DETEMINISTIC: (
+    projectId,
+    string,
+    keyName,
+    wrappedKey,
+    surrogateType
+  ) => ({
+    REQUEST_REIDENTIFY_CONTENT: {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              infoTypes: [{name: surrogateType}],
+              primitiveTransformation: {
+                cryptoDeterministicConfig: {
+                  cryptoKey: {
+                    kmsWrapped: {
+                      wrappedKey: wrappedKey,
+                      cryptoKeyName: keyName,
+                    },
+                  },
+                  surrogateInfoType: {name: surrogateType},
+                },
+              },
+            },
+          ],
+        },
+      },
+      inspectConfig: {
+        customInfoTypes: [
+          {
+            infoType: {name: surrogateType},
+            surrogateType: {},
+          },
+        ],
+      },
+      item: {
+        value: string,
+      },
+    },
+    RESPONSE_REIDENTIFY_CONTENT: [{item: {value: ''}}],
+  }),
 };
 
 module.exports = {MOCK_DATA};


### PR DESCRIPTION
Added unit test cases for same

## Description

References:-https://cloud.google.com/dlp/docs/inspect-sensitive-text-de-identify#deidentify
https://cloud.google.com/dlp/docs/inspect-sensitive-text-de-identify#reidentify

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
