### PR TITLE
DLP: Added sample for update stored infotype

### DIFF
--- a/dlp/package.json
+++ b/dlp/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@google-cloud/dlp": "^4.3.0",
     "@google-cloud/pubsub": "^3.0.0",
+    "@google-cloud/storage": "^6.11.0",
     "mime": "^3.0.0"
   },
   "devDependencies": {

--- a/dlp/system-test/metadata.test.js
+++ b/dlp/system-test/metadata.test.js
@@ -25,14 +25,13 @@ const dataSetId = 'samples';
 const tableId = 'github_nested';
 const fieldId = 'url';
 
-const bucketName = process.env.BUCKET_NAME;
-const infoTypeCloudStorageFileSet = `gs://${bucketName}/test.txt`;
-
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const client = new DLP.DlpServiceClient();
 describe('metadata', () => {
   let projectId, storedInfoTypeId;
+  const bucketName = process.env.BUCKET_NAME;
+  const infoTypeCloudStorageFileSet = `gs://${bucketName}/test.txt`;
 
   before(async () => {
     projectId = await client.getProjectId();

--- a/dlp/system-test/metadata.test.js
+++ b/dlp/system-test/metadata.test.js
@@ -28,7 +28,7 @@ const fieldId = 'url';
 
 const storage = new Storage();
 const bucketName = `test-bucket-${uuid.v4()}`;
-const testFile = 'resources/test.txt'
+const testFile = 'resources/test.txt';
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 

--- a/dlp/system-test/resources/test.txt
+++ b/dlp/system-test/resources/test.txt
@@ -1,0 +1,3 @@
+user1
+user2
+user3

--- a/dlp/system-test/triggers.test.js
+++ b/dlp/system-test/triggers.test.js
@@ -33,7 +33,7 @@ describe('triggers', () => {
   const infoType = 'PERSON_NAME';
   const minLikelihood = 'VERY_LIKELY';
   const maxFindings = 5;
-  const bucketName = process.env.BUCKET_NAME;
+  const bucketName = process.env.BUCKET_NAME || 'long-door-651';
 
   before(async () => {
     projectId = await client.getProjectId();

--- a/dlp/updateStoredInfoType.js
+++ b/dlp/updateStoredInfoType.js
@@ -1,0 +1,80 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Update stored infoType.
+//  description: Uses the Data Loss Prevention API to update a stored infoType.
+//  usage: node updateStoredInfoType.js projectId  infoTypeId, outputPath, fileSetUrl
+function main(projectId, infoTypeId, outputPath, fileSetUrl) {
+  // [START dlp_update_stored_infotype]
+  // Import the required libraries
+  const dlp = require('@google-cloud/dlp');
+
+  // Create a DLP client
+  const dlpClient = new dlp.DlpServiceClient();
+
+  // The project ID to run the API call under.
+  // const projectId = "your-project-id";
+
+  // The identifier for the stored infoType
+  // const infoTypeId = 'github-usernames';
+
+  // The path to the location in a Cloud Storage bucket to store the created dictionary
+  // const outputPath = 'cloud-bucket-path';
+
+  // Path of file containing term list
+  // const cloudStorageFileSet = 'gs://[PATH_TO_GS]';
+
+  async function updateStoredInfoType() {
+    // Specify configuration of the large custom dictionary including cloudStorageFileSet and outputPath
+    const largeCustomDictionaryConfig = {
+      outputPath: {
+        path: outputPath,
+      },
+      cloudStorageFileSet: {
+        url: fileSetUrl,
+      },
+    };
+
+    // Construct the job creation request to be sent by the client.
+    const updateStoredInfoTypeRequest = {
+      name: `projects/${projectId}/storedInfoTypes/${infoTypeId}`,
+      config: {
+        largeCustomDictionary: largeCustomDictionaryConfig,
+      },
+      updateMask: {
+        paths: ['large_custom_dictionary.cloud_storage_file_set.url'],
+      },
+    };
+
+    // Send the job creation request and process the response.
+    const [response] = await dlpClient.updateStoredInfoType(
+      updateStoredInfoTypeRequest
+    );
+
+    // Print the results.
+    console.log(`InfoType updated successfully: ${JSON.stringify(response)}`);
+  }
+  updateStoredInfoType();
+  // [END dlp_update_stored_infotype]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));


### PR DESCRIPTION
Added unit test cases for same

## Description

Reference:- https://cloud.google.com/dlp/docs/creating-stored-infotypes#rebuild

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
