### PR TITLE
refactor: upgrade websockets run to node 16 🚧 

### DIFF
--- a/run/websockets/package.json
+++ b/run/websockets/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "license": "Apache Version 2.0",
   "author": "Google LLC",
+  "engines": {
+    "node": ">=16.x.x"
+  },
   "scripts": {
     "start": "node index.js",
     "system-test": "c8 mocha test/system.test.js --timeout=420000 --exit"
@@ -21,6 +24,6 @@
     "google-auth-library": "^8.7.0",
     "got": "^11.8.3",
     "mocha": "^10.2.0",
-    "puppeteer": "^20.0.0" 
+    "puppeteer": "^20.0.0"
   }
 }


### PR DESCRIPTION
## Description

Fixes #3328 

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
