### PR TITLE
fix(aiplatform): reset timeout and skip deploy model test

### DIFF
--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -35,7 +35,7 @@ jobs:
   test:
     if: github.event.action != 'labeled' || github.event.label.name == 'actions:force-run'
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 120
     permissions:
       contents: 'write'
       pull-requests: 'write'

--- a/ai-platform/snippets/test/deploy-model-custom-trained-model.test.js
+++ b/ai-platform/snippets/test/deploy-model-custom-trained-model.test.js
@@ -32,7 +32,8 @@ const location = process.env.LOCATION;
 let deployedModelId;
 let endpointId;
 
-describe('AI platform deploy model custom model', () => {
+// TODO (#3302): temporarily skip this test to help test run stability diagnosis
+describe.skip('AI platform deploy model custom model', () => {
   it('should deploy the custom model in the specified endpoint', async () => {
     const endOut = execSync(
       `node ./create-endpoint.js ${endpointDisplayName} ${project} \


### PR DESCRIPTION
## Description

Fixes #3302 
Reset timeout back to 120m as increasing timeout didn't work.
Temporarily skip the deploy model test to see if the test is the cause of the test run stalling.


Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
