### PR TITLE
DLP: Added samples for inspect image file

### DIFF
--- a/dlp/inspectImageFile.js
+++ b/dlp/inspectImageFile.js
@@ -1,0 +1,102 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspects a image file.
+//  description: Inspect a image for sensitive data like Phone Number, Email.
+//  usage: node inspectImageFile.js.js my-project imagePath infoTypes
+function main(projectId, imagePath) {
+  // [START dlp_inspect_image_file]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+  const mime = require('mime');
+  const fs = require('fs');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const imagePath = './test.jpeg';
+
+  // InfoTypes
+  const infoTypes = [
+    {name: 'PHONE_NUMBER'},
+    {name: 'EMAIL_ADDRESS'},
+    {name: 'CREDIT_CARD_NUMBER'},
+  ];
+
+  async function inspectImageFile() {
+    let fileBytes = null;
+    let fileTypeConstant = null;
+    try {
+      // Load Image
+      fileTypeConstant =
+        ['image/jpeg', 'image/bmp', 'image/png', 'image/svg'].indexOf(
+          mime.getType(imagePath)
+        ) + 1;
+      fileBytes = Buffer.from(fs.readFileSync(imagePath)).toString('base64');
+    } catch (error) {
+      console.log(error);
+      return;
+    }
+
+    // Specify item to inspect
+    const item = {
+      byteItem: {
+        type: fileTypeConstant,
+        data: fileBytes,
+      },
+    };
+
+    // Specify inspect configuration to match information with mentioned infotypes.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      includeQuote: true,
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectImageFile();
+  // [END dlp_inspect_image_file]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/inspectImageFileListedInfoTypes.js
+++ b/dlp/inspectImageFileListedInfoTypes.js
@@ -1,0 +1,101 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspects a image file.
+//  description: Inspect a image for certain built-in infoTypes.
+//  usage: node inspectImageFileListedInfoTypes.js my-project imagePath infoTypes
+function main(projectId, imagePath) {
+  // [START dlp_inspect_image_listed_infotypes]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+  const mime = require('mime');
+  const fs = require('fs');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const imagePath = './test.pdf';
+
+  // InfoTypes
+  const infoTypes = [
+    {name: 'PHONE_NUMBER'},
+    {name: 'EMAIL_ADDRESS'},
+    {name: 'US_SOCIAL_SECURITY_NUMBER'},
+  ];
+
+  async function inspectImageFileListedInfoTypes() {
+    let fileBytes = null;
+    let fileTypeConstant = null;
+    try {
+      // Load Image
+      fileTypeConstant =
+        ['image/jpeg', 'image/bmp', 'image/png', 'image/svg'].indexOf(
+          mime.getType(imagePath)
+        ) + 1;
+      fileBytes = Buffer.from(fs.readFileSync(imagePath)).toString('base64');
+    } catch (error) {
+      console.log(error);
+      return;
+    }
+    // Specify item to inspect
+    const item = {
+      byteItem: {
+        type: fileTypeConstant,
+        data: fileBytes,
+      },
+    };
+
+    // Specify inspect configuration to match information with mentioned infotypes.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      includeQuote: true,
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectImageFileListedInfoTypes();
+  // [END dlp_inspect_image_listed_infotypes]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -906,4 +906,46 @@ describe('inspect', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_inspect_image_file
+  it('should inspect a image file for matching infoTypes', () => {
+    const output = execSync(
+      `node inspectImageFile.js ${projectId} "resources/test.png"`
+    );
+    assert.match(output, /Findings: 2/);
+    assert.match(output, /InfoType: EMAIL_ADDRESS/);
+    assert.match(output, /InfoType: PHONE_NUMBER/);
+  });
+
+  it('should report any error while inspecting a image file', () => {
+    let output;
+    try {
+      output = execSync(`node inspectImageFile.js ${projectId} INVALID_PATH`);
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_PATH');
+  });
+
+  // dlp_inspect_image_listed_infotypes
+  it('should inspect a image file for matching infoTypes', () => {
+    const output = execSync(
+      `node inspectImageFileListedInfoTypes.js ${projectId} "resources/test.png"`
+    );
+    assert.match(output, /Findings: 2/);
+    assert.match(output, /InfoType: EMAIL_ADDRESS/);
+    assert.match(output, /InfoType: PHONE_NUMBER/);
+  });
+
+  it('should report any error while inspecting a image file', () => {
+    let output;
+    try {
+      output = execSync(
+        `node inspectImageFileListedInfoTypes.js ${projectId} INVALID_PATH`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_PATH');
+  });
 });


### PR DESCRIPTION
Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/samples/dlp-inspect-image-file
https://cloud.google.com/dlp/docs/samples/dlp-inspect-image-listed-infotypes

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
