### PR TITLE
DLP: Added sample for de-identify table with crypto hash transformations

### DIFF
--- a/dlp/deIdentifyTableWithCryptoHash.js
+++ b/dlp/deIdentifyTableWithCryptoHash.js
@@ -1,0 +1,119 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Deidentifying the table data with crypto key defined.
+//  description: Uses the Data Loss Prevention API to Deidentifying the table data with crypto key defined.
+//  usage: node deIdentifyTableWithCryptoHash.js projectId, transientKey
+function main(projectId, transientKey) {
+  // [START dlp_deidentify_table_with_crypto_hash]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // Crypto key
+  // const transientKey = 'YOUR_TRANSIENT_CRYPTO_KEY';
+
+  // The table to de-identify.
+  const tableToDeIdentify = {
+    headers: [{name: 'userid'}, {name: 'comments'}],
+    rows: [
+      {
+        values: [
+          {stringValue: 'user1@example.org'},
+          {
+            stringValue:
+              'my email is user1@example.org and phone is 858-555-0222',
+          },
+        ],
+      },
+      {
+        values: [
+          {stringValue: 'user2@example.org'},
+          {
+            stringValue:
+              'my email is user2@example.org and phone is 858-555-0223',
+          },
+        ],
+      },
+      {
+        values: [
+          {stringValue: 'user3@example.org'},
+          {
+            stringValue:
+              'my email is user3@example.org and phone is 858-555-0224',
+          },
+        ],
+      },
+    ],
+  };
+  async function deIdentifyTableWithCryptoHash() {
+    // Specify crypto hash configuration that uses transient key.
+    const cryptoHashConfig = {
+      cryptoKey: {
+        transient: {
+          name: transientKey,
+        },
+      },
+    };
+
+    // Construct de-identify request that uses crypto hash configuration.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              primitiveTransformation: {
+                cryptoHashConfig: cryptoHashConfig,
+              },
+              infoTypes: [{name: 'PHONE_NUMBER'}, {name: 'EMAIL_ADDRESS'}],
+            },
+          ],
+        },
+      },
+      item: {table: tableToDeIdentify},
+    };
+
+    // Send the request and receive response from the service.
+    const [response] = await dlp.deidentifyContent(request);
+    const deidentifiedTable = response.item.table;
+
+    // Print the results.
+    console.log(
+      `Table after de-identification:\n${JSON.stringify(
+        deidentifiedTable,
+        null,
+        2
+      )}`
+    );
+  }
+
+  deIdentifyTableWithCryptoHash();
+  // [END dlp_deidentify_table_with_crypto_hash]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/deIdentifyTableWithCryptoHash.js
+++ b/dlp/deIdentifyTableWithCryptoHash.js
@@ -17,8 +17,8 @@
 // sample-metadata:
 //  title: Deidentifying the table data with crypto key defined.
 //  description: Uses the Data Loss Prevention API to Deidentifying the table data with crypto key defined.
