### PR TITLE
feat(cloud-sql): add tedious connector sample

### DIFF
--- a/cloud-sql/sqlserver/tedious/Dockerfile
+++ b/cloud-sql/sqlserver/tedious/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the official lightweight Node.js image.
+
+# https://hub.docker.com/_/node
+FROM node:18-slim
+
+# Create and change to the app directory.
+WORKDIR /app
+
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure both package.json AND package-lock.json are copied.
+# Copying this separately prevents re-running npm install on every code change.
+COPY package*.json ./
+
+# Install dependencies.
+# If you add a package-lock.json speed your build by switching to 'npm ci'.
+# RUN npm ci --only=production
+RUN npm install --production
+
+# Copy local code to the container image.
+COPY . ./
+
+# Run the web service on container startup.
+CMD [ "npm", "start" ]

--- a/cloud-sql/sqlserver/tedious/README.md
+++ b/cloud-sql/sqlserver/tedious/README.md
@@ -1,0 +1,384 @@
+# Connecting to Cloud SQL - MS SQL Server
+
+This demo application can be used to connect to Cloud SQL in two different ways:
+
+1. [The Cloud SQL Node.js Connector](https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector) (recommended)
+2. [The Cloud SQL Auth Proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy)
+
+Using the Cloud SQL Node.js Connector package is recommended over the
+Cloud SQL Auth Proxy as it provides all the same functionality and features but
+as a npm package. See [`@google-cloud/cloud-sql-connector`](https://www.npmjs.com/package/@google-cloud/cloud-sql-connector).
+
+## Before you begin
+
+:warning: Note that this sample currently does not support connection pooling,
+this issue is
+[being tracked in the **Cloud SQL Node.js Connector** repository](https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector/issues/154). Ideally the `mssql` example will be updated to support a modern version of `tedious` that has support to the Cloud SQL Node.js Connector but for now, keep in mind that this is a limited example.
+
+1. If you haven't already, set up a Node.js Development Environment by following
+the [Node.js setup guide](https://cloud.google.com/nodejs/docs/setup)  and
+[create a
+project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
+
+1. [Create a Google Cloud SQL "SQL Server" instance](
+    <https://cloud.google.com/sql/docs/sqlserver/create-instance>). Note the
+    instance `connection name` of the instance that you create, and password
+    that you specify for the default 'sqlserver' user.
+
+1. Under the instance's "DATABASES" tab, create a new database.
+
+    1. Click **Create database**.
+
+    1. For **Database name**, enter `votes`.
+
+    1. Click **CREATE**.
+
+1. Create a service account following these
+   [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating),
+   and then grant the `roles/cloudsql.client` role following these
+   [instructions](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
+   Download a JSON key to use to authenticate your connection.
+
+Note: Defining credentials in environment variables is convenient, but not
+secure. For a more secure solution, use [Secret
+Manager](https://cloud.google.com/secret-manager/) to help keep secrets safe.
+You can then define `export
+CLOUD_SQL_CREDENTIALS_SECRET='projects/PROJECT_ID/secrets/SECRET_ID/versions/VERSION'`
+to reference a secret that stores your Cloud SQL database password. The sample
+app checks for your defined secret version. If a version is present, the app
+retrieves the `DB_PASS` from Secret Manager before it connects to Cloud SQL.
+
+## Cloud SQL Node.js Connector Usage
+
+### Running locally
+
+To run the demo application locally using the Cloud SQL Node.js Connector, set
+environment variables and install dependencies as shown below.
+
+Note: The `INSTANCE_CONNECTION_NAME` for your instance can be found on the
+**Overview** page for your instance in the
+[Google Cloud console](https://console.cloud.google.com/sql) or by running
+the following command:
+
+```sh
+gcloud sql instances describe <INSTANCE_NAME> --format='value(connectionName)'
+```
+
+#### Linux / Mac OS
+
+Use these terminal commands to initialize environment variables:
+
+```bash
+export INSTANCE_CONNECTION_NAME='<INSTANCE_CONNECTION_NAME>'
+export DB_USER='<DB_USER_NAME>'
+export DB_PASS='<DB_PASSWORD>'
+export DB_NAME='<DB_NAME>'
+```
+
+#### Windows/PowerShell
+
+Use these PowerShell commands to initialize environment variables:
+
+```powershell
+$env:INSTANCE_CONNECTION_NAME="<INSTANCE_CONNECTION_NAME>"
+$env:DB_USER="<DB_USER_NAME>"
+$env:DB_PASS="<DB_PASSWORD>"
+$env:DB_NAME="<DB_NAME>"
+```
+
+### Testing the application
+
+1. Next, install the Node.js packages necessary to run the app locally by
+   running the following command:
+
+    ```sh
+    npm install
+    ```
+
+2. Run the sample app locally with the following command:
+
+    ```sh
+    npm start
+    ```
+
+Navigate towards `http://127.0.0.1:8080` to verify your application is running
+correctly.
+
+### Deploy to Google App Engine Standard
+
+1. To allow your app to connect to your Cloud SQL instance when the app is
+   deployed, modify the [`app.standard.yaml`](app.standard.yaml) to add the
+   user, password, database, and an instance connection name to the related
+   environment variables, like in the example below:
+
+    ```yaml
+    env_variables:
+      INSTANCE_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>
+      DB_USER: MY_DB_USER
+      DB_PASS: MY_DB_PASSWORD
+      DB_NAME: MY_DATABASE
+    ```
+
+2. To deploy to App Engine Standard, run the following command:
+
+    ```sh
+    gcloud app deploy app.standard.yaml
+    ```
+
+3. To launch your browser and view the app at
+   <https://[YOUR_PROJECT_ID]>.appspot.com, run the following command:
+
+    ```sh
+    gcloud app browse
+    ```
+
+### Deploy to Google App Engine Flexible
+
+1. To allow your app to connect to your Cloud SQL instance when the app is
+   deployed, modify the [`app.flexible.yaml`](app.flexible.yaml) to add the
+   user, password, database, and an instance connection name to the related
+   environment variables, like in the example below:
+
+    ```yaml
+    env_variables:
+      INSTANCE_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>
+      DB_USER: MY_DB_USER
+      DB_PASS: MY_DB_PASSWORD
+      DB_NAME: MY_DATABASE
+    ```
+
+2. To deploy to App Engine Node.js Flexible Environment, run the following
+   command:
+
+    ```sh
+    gcloud app deploy app.flexible.yaml
+    ```
+
+3. To launch your browser and view the app at
+   <https://[YOUR_PROJECT_ID]>.appspot.com, run the following command:
+
+    ```sh
+    gcloud app browse
+    ```
+
+### Deploy to Cloud Run
+
+See the [Cloud Run
+documentation](https://cloud.google.com/sql/docs/sqlserver/connect-run) for more
+details on connecting a Cloud Run service to Cloud SQL.
+
+Build and deploy the service to Cloud Run:
+
+```sh
+gcloud run deploy run-sql --source . /
+    --allow-unauthenticated \
+    --set-env-vars INSTANCE_CONNECTION_NAME=[INSTANCE_CONNECTION_NAME],\
+      DB_USER=[MY_DB_USER],DB_PASS=[MY_DB_PASS],DB_NAME=[MY_DB]
+```
+
+Replace environment variables with the correct values for your Cloud SQL
+instance configuration.
+
+It is recommended to use the [Secret Manager
+integration](https://cloud.google.com/run/docs/configuring/secrets) for Cloud
+Run instead of using environment variables for the SQL configuration. The
+service injects the SQL credentials from Secret Manager at runtime via an
+environment variable.
+
+Create secrets via the command line:
+
+```sh
+echo -n $INSTANCE_CONNECTION_NAME | \
+    gcloud secrets create [INSTANCE_CONNECTION_NAME_SECRET] --data-file=-
+```
+
+Deploy the service to Cloud Run specifying the env var name and secret name:
+
+```sh
+gcloud run deploy run-sql --source . /
+    --allow-unauthenticated \
+    --update-secrets INSTANCE_CONNECTION_NAME=[INSTANCE_CONNECTION_NAME_SECRET]:latest, \
+      DB_USER=[DB_USER_SECRET]:latest, \
+      DB_PASS=[DB_PASS_SECRET]:latest, \
+      DB_NAME=[DB_NAME_SECRET]:latest
+```
+
+1. Navigate your browser to the URL noted in step 2.
+
+For more details about using Cloud Run see <http://cloud.run>. Review other
+[Node.js on Cloud Run samples](../../../run/).
+
+### Deploy to Cloud Functions
+
+To deploy the service to [Cloud Functions](https://cloud.google.com/functions/docs) run the following command:
+
+```sh
+gcloud functions deploy votes --gen2 --runtime nodejs18 --trigger-http \
+  --allow-unauthenticated \
+  --entry-point votes \
+  --region <INSTANCE_REGION> \
+  --set-env-vars INSTANCE_CONNECTION_NAME=<PROJECT_ID>:<INSTANCE_REGION>:<INSTANCE_NAME> \
+  --set-env-vars DB_USER=$DB_USER \
+  --set-env-vars DB_PASS=$DB_PASS \
+  --set-env-vars DB_NAME=$DB_NAME
+```
+
+## Cloud SQL Auth Proxy Usage
+
+### Running locally
+
+You may optionally download and install the `cloud-sql-proxy` by
+[following the
+instructions](https://cloud.google.com/sql/docs/sqlserver/sql-proxy#install) as an
+alternative to using the
+[Cloud SQL Node.js Connector](https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector).
+
+### Launch proxy with TCP
+
+To run the sample locally with a TCP connection, set environment variables and
+launch the proxy as shown below.
+
+#### Linux / Mac OS
+
+Use these terminal commands to initialize environment variables:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS='/path/to/service/account/key.json'
+export INSTANCE_HOST='127.0.0.1'
+export DB_PORT='1433'
+export DB_USER='<DB_USER_NAME>'
+export DB_PASS='<DB_PASSWORD>'
+export DB_NAME='<DB_NAME>'
+```
+
+Then use this command to launch the proxy in the background:
+
+```bash
+./cloud-sql-proxy <PROJECT_ID>:<INSTANCE_REGION>:<INSTANCE_NAME> &
+```
+
+#### Windows/PowerShell
+
+Use these PowerShell commands to initialize environment variables:
+
+```powershell
+$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
+$env:INSTANCE_HOST="127.0.0.1"
+$env:DB_PORT="1433"
+$env:DB_USER="<DB_USER_NAME>"
+$env:DB_PASS="<DB_PASSWORD>"
+$env:DB_NAME="<DB_NAME>"
+```
+
+Then use this command to launch the proxy in a separate PowerShell session:
+
+```powershell
+Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:1433 -credential_file=<CREDENTIALS_JSON_FILE>"
+```
+
+### Testing the application
+
+1. Next, install the Node.js packages necessary to run the app locally by
+   running the following command:
+
+    ```sh
+    npm install
+    ```
+
+2. Run the sample app locally with the following command:
+
+    ```sh
+    npm start
+    ```
+
+Navigate towards `http://127.0.0.1:8080` to verify your application is running
+correctly.
+
+### Deploy to Google App Engine Standard
+
+To run on GAE-Standard, create an App Engine project by following the setup for
+these
+[instructions](https://cloud.google.com/appengine/docs/standard/nodejs/quickstart#before-you-begin).
+
+First, update [`app.standard.yaml`](app.standard.yaml) with the correct values
+to pass the environment variables into the runtime. e.g:
+
+```
+env_variables:
+  INSTANCE_HOST: 127.0.0.1
+  DB_USER: MY_DB_USER
+  DB_PASS: MY_DB_PASSWORD
+  DB_NAME: MY_DATABASE
+  DB_PORT: 1433
+```
+
+Next, the following command will deploy the application to your Google Cloud
+project:
+
+```bash
+gcloud app deploy app.standard.yaml
+```
+
+To launch your browser and view the app at
+<https://[YOUR_PROJECT_ID>].appspot.com, run the following command:
+
+```bash
+gcloud app browse
+```
+
+### Deploy to Google App Engine Flexible
+
+App Engine Flexible supports connecting to your SQL Server instance through TCP
+
+First, update [`app.flexible.yaml`](app.flexible.yaml) with the correct values
+to pass the environment variables and instance name into the runtime. e.g:
+
+```
+env_variables:
+  INSTANCE_HOST: 172.17.0.1
+  DB_USER: MY_DB_USER
+  DB_PASS: MY_DB_PASSWORD
+  DB_NAME: MY_DATABASE
+  DB_PORT: 1433
+```
+
+Then, make sure that the service account
+`service-{PROJECT_NUMBER}>@gae-api-prod.google.com.iam.gserviceaccount.com` has
+the IAM role `Cloud SQL Client`.
+
+The following command will deploy the application to your Google Cloud project:
+
+```bash
+gcloud app deploy app.flexible.yaml
+```
+
+### Deploy to Cloud Functions
+
+To deploy the service to [Cloud Functions](https://cloud.google.com/functions/docs) run the following command:
+
+```sh
+gcloud functions deploy votes --gen2 --runtime nodejs18 --trigger-http \
+  --allow-unauthenticated \
+  --entry-point votes \
+  --region <INSTANCE_REGION> \
+  --set-env-vars INSTANCE_HOST='127.0.0.1'> \
+  --set-env-vars DB_PORT='1433' \
+  --set-env-vars DB_USER=$DB_USER \
+  --set-env-vars DB_PASS=$DB_PASS \
+  --set-env-vars DB_NAME=$DB_NAME
+```
+
+Note: If the function fails to deploy or returns a `500: Internal service error`,
+this may be due to a known limitation with Cloud Functions gen2 not being able
+to configure the underlying Cloud Run service with a Cloud SQL connection.
+
+A workaround command to fix this is is to manually revise the Cloud Run
+service with the Cloud SQL Connection:
+
+```sh
+gcloud run deploy votes --source . \
+  --region <INSTANCE_REGION> \
+  --add-cloudsql-instances <PROJECT_ID>:<INSTANCE_REGION>:<INSTANCE_NAME>
+```
+
+The Cloud Function command above can now be re-run with a successful deployment.

--- a/cloud-sql/sqlserver/tedious/app.flexible.yaml
+++ b/cloud-sql/sqlserver/tedious/app.flexible.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: custom
+env: flex
+
+# The following env variables may contain sensitive information that grants
+# anyone access to your database. Do not add this file to your source control.
+env_variables:
+  INSTANCE_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>
+  DB_USER: MY_DB_USER
+  DB_PASS: MY_DB_PASSWORD
+  DB_NAME: MY_DATABASE

--- a/cloud-sql/sqlserver/tedious/app.standard.yaml
+++ b/cloud-sql/sqlserver/tedious/app.standard.yaml
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: nodejs18
+ 
+# The following env variables may contain sensitive information that grants
+# anyone access to your database. Do not add this file to your source control.
+env_variables:
+  INSTANCE_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>
+  DB_USER: MY_DB_USER
+  DB_PASS: MY_DB_PASSWORD
+  DB_NAME: MY_DATABASE

--- a/cloud-sql/sqlserver/tedious/connect-connector.js
+++ b/cloud-sql/sqlserver/tedious/connect-connector.js
@@ -1,0 +1,76 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+// [START cloud_sql_sqlserver_tedious_connect_connector]
+const {Connection} = require('tedious');
+const {Connector} = require('@google-cloud/cloud-sql-connector');
+
+// In case the PRIVATE_IP environment variable is defined then we set
+// the ipType=PRIVATE for the new connector instance, otherwise defaults
+// to public ip type.
+const getIpType = () =>
+  process.env.PRIVATE_IP === '1' || process.env.PRIVATE_IP === 'true'
+    ? 'PRIVATE'
+    : 'PUBLIC';
+
+// connectWithConnector initializes a TCP connection
+// to a Cloud SQL instance of SQL Server.
+const connectWithConnector = async config => {
+  // Note: Saving credentials in environment variables is convenient, but not
+  // secure - consider a more secure solution such as
+  // Cloud Secret Manager (https://cloud.google.com/secret-manager) to help
+  // keep secrets safe.
+  const connector = new Connector();
+  const clientOpts = await connector.getTediousOptions({
+    instanceConnectionName: process.env.INSTANCE_CONNECTION_NAME,
+    ipType: getIpType(),
+  });
+  const dbConfig = {
+    // Please note that the `server` property here is not used and is only
+    // defined due to a bug in the tedious driver
+    // (ref: https://github.com/tediousjs/tedious/issues/1541)
+    // With that in mind, do not try to change this value since it will have no
+    // impact in how the connector works, this sample will be updated to remove
+    // this property declaration as soon as the tedious driver bug is fixed
+    server: '0.0.0.0', // e.g. '127.0.0.1'
+    authentication: {
+      type: 'default',
+      options: {
+        userName: process.env.DB_USER, // e.g. 'my-db-user'
+        password: process.env.DB_PASS, // e.g. 'my-db-password'
+      },
+    },
+    options: {
+      ...clientOpts,
+      // Please note that the `port` property here is not used and is only
+      // defined due to a bug in the tedious driver
+      // (ref: https://github.com/tediousjs/tedious/issues/1541)
+      // With that in mind, do not try to change this value since it will have
+      // no impact in how the connector works, this sample will be updated to
+      // remove this property declaration as soon as the tedious driver bug is
+      // fixed
+      port: 9999,
+      database: process.env.DB_NAME, // e.g. 'my-database'
+      useColumnNames: true,
+    },
+    // ... Specify additional properties here.
+    ...config,
+  };
+
+  // Establish a connection to the database.
+  return new Connection(dbConfig);
+};
+// [END cloud_sql_sqlserver_tedious_connect_connector]
+module.exports = connectWithConnector;

--- a/cloud-sql/sqlserver/tedious/connect-tcp.js
+++ b/cloud-sql/sqlserver/tedious/connect-tcp.js
@@ -1,0 +1,58 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+// [START cloud_sql_sqlserver_tedious_connect_tcp]
+const {Connection} = require('tedious');
+
+// connectWithConnector initializes a TCP connection
+// to a Cloud SQL instance of SQL Server.
+const connectWithTcpSocket = async config => {
+  // Note: Saving credentials in environment variables is convenient, but not
+  // secure - consider a more secure solution such as
+  // Cloud Secret Manager (https://cloud.google.com/secret-manager) to help
+  // keep secrets safe.
+  const dbConfig = {
+    server: process.env.INSTANCE_HOST, // e.g. '127.0.0.1'
+    authentication: {
+      type: 'default',
+      options: {
+        userName: process.env.DB_USER, // e.g. 'my-db-user'
+        password: process.env.DB_PASS, // e.g. 'my-db-password'
+      },
+    },
+    options: {
+      port: parseInt(process.env.DB_PORT), // e.g. 1433
+      database: process.env.DB_NAME, // e.g. 'my-database'
+      useColumnNames: true,
+      encrypt: false,
+    },
+    // ... Specify additional properties here.
+    ...config,
+  };
+  // [END cloud_sql_sqlserver_tedious_connect_tcp]
+
+  // (OPTIONAL) Configure encrypted connection
+  // For deployments that connect directly to a Cloud SQL instance without
+  // using the Cloud SQL Proxy, configure encrypted connection.
+  if (process.env.PRIVATE_IP === '1' || process.env.PRIVATE_IP === 'true') {
+    dbConfig.options.encrypt = true;
+  }
+
+  // [START cloud_sql_sqlserver_tedious_connect_tcp]
+  // Establish a connection to the database.
+  return new Connection(dbConfig);
+};
+// [END cloud_sql_sqlserver_tedious_connect_tcp]
+module.exports = connectWithTcpSocket;

--- a/cloud-sql/sqlserver/tedious/deployment.yaml
+++ b/cloud-sql/sqlserver/tedious/deployment.yaml
@@ -1,0 +1,58 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_sql_sqlserver_tedious_gke_quickstart_deployment]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gke-cloud-sql-quickstart
+spec:
+  selector:
+    matchLabels:
+      app: gke-cloud-sql-app
+  template:
+    metadata:
+      labels:
+        app: gke-cloud-sql-app
+    spec:
+      serviceAccountName: <YOUR-KSA-NAME>
+      containers:
+      - name: gke-cloud-sql-app
+        # Replace <LOCATION> with your Artifact Registry location (e.g., us-central1).
+        # Replace <YOUR_PROJECT_ID> with your project ID.
+        image: <LOCATION>-docker.pkg.dev/<YOUR_PROJECT_ID>/gke-cloud-sql-repo/gke-sql:latest
+        # This app listens on port 8080 for web traffic by default.
+        ports:
+        - containerPort: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        - name: INSTANCE_CONNECTION_NAME
+          value: "<INSTANCE_CONNECTION_NAME>"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: <YOUR-DB-SECRET>
+              key: username
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: <YOUR-DB-SECRET>
+              key: password
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: <YOUR-DB-SECRET>
+              key: database
+# [END cloud_sql_sqlserver_tedious_gke_quickstart_deployment]

--- a/cloud-sql/sqlserver/tedious/index.js
+++ b/cloud-sql/sqlserver/tedious/index.js
@@ -1,0 +1,212 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const express = require('express');
+const createConnectorConnection = require('./connect-connector.js');
+const createTcpConnection = require('./connect-tcp.js');
+const getTediousHelper = require('./tedious-helper.js');
+
+const app = express();
+app.set('view engine', 'pug');
+app.enable('trust proxy');
+
+// This middleware is available in Express v4.16.0 onwards
+// Automatically parse request body as form data.
+app.use(express.urlencoded({extended: false}));
+app.use(express.json());
+
+// Set Content-Type for all responses for these routes.
+app.use((req, res, next) => {
+  res.set('Content-Type', 'text/html');
+  next();
+});
+
+// Create a Winston logger that streams to Stackdriver Logging.
+const winston = require('winston');
+const {LoggingWinston} = require('@google-cloud/logging-winston');
+const loggingWinston = new LoggingWinston();
+const logger = winston.createLogger({
+  level: 'info',
+  transports: [new winston.transports.Console(), loggingWinston],
+});
+
+// Retrieve and return a specified secret from Secret Manager
+const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+const client = new SecretManagerServiceClient();
+
+async function accessSecretVersion(secretName) {
+  const [version] = await client.accessSecretVersion({name: secretName});
+  return version.payload.data;
+}
+
+const createConnection = async () => {
+  // Check if a Secret Manager secret version is defined
+  // If a version is defined, retrieve the secret from Secret Manager and set as the DB_PASS
+  const {CLOUD_SQL_CREDENTIALS_SECRET} = process.env;
+  if (CLOUD_SQL_CREDENTIALS_SECRET) {
+    const secrets = await accessSecretVersion(CLOUD_SQL_CREDENTIALS_SECRET);
+    try {
+      process.env.DB_PASS = secrets.toString();
+    } catch (err) {
+      err.message = `Unable to parse secret from Secret Manager. Make sure that the secret is JSON formatted: \n ${err.message} `;
+      throw err;
+    }
+  }
+
+  if (process.env.INSTANCE_CONNECTION_NAME) {
+    return createConnectorConnection();
+  } else {
+    return createTcpConnection();
+  }
+};
+
+let validSchema = false;
+let connection;
+
+const ensureSchema = async () => {
+  // Wait for tables to be created (if they don't already exist).
+  await connection.query(
+    `IF NOT EXISTS (
+        SELECT * FROM sysobjects WHERE name='votes' and xtype='U')
+      CREATE TABLE votes (
+        vote_id INT NOT NULL IDENTITY,
+        time_cast DATETIME NOT NULL,
+        candidate VARCHAR(6) NOT NULL,
+        PRIMARY KEY (vote_id));`
+  );
+  console.log("Ensured that table 'votes' exists");
+  validSchema = true;
+};
+
+const connectionPromise = createConnection()
+  .then(conn => {
+    connection = getTediousHelper(conn);
+  })
+  .then(() => connection.connect())
+  .then(ensureSchema)
+  .catch(err => {
+    logger.error(err);
+    throw err;
+  });
+
+app.use(async (req, res, next) => {
+  if (validSchema) {
+    return next();
+  }
+  try {
+    await connectionPromise;
+    next();
+  } catch (err) {
+    logger.error(err);
+    return next(err);
+  }
+});
+
+// Serve the index page, showing vote tallies.
+const httpGet = async (req, res) => {
+  try {
+    // Get the 5 most recent votes.
+    const recentVotes = await connection.query(
+      'SELECT TOP(5) candidate, time_cast FROM votes ORDER BY time_cast DESC'
+    );
+
+    const {NVarChar} = connection.TYPES;
+
+    // Get votes
+    const stmt =
+      'SELECT COUNT(vote_id) as count FROM votes WHERE candidate=@candidate';
+    const [tabsVotes] = await connection.query(stmt, [
+      ['candidate', NVarChar, 'TABS'],
+    ]);
+    const [spacesVotes] = await connection.query(stmt, [
+      ['candidate', NVarChar, 'SPACES'],
+    ]);
+
+    // failing: no recordset on undefined
+    res.render('index.pug', {
+      recentVotes: recentVotes || [],
+      tabCount: tabsVotes.count.value,
+      spaceCount: spacesVotes.count.value,
+    });
+  } catch (err) {
+    logger.error(err);
+    res
+      .status(500)
+      .send(
+        'Unable to load page. Please check the application logs for more details.'
+      )
+      .end();
+  }
+};
+
+app.get('/', httpGet);
+
+// Handle incoming vote requests and inserting them into the database.
+const httpPost = async (req, res) => {
+  const {team} = req.body;
+  const timestamp = new Date();
+
+  if (!team || (team !== 'TABS' && team !== 'SPACES')) {
+    return res.status(400).send('Invalid team specified.').end();
+  }
+
+  try {
+    const stmt =
+      'INSERT INTO votes (time_cast, candidate) VALUES (@timestamp, @team)';
+    const {DateTime, NVarChar} = connection.TYPES;
+    // Runs query
+    await connection.query(stmt, [
+      ['timestamp', DateTime, timestamp],
+      ['team', NVarChar, team],
+    ]);
+  } catch (err) {
+    // If something goes wrong, handle the error in this section. This might
+    // involve retrying or adjusting parameters depending on the situation.
+    logger.error(err);
+    return res
+      .status(500)
+      .send(
+        'Unable to successfully cast vote! Please check the application logs for more details.'
+      )
+      .end();
+  }
+
+  res.status(200).send(`Successfully voted for ${team} at ${timestamp}`).end();
+};
+
+app.post('*', httpPost);
+
+/**
+ * Responds to GET and POST requests for TABS vs SPACES sample app.
+ *
+ * @param {Object} req Cloud Function request context.
+ * @param {Object} res Cloud Function response context.
+ */
+exports.votes = (req, res) => {
+  switch (req.method) {
+    case 'GET':
+      httpGet(req, res);
+      break;
+    case 'POST':
+      httpPost(req, res);
+      break;
+    default:
+      res.status(405).send({error: 'Something blew up!'});
+      break;
+  }
+};
+
+module.exports.app = app;

--- a/cloud-sql/sqlserver/tedious/package.json
+++ b/cloud-sql/sqlserver/tedious/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cloudsql-sqlserver",
+  "description": "Node.js SQL Server sample for Cloud SQL",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google Inc.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "scripts": {
+    "start": "node server/server.js",
+    "system-test": "c8 mocha test/*.test.js --timeout=60000 --exit",
+    "test": "npm run system-test"
+  },
+  "dependencies": {
+    "@google-cloud/cloud-sql-connector": "^0.4.0",
+    "@google-cloud/functions-framework": "^3.0.0",
+    "@google-cloud/logging-winston": "^5.0.0",
+    "@google-cloud/secret-manager": "^4.0.0",
+    "express": "^4.17.1",
+    "pug": "^3.0.0",
+    "tedious": "^16.1.0",
+    "winston": "^3.1.0"
+  },
+  "devDependencies": {
+    "c8": "^8.0.0",
+    "mocha": "^10.0.0",
+    "supertest": "^6.0.0"
+  }
+}

--- a/cloud-sql/sqlserver/tedious/server/server.js
+++ b/cloud-sql/sqlserver/tedious/server/server.js
@@ -1,0 +1,31 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const app = require('../index.js');
+
+const PORT = parseInt(process.env.PORT) || 8080;
+const server = app.app.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+  console.log('Press Ctrl+C to quit.');
+});
+
+const environment = process.env.NODE_ENV || 'development';
+if (environment === 'development') {
+  process.on('unhandledRejection', err => {
+    console.error(err);
+    throw err;
+  });
+}
+
+module.exports = server;

--- a/cloud-sql/sqlserver/tedious/service-account.yaml
+++ b/cloud-sql/sqlserver/tedious/service-account.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_sql_sqlserver_tedious_gke_quickstart_sa]
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <YOUR-KSA-NAME> # TODO(developer): replace this value
+# [END cloud_sql_sqlserver_tedious_gke_quickstart_sa]

--- a/cloud-sql/sqlserver/tedious/service.yaml
+++ b/cloud-sql/sqlserver/tedious/service.yaml
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_sql_sqlserver_tedious_gke_quickstart_service]
+# The service provides a load-balancing proxy over the gke-cloud-sql-app
+# pods. By specifying the type as a 'LoadBalancer', Kubernetes Engine will
+# create an external HTTP load balancer.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gke-cloud-sql-app
+spec:
+  type: LoadBalancer
+  selector:
+    app: gke-cloud-sql-app
+  ports:
+  - port: 80
+    targetPort: 8080
+# [END cloud_sql_sqlserver_tedious_gke_quickstart_service]

--- a/cloud-sql/sqlserver/tedious/tedious-helper.js
+++ b/cloud-sql/sqlserver/tedious/tedious-helper.js
@@ -1,0 +1,99 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {Request, TYPES} = require('tedious');
+
+// Promisifies the callback-based Tedious connect API
+const connect = connection => () =>
+  new Promise((res, rej) => {
+    connection.connect(err => {
+      if (err) {
+        return rej(err);
+      }
+      res();
+    });
+  });
+
+// Helper to execute SQL queries using the Tedious.Request API
+const query = connection => (value, inputs) =>
+  new Promise((res, rej) => {
+    let error = false;
+    const result = [];
+
+    // Initialized callback-based Tedious Request API
+    const req = new Request(value, err => {
+      if (err) {
+        rej(err);
+        error = true;
+      }
+    });
+
+    // if original Request callback API failed, skip
+    if (error) {
+      return;
+    }
+
+    // set error, progress and completion listeners in a way that is
+    // easy to dereference them all once the query resolves
+    const errorListener = err => {
+      cleanListeners();
+      rej(err);
+    };
+    const progressListener = columns => {
+      result.push(columns);
+    };
+    const successListener = () => {
+      cleanListeners();
+      res(result);
+    };
+    const cleanListeners = () => {
+      req
+        .off('error', errorListener)
+        .off('row', progressListener)
+        .off('requestCompleted', successListener);
+    };
+    req
+      .on('error', errorListener)
+      .on('row', progressListener)
+      .on('requestCompleted', successListener);
+
+    // Optionally add parameters to queries that are defining input
+    if (inputs && inputs.length) {
+      for (const input of inputs) {
+        const [name, type, value] = input;
+        req.addParameter(name, type, value);
+      }
+    }
+
+    // executes the query
+    try {
+      connection.execSql(req);
+    } catch (err) {
+      cleanListeners();
+      return rej(err);
+    }
+  });
+
+// Returns a helper object that has a connect and a query method,
+// abstracting the verbose internal logic for interacting
+// with the Tedious driver APIs.
+const getTediousHelper = conn => ({
+  connect: connect(conn),
+  query: query(conn),
+  TYPES,
+});
+
+module.exports = getTediousHelper;

--- a/cloud-sql/sqlserver/tedious/test/server.test.js
+++ b/cloud-sql/sqlserver/tedious/test/server.test.js
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const path = require('path');
+const request = require('supertest');
+const assert = require('assert');
+
+const SAMPLE_PATH = path.join(__dirname, '../server/server.js');
+
+const serverConnector = require(SAMPLE_PATH);
+
+const _instance_connect_backup = process.env.INSTANCE_CONNECTION_NAME;
+delete process.env.INSTANCE_CONNECTION_NAME;
+
+const serverTcp = require(SAMPLE_PATH);
+
+process.env.INSTANCE_CONNECTION_NAME = _instance_connect_backup;
+
+after(() => {
+  serverTcp.close();
+});
+
+it('should display the default page with connector', async () => {
+  await request(serverConnector)
+    .get('/')
+    .expect(response => {
+      assert.ok(response.text.includes('Tabs VS Spaces'));
+    })
+    .expect(200);
+});
+
+it('should display the default page over tcp', async () => {
+  await request(serverTcp)
+    .get('/')
+    .expect(response => {
+      assert.ok(response.text.includes('Tabs VS Spaces'));
+    })
+    .expect(200);
+});
+
+it('should handle insert error', async () => {
+  const expectedResult = 'Invalid team specified';
+
+  await request(serverTcp)
+    .post('/')
+    .expect(400)
+    .expect(response => {
+      assert.ok(response.text.includes(expectedResult));
+    });
+});

--- a/cloud-sql/sqlserver/tedious/views/index.pug
+++ b/cloud-sql/sqlserver/tedious/views/index.pug
@@ -1,0 +1,68 @@
+doctype html
+html(lang="en")
+  head
+    title Tabs VS Spaces
+
+    link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css")
+    link(rel="stylesheet", href="https://fonts.googleapis.com/icon?family=Material+Icons")
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js")
+  body
+
+    nav(class="red lighten-1")
+      div(class="nav-wrapper")
+        a(href="#" class="brand-logo center") Tabs VS Spaces
+
+    div(class="section")
+
+      div(class="center")
+        h4
+          - var diff = tabCount - spaceCount
+          if tabCount > spaceCount
+            = 'TABS are winning by ' + (tabCount - spaceCount) + ' votes!'
+          else if spaceCount > tabCount
+            = 'SPACES are winning by ' + (spaceCount - tabCount) + ' votes!'
+          else
+            = 'TABS and SPACES are evenly matched!'
+
+      div(class="row center")
+        div(class="col s6 m5 offset-m1")
+          div(class=(leadTeam === 'TABS') ? 'card-panel green lighten-3' : 'card-panel')
+            i(class="material-icons large") keyboard_tab
+            h3 #{tabCount} votes
+            button(id="voteTabs" class="btn green") Vote for TABS
+        div(class="col s6 m5")
+          div(class=(leadTeam === 'SPACES') ? 'card-panel blue lighten-3' : 'card-panel')
+            i(class="material-icons large") space_bar
+            h3 #{spaceCount} votes
+            button(id="voteSpaces" class="btn blue") Vote for SPACES
+
+      h4(class="header center") Recent Votes
+      ul(class="container collection center")
+        each vote in recentVotes
+          li(class="collection-item avatar")
+            if vote.candidate.value.trim() === 'TABS'
+              i(class="material-icons circle green") keyboard_tab
+            else
+              i(class="material-icons circle blue") space_bar
+            span(class="title") A vote for <b>#{vote.candidate.value}</b>
+            p was cast at #{vote.time_cast.value}.
+
+    script.
+      function vote(team) {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function () {
+          var msg = "";
+          if (this.readyState == 4) {
+            window.location.reload();
+          }
+        };
+        xhr.open("POST", "/votes", true);
+        xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        xhr.send("team=" + team);
+      }
+       document.getElementById("voteTabs").addEventListener("click", function () {
+        vote("TABS");
+      });
+      document.getElementById("voteSpaces").addEventListener("click", function () {
+        vote("SPACES");
+      });


### PR DESCRIPTION
This new sample uses the **Cloud SQL Node.js Connector** to connect to Cloud SQL instances instead of relying on the standalone Cloud SQL Proxy.

The original SQL Server sample from `cloud-sql/sqlserver/mssql` does not support the Cloud SQL Node.js Connector so this PR adds a new example residing in a new location: `cloud-sql/sqlserver/tedious`.

Ref: https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector
Ref: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3264
Ref: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3266
