### PR TITLE
chore(cleanup): retire media translate samples

### DIFF
--- a/mediatranslation/README.md
+++ b/mediatranslation/README.md
@@ -1,0 +1,6 @@
+# Media Translation API deprication
+
+Media Translation API is [deprecated] and will no longer be available on Google Cloud after July 1, 2024.
+All API code samples under this folder are no longer maintained and will be removed after July 1, 2024.
+
+[deprecated]: https://cloud.google.com/translate/media/docs/deprecations

--- a/mediatranslation/test/quickstart.test.js
+++ b/mediatranslation/test/quickstart.test.js
@@ -23,8 +23,9 @@ const cmd = 'node quickstart.js';
 const filePath = path.join(__dirname, '..', 'resources/audio.raw');
 const exec = cmd => execSync(cmd, {encoding: 'utf-8'});
 
+// skip this test because testing code sample is deprecated
 describe('Quickstart', () => {
-  it('should translate from a streamed file', async () => {
+  it.skip('should translate from a streamed file', async () => {
     const stdout = exec(`${cmd} ${filePath} linear16 en-US es-ES`);
     assert.include(stdout, 'Partial translation');
   });

--- a/mediatranslation/test/translate_from_file.test.js
+++ b/mediatranslation/test/translate_from_file.test.js
@@ -23,8 +23,9 @@ const cmd = 'node translate_from_file.js';
 const filePath = path.join(__dirname, '..', 'resources/audio.raw');
 const exec = cmd => execSync(cmd, {encoding: 'utf-8'});
 
+// skip this test because testing code sample is deprecated
 describe('MediaTranslation', () => {
-  it('should translate from a streamed file', async () => {
+  it.skip('should translate from a streamed file', async () => {
     const stdout = exec(`${cmd} ${filePath} linear16 en-US es-ES`);
     assert.include(stdout, 'Partial translation');
   });


### PR DESCRIPTION
### Description

Adds README with the deprecation message.
Removes tests.

Fixes #3323