-//  usage: node deIdentifyTableWithCryptoHash.js projectId, transientKey
-function main(projectId, transientKey) {
+//  usage: node deIdentifyTableWithCryptoHash.js projectId, transientKeyName
+function main(projectId, transientKeyName) {
   // [START dlp_deidentify_table_with_crypto_hash]
   // Imports the Google Cloud Data Loss Prevention library
   const DLP = require('@google-cloud/dlp');
@@ -30,7 +30,7 @@ function main(projectId, transientKey) {
   // const projectId = 'my-project';
 
   // Crypto key
-  // const transientKey = 'YOUR_TRANSIENT_CRYPTO_KEY';
+  // const transientKeyName = 'YOUR_TRANSIENT_CRYPTO_KEY';
 
   // The table to de-identify.
   const tableToDeIdentify = {
@@ -70,7 +70,7 @@ function main(projectId, transientKey) {
     const cryptoHashConfig = {
       cryptoKey: {
         transient: {
-          name: transientKey,
+          name: transientKeyName,
         },
       },
     };

--- a/dlp/deIdentifyTableWithMultipleCryptoHash.js
+++ b/dlp/deIdentifyTableWithMultipleCryptoHash.js
@@ -1,0 +1,160 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify the table using two separate cryptographic hash transformations.
+//  description: Uses the Data Loss Prevention API to de-identify the table using two separate cryptographic hash transformations.
+//  usage: node deIdentifyTableWithMultipleCryptoHash projectId, transientKey, transientKey2
+function main(projectId, transientKey1, transientKey2) {
+  // [START dlp_deidentify_table_with_multiple_crypto_hash]
+  // Imports the Google Cloud client library
+  const DLP = require('@google-cloud/dlp');
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // Crypto key 1
+  // const transientKey1 = 'YOUR_TRANSIENT_CRYPTO_KEY';
+
+  // Crypto key 2
+  // const transientKey2 = 'YOUR_TRANSIENT_CRYPTO_KEY_2';
+
+  // The table to de-identify.
+  const tableToDeIdentify = {
+    headers: [{name: 'userid'}, {name: 'comments'}],
+    rows: [
+      {
+        values: [
+          {stringValue: 'user1@example.org'},
+          {
+            stringValue:
+              'my email is user1@example.org and phone is 858-555-0222',
+          },
+        ],
+      },
+      {
+        values: [
+          {stringValue: 'user2@example.org'},
+          {
+            stringValue:
+              'my email is user2@example.org and phone is 858-555-0223',
+          },
+        ],
+      },
+      {
+        values: [
+          {
+            stringValue: 'user3@example.org',
+          },
+          {
+            stringValue:
+              'my email is user3@example.org and phone is 858-555-0224',
+          },
+        ],
+      },
+    ],
+  };
+
+  async function deIdentifyTableWithMultipleCryptoHash() {
+    // The type of info the inspection will look for.
+    const infoTypes = [{name: 'PHONE_NUMBER'}, {name: 'EMAIL_ADDRESS'}];
+
+    // The fields to be de-identified.
+    const fieldIds1 = [{name: 'userid'}];
+
+    const fieldIds2 = [{name: 'comments'}];
+
+    // Construct two primitive transformations using two different keys.
+    const primitiveTransformation1 = {
+      cryptoHashConfig: {
+        cryptoKey: {
+          transient: {
+            name: transientKey1,
+          },
+        },
+      },
+    };
+
+    const primitiveTransformation2 = {
+      cryptoHashConfig: {
+        cryptoKey: {
+          transient: {
+            name: transientKey2,
+          },
+        },
+      },
+    };
+
+    // Construct infoType transformation using transient key 2
+    const infoTypeTransformation = {
+      primitiveTransformation: primitiveTransformation2,
+      infoTypes: infoTypes,
+    };
+
+    // Associate each field with transformation defined above.
+    const fieldTransformations = [
+      {
+        fields: fieldIds1,
+        primitiveTransformation: primitiveTransformation1,
+      },
+      {
+        fields: fieldIds2,
+        infoTypeTransformations: {
+          transformations: [infoTypeTransformation],
+        },
+      },
+    ];
+
+    // Use transformation confiugrations and construct de-identify configuration.
+    const deidentifyConfig = {
+      recordTransformations: {
+        fieldTransformations: fieldTransformations,
+      },
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: deidentifyConfig,
+      inspectConfig: {
+        infoTypes: infoTypes,
+      },
+      item: {
+        table: tableToDeIdentify,
+      },
+    };
+
+    // Send the request and receive response from the service.
+    const [response] = await dlp.deidentifyContent(request);
+
+    const deidentifiedTable = response.item.table;
+
+    // Print the results.
+    console.log(
+      `Deidentified table: ${JSON.stringify(deidentifiedTable, null, 2)}`
+    );
+  }
+  deIdentifyTableWithMultipleCryptoHash();
+  // [END dlp_deidentify_table_with_multiple_crypto_hash]
+}
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -628,4 +628,58 @@ describe('deid', () => {
       assert.equal(error.message, 'Failed');
     }
   });
+
+  // dlp_deidentify_table_with_crypto_hash
+  it('should deidentify table using defined crypto key', () => {
+    let output;
+    try {
+      output = execSync(
+        `node deIdentifyTableWithCryptoHash.js ${projectId} CRYPTO_KEY_1`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.notMatch(output, /"stringValue": user1@example.org/);
+    assert.notMatch(output, /"stringValue": user2@example.org/);
+    assert.notInclude(output, '858-555-0224');
+  });
+
+  it('should handle deidentification errors', () => {
+    let output;
+    try {
+      output = execSync(
+        'node deIdentifyTableWithCryptoHash.js BAD_PROJECT_ID CRYPTO_KEY_1'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
+
+  // dlp_deidentify_table_with_multiple_crypto_hash
+  it('should transform columns in the table using two separate cryptographic hash transformations', () => {
+    let output;
+    try {
+      output = execSync(
+        `node deIdentifyTableWithMultipleCryptoHash.js ${projectId} CRYPTO_KEY_1 CRYPTO_KEY_2`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.notMatch(output, /"stringValue": user1@example.org/);
+    assert.notMatch(output, /"stringValue": user2@example.org/);
+    assert.notInclude(output, '858-555-0224');
+  });
+
+  it('should handle deidentification errors', () => {
+    let output;
+    try {
+      output = execSync(
+        'node deIdentifyTableWithMultipleCryptoHash.js BAD_PROJECT_ID CRYPTO_KEY_1 CRYPTO_KEY_2'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_findings_using_a_cryptographic_hash_transformation
https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_findings_using_two_separate_cryptographic_hash_transformations

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
