### PR TITLE
Added sample for inspect GCS file, bigquery and datastore with SCC action

### DIFF
--- a/dlp/inspectBigquerySendToScc.js
+++ b/dlp/inspectBigquerySendToScc.js
@@ -1,0 +1,142 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Create a Dlp Job with Big Query Data and send its findings to Scc
+//  description: Uses the Data Loss Prevention API to Create a Dlp Job with Big Query Data and send its findings to Scc
+//  usage: node inspectBigquerySendToScc.js my-project dataProjectId datasetId tableId
+async function main(projectId, dataProjectId, datasetId, tableId) {
+  // [START dlp_inspect_bigquery_send_to_scc]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under.
+  // const projectId = "your-project-id";
+
+  // The project ID the table is stored under
+  // This may or (for public datasets) may not equal the calling project ID
+  // const dataProjectId = 'my-project';
+
+  // The ID of the dataset to inspect, e.g. 'my_dataset'
+  // const datasetId = 'my_dataset';
+
+  // The ID of the table to inspect, e.g. 'my_table'
+  // const tableId = 'my_table';
+
+  async function inspectBigQuerySendToScc() {
+    // Specify the storage configuration object with big query table.
+    const storageItem = {
+      bigQueryOptions: {
+        tableReference: {
+          projectId: dataProjectId,
+          datasetId: datasetId,
+          tableId: tableId,
+        },
+      },
+    };
+
+    // Specify the type of info the inspection will look for.
+    const infoTypes = [
+      {name: 'EMAIL_ADDRESS'},
+      {name: 'PERSON_NAME'},
+      {name: 'LOCATION'},
+      {name: 'PHONE_NUMBER'},
+    ];
+
+    // Construct inspect configuration.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      includeQuote: true,
+      minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+      limits: {
+        maxFindingsPerItem: 100,
+      },
+    };
+
+    // Specify the action that is triggered when the job completes.
+    const action = {
+      publishSummaryToCscc: {
+        enable: true,
+      },
+    };
+
+    // Configure the inspection job we want the service to perform.
+    const inspectJobConfig = {
+      inspectConfig: inspectConfig,
+      storageConfig: storageItem,
+      actions: [action],
+    };
+
+    // Construct the job creation request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: inspectJobConfig,
+    };
+
+    // Send the job creation request and process the response.
+    const [jobsResponse] = await dlp.createDlpJob(request);
+    const jobName = jobsResponse.name;
+
+    // Waiting for a maximum of 15 minutes for the job to get complete.
+    let job;
+    let numOfAttempts = 30;
+    while (numOfAttempts > 0) {
+      // Fetch DLP Job status
+      [job] = await dlp.getDlpJob({name: jobName});
+
+      // Check if the job has completed.
+      if (job.state === 'DONE') {
+        break;
+      }
+      if (job.state === 'FAILED') {
+        console.log('Job Failed, Please check the configuration.');
+        return;
+      }
+      // Sleep for a short duration before checking the job status again.
+      await new Promise(resolve => {
+        setTimeout(() => resolve(), 30000);
+      });
+      numOfAttempts -= 1;
+    }
+
+    // Print out the results.
+    const infoTypeStats = job.inspectDetails.result.infoTypeStats;
+    if (infoTypeStats.length > 0) {
+      infoTypeStats.forEach(infoTypeStat => {
+        console.log(
+          `  Found ${infoTypeStat.count} instance(s) of infoType ${infoTypeStat.infoType.name}.`
+        );
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  await inspectBigQuerySendToScc();
+  // [END dlp_inspect_bigquery_send_to_scc]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/inspectDatastoreSendToScc.js
+++ b/dlp/inspectDatastoreSendToScc.js
@@ -1,0 +1,138 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Create a Dlp Job with Datastore Data and send its findings to Scc
+//  description: Uses the Data Loss Prevention API to Create a Dlp Job with Datastore Data and send its findings to Scc
+//  usage: node inspectDatastoreSendToScc.js my-project datastoreNamespace, datastoreKind
+async function main(projectId, datastoreNamespace, datastoreKind) {
+  // [START dlp_inspect_datastore_send_to_scc]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under.
+  // const projectId = "your-project-id";
+
+  // Datastore namespace
+  // const datastoreNamespace = 'datastore-namespace';
+
+  // Datastore kind
+  // const datastoreKind = 'datastore-kind';
+
+  async function inspectDatastoreSendToScc() {
+    // Specify the storage configuration object with datastore.
+    const storageConfig = {
+      datastoreOptions: {
+        kind: {
+          name: datastoreKind,
+        },
+        partitionId: {
+          projectId: projectId,
+          namespaceId: datastoreNamespace,
+        },
+      },
+    };
+
+    // Construct the info types to look for in the datastore.
+    const infoTypes = [
+      {name: 'EMAIL_ADDRESS'},
+      {name: 'PERSON_NAME'},
+      {name: 'LOCATION'},
+      {name: 'PHONE_NUMBER'},
+    ];
+
+    // Construct the inspection configuration.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+      limits: {
+        maxFindingsPerItem: 100,
+      },
+      includeQuote: true,
+    };
+
+    // Specify the action that is triggered when the job completes
+    const action = {
+      publishSummaryToCscc: {enable: true},
+    };
+
+    // Configure the inspection job we want the service to perform.
+    const inspectJobConfig = {
+      inspectConfig: inspectConfig,
+      storageConfig: storageConfig,
+      actions: [action],
+    };
+
+    // Construct the job creation request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: inspectJobConfig,
+    };
+
+    // Send the job creation request and process the response.
+    const [jobsResponse] = await dlp.createDlpJob(request);
+    const jobName = jobsResponse.name;
+
+    // Waiting for a maximum of 15 minutes for the job to get complete.
+    let job;
+    let numOfAttempts = 30;
+    while (numOfAttempts > 0) {
+      // Fetch DLP Job status
+      [job] = await dlp.getDlpJob({name: jobName});
+
+      // Check if the job has completed.
+      if (job.state === 'DONE') {
+        break;
+      }
+      if (job.state === 'FAILED') {
+        console.log('Job Failed, Please check the configuration.');
+        return;
+      }
+      // Sleep for a short duration before checking the job status again.
+      await new Promise(resolve => {
+        setTimeout(() => resolve(), 30000);
+      });
+      numOfAttempts -= 1;
+    }
+
+    // Print out the results.
+    const infoTypeStats = job.inspectDetails.result.infoTypeStats;
+    if (infoTypeStats.length > 0) {
+      infoTypeStats.forEach(infoTypeStat => {
+        console.log(
+          `Found ${infoTypeStat.count} instance(s) of infoType ${infoTypeStat.infoType.name}.`
+        );
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  await inspectDatastoreSendToScc();
+  // [END dlp_inspect_datastore_send_to_scc]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/inspectGcsSendToScc.js
+++ b/dlp/inspectGcsSendToScc.js
@@ -1,0 +1,129 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Create a Dlp Job with GCS Data and send its findings to Scc
+//  description: Uses the Data Loss Prevention API to Create a Dlp Job with GCS Data and send its findings to Scc
+//  usage: node inspectGcsSendToScc.js my-project gcsPath
+async function main(projectId, gcsPath) {
+  // [START dlp_inspect_gcs_send_to_scc]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlpClient = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'your-project-id';
+
+  // The name of the file in the bucket
+  // const gcsPath = 'gcs-file-path';
+
+  async function inspectGCSSendToScc() {
+    // Specify the storage configuration object with GCS URL.
+    const storageConfig = {
+      cloudStorageOptions: {
+        fileSet: {
+          url: gcsPath,
+        },
+      },
+    };
+
+    // Construct the info types to look for in the GCS file.
+    const infoTypes = [
+      {name: 'EMAIL_ADDRESS'},
+      {name: 'PERSON_NAME'},
+      {name: 'LOCATION'},
+      {name: 'PHONE_NUMBER'},
+    ];
+
+    // Construct the inspection configuration.
+    const inspectConfig = {
+      infoTypes,
+      minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+      limits: {
+        maxFindingsPerItem: 100,
+      },
+    };
+
+    // Specify the action that is triggered when the job completes.
+    const action = {
+      publishSummaryToCscc: {},
+    };
+
+    // Configure the inspection job we want the service to perform.
+    const jobConfig = {
+      inspectConfig,
+      storageConfig,
+      actions: [action],
+    };
+
+    // Construct the job creation request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: jobConfig,
+    };
+
+    // Send the job creation request and process the response.
+    const [jobsResponse] = await dlpClient.createDlpJob(request);
+    const jobName = jobsResponse.name;
+
+    // Waiting for a maximum of 15 minutes for the job to get complete.
+    let job;
+    let numOfAttempts = 30;
+    while (numOfAttempts > 0) {
+      // Fetch DLP Job status
+      [job] = await dlpClient.getDlpJob({name: jobName});
+
+      // Check if the job has completed.
+      if (job.state === 'DONE') {
+        break;
+      }
+      if (job.state === 'FAILED') {
+        console.log('Job Failed, Please check the configuration.');
+        return;
+      }
+      // Sleep for a short duration before checking the job status again.
+      await new Promise(resolve => {
+        setTimeout(() => resolve(), 30000);
+      });
+      numOfAttempts -= 1;
+    }
+
+    // Print out the results.
+    const infoTypeStats = job.inspectDetails.result.infoTypeStats;
+    if (infoTypeStats.length > 0) {
+      infoTypeStats.forEach(infoTypeStat => {
+        console.log(
+          `Found ${infoTypeStat.count} instance(s) of infoType ${infoTypeStat.infoType.name}.`
+        );
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  await inspectGCSSendToScc();
+  // [END dlp_inspect_gcs_send_to_scc]
+}
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -948,4 +948,231 @@ describe('inspect', () => {
     }
     assert.include(output, 'INVALID_PATH');
   });
+
+  // dlp_inspect_gcs_with_sampling
+  it('should inspect a GCS file and send results to SCC', async () => {
+    const jobName = 'test-job-name';
+    const gcsUri = 'test-uri';
+    const DATA_CONSTANTS = MOCK_DATA.INSPECT_GCS_SEND_TO_SCC(
+      projectId,
+      gcsUri,
+      jobName
+    );
+    const mockCreateDlpJob = sinon.stub().resolves([{name: jobName}]);
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'createDlpJob',
+      mockCreateDlpJob
+    );
+
+    const mockGetDlpJob = sinon.fake.resolves(
+      DATA_CONSTANTS.RESPONSE_GET_DLP_JOB_SUCCESS
+    );
+    sinon.replace(DLP.DlpServiceClient.prototype, 'getDlpJob', mockGetDlpJob);
+    const mockConsoleLog = sinon.stub();
+    sinon.replace(console, 'log', mockConsoleLog);
+
+    const inspectGcsSendToScc = proxyquire('../inspectGcsSendToScc', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    await inspectGcsSendToScc(projectId, gcsUri);
+    sinon.assert.calledOnceWithExactly(
+      mockCreateDlpJob,
+      DATA_CONSTANTS.REQUEST_CREATE_DLP_JOB
+    );
+    sinon.assert.calledOnce(mockGetDlpJob);
+  });
+
+  it('should handle error if inspect job results into failure', async () => {
+    const jobName = 'test-job-name';
+    const gcsUri = 'test-uri';
+    const DATA_CONSTANTS = MOCK_DATA.INSPECT_GCS_SEND_TO_SCC(
+      projectId,
+      gcsUri,
+      jobName
+    );
+    const mockCreateDlpJob = sinon.stub().resolves([{name: jobName}]);
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'createDlpJob',
+      mockCreateDlpJob
+    );
+
+    const mockGetDlpJob = sinon.fake.resolves(
+      DATA_CONSTANTS.RESPONSE_GET_DLP_JOB_FAILED
+    );
+    sinon.replace(DLP.DlpServiceClient.prototype, 'getDlpJob', mockGetDlpJob);
+    const mockConsoleLog = sinon.stub();
+    sinon.replace(console, 'log', mockConsoleLog);
+
+    const inspectGcsSendToScc = proxyquire('../inspectGcsSendToScc', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    await inspectGcsSendToScc(projectId, gcsUri);
+    sinon.assert.calledOnce(mockGetDlpJob);
+    sinon.assert.calledWithMatch(
+      mockConsoleLog,
+      'Job Failed, Please check the configuration.'
+    );
+  });
+
+  // dlp_inspect_bigquery_send_to_scc
+  it('should inspect bigquery table and send results to SCC', async () => {
+    const jobName = 'test-job-name';
+    const DATA_CONSTANTS = MOCK_DATA.INSPECT_BIG_QUERY_SEND_TO_SCC(
+      projectId,
+      dataProject,
+      datasetId,
+      tableId,
+      jobName
+    );
+    const mockCreateDlpJob = sinon.stub().resolves([{name: jobName}]);
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'createDlpJob',
+      mockCreateDlpJob
+    );
+
+    const mockGetDlpJob = sinon.fake.resolves(
+      DATA_CONSTANTS.RESPONSE_GET_DLP_JOB_SUCCESS
+    );
+    sinon.replace(DLP.DlpServiceClient.prototype, 'getDlpJob', mockGetDlpJob);
+    const mockConsoleLog = sinon.stub();
+    sinon.replace(console, 'log', mockConsoleLog);
+
+    const inspectBigquerySendToScc = proxyquire('../inspectBigquerySendToScc', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    await inspectBigquerySendToScc(projectId, dataProject, datasetId, tableId);
+    sinon.assert.calledOnceWithExactly(
+      mockCreateDlpJob,
+      DATA_CONSTANTS.REQUEST_CREATE_DLP_JOB
+    );
+    sinon.assert.calledOnce(mockGetDlpJob);
+  });
+
+  it('should handle error if inspect job results into failure', async () => {
+    const jobName = 'test-job-name';
+    const DATA_CONSTANTS = MOCK_DATA.INSPECT_BIG_QUERY_SEND_TO_SCC(
+      projectId,
+      dataProject,
+      datasetId,
+      tableId,
+      jobName
+    );
+    const mockCreateDlpJob = sinon.stub().resolves([{name: jobName}]);
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'createDlpJob',
+      mockCreateDlpJob
+    );
+
+    const mockGetDlpJob = sinon.fake.resolves(
+      DATA_CONSTANTS.RESPONSE_GET_DLP_JOB_FAILED
+    );
+    sinon.replace(DLP.DlpServiceClient.prototype, 'getDlpJob', mockGetDlpJob);
+    const mockConsoleLog = sinon.stub();
+    sinon.replace(console, 'log', mockConsoleLog);
+
+    const inspectBigQuerySendToScc = proxyquire('../inspectBigquerySendToScc', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    await inspectBigQuerySendToScc(projectId, dataProject, datasetId, tableId);
+    sinon.assert.calledOnce(mockGetDlpJob);
+    sinon.assert.calledWithMatch(
+      mockConsoleLog,
+      'Job Failed, Please check the configuration.'
+    );
+  });
+
+  // dlp_inspect_datastore_send_to_scc
+  it('should inspect datastore and send results to SCC', async () => {
+    const jobName = 'test-job-name';
+    const datastoreNamespace = 'datastore-namespace';
+    const datastoreKind = 'datastore-kind';
+    const DATA_CONSTANTS = MOCK_DATA.INSPECT_DATASTORE_SEND_TO_SCC(
+      projectId,
+      datastoreNamespace,
+      datastoreKind,
+      jobName
+    );
+    const mockCreateDlpJob = sinon.stub().resolves([{name: jobName}]);
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'createDlpJob',
+      mockCreateDlpJob
+    );
+
+    const mockGetDlpJob = sinon.fake.resolves(
+      DATA_CONSTANTS.RESPONSE_GET_DLP_JOB_SUCCESS
+    );
+    sinon.replace(DLP.DlpServiceClient.prototype, 'getDlpJob', mockGetDlpJob);
+    const mockConsoleLog = sinon.stub();
+    sinon.replace(console, 'log', mockConsoleLog);
+
+    const inspectDatastoreSendToScc = proxyquire(
+      '../inspectDatastoreSendToScc',
+      {
+        '@google-cloud/dlp': {DLP: DLP},
+      }
+    );
+
+    await inspectDatastoreSendToScc(
+      projectId,
+      datastoreNamespace,
+      datastoreKind
+    );
+    sinon.assert.calledOnceWithExactly(
+      mockCreateDlpJob,
+      DATA_CONSTANTS.REQUEST_CREATE_DLP_JOB
+    );
+    sinon.assert.calledOnce(mockGetDlpJob);
+  });
+
+  it('should handle error if inspect job results into failure', async () => {
+    const jobName = 'test-job-name';
+    const datastoreNamespace = 'datastore-namespace';
+    const datastoreKind = 'datastore-kind';
+    const DATA_CONSTANTS = MOCK_DATA.INSPECT_DATASTORE_SEND_TO_SCC(
+      projectId,
+      datastoreNamespace,
+      datastoreKind,
+      jobName
+    );
+    const mockCreateDlpJob = sinon.stub().resolves([{name: jobName}]);
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'createDlpJob',
+      mockCreateDlpJob
+    );
+
+    const mockGetDlpJob = sinon.fake.resolves(
+      DATA_CONSTANTS.RESPONSE_GET_DLP_JOB_FAILED
+    );
+    sinon.replace(DLP.DlpServiceClient.prototype, 'getDlpJob', mockGetDlpJob);
+    const mockConsoleLog = sinon.stub();
+    sinon.replace(console, 'log', mockConsoleLog);
+
+    const inspectDatastoreSendToScc = proxyquire(
+      '../inspectDatastoreSendToScc',
+      {
+        '@google-cloud/dlp': {DLP: DLP},
+      }
+    );
+
+    await inspectDatastoreSendToScc(
+      projectId,
+      datastoreNamespace,
+      datastoreKind
+    );
+    sinon.assert.calledOnce(mockGetDlpJob);
+    sinon.assert.calledWithMatch(
+      mockConsoleLog,
+      'Job Failed, Please check the configuration.'
+    );
+  });
 });

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -364,6 +364,191 @@ const MOCK_DATA = {
     },
     RESPONSE_REIDENTIFY_CONTENT: [{item: {value: ''}}],
   }),
+  INSPECT_GCS_SEND_TO_SCC: (projectId, gcsUri, jobName) => ({
+    REQUEST_CREATE_DLP_JOB: {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: {
+        inspectConfig: {
+          infoTypes: [
+            {name: 'EMAIL_ADDRESS'},
+            {name: 'PERSON_NAME'},
+            {name: 'LOCATION'},
+            {name: 'PHONE_NUMBER'},
+          ],
+          minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+          limits: {
+            maxFindingsPerItem: 100,
+          },
+        },
+        storageConfig: {
+          cloudStorageOptions: {
+            fileSet: {url: gcsUri},
+          },
+        },
+        actions: [
+          {
+            publishSummaryToCscc: {},
+          },
+        ],
+      },
+    },
+    RESPONSE_GET_DLP_JOB_SUCCESS: [
+      {
+        name: jobName,
+        state: 'DONE',
+        inspectDetails: {
+          result: {
+            infoTypeStats: [
+              {
+                count: 1,
+                infoType: {
+                  name: 'PERSON_NAME',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+    RESPONSE_GET_DLP_JOB_FAILED: [
+      {
+        name: jobName,
+        state: 'FAILED',
+        inspectDetails: {},
+      },
+    ],
+  }),
+  INSPECT_BIG_QUERY_SEND_TO_SCC: (
+    projectId,
+    dataProjectId,
+    datasetId,
+    tableId,
+    jobName
+  ) => ({
+    REQUEST_CREATE_DLP_JOB: {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: {
+        inspectConfig: {
+          infoTypes: [
+            {name: 'EMAIL_ADDRESS'},
+            {name: 'PERSON_NAME'},
+            {name: 'LOCATION'},
+            {name: 'PHONE_NUMBER'},
+          ],
+          minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+          limits: {
+            maxFindingsPerItem: 100,
+          },
+          includeQuote: true,
+        },
+        storageConfig: {
+          bigQueryOptions: {
+            tableReference: {
+              projectId: dataProjectId,
+              datasetId: datasetId,
+              tableId: tableId,
+            },
+          },
+        },
+        actions: [
+          {
+            publishSummaryToCscc: {enable: true},
+          },
+        ],
+      },
+    },
+    RESPONSE_GET_DLP_JOB_SUCCESS: [
+      {
+        name: jobName,
+        state: 'DONE',
+        inspectDetails: {
+          result: {
+            infoTypeStats: [
+              {
+                count: 1,
+                infoType: {
+                  name: 'PERSON_NAME',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+    RESPONSE_GET_DLP_JOB_FAILED: [
+      {
+        name: jobName,
+        state: 'FAILED',
+        inspectDetails: {},
+      },
+    ],
+  }),
+  INSPECT_DATASTORE_SEND_TO_SCC: (
+    projectId,
+    datastoreNamespace,
+    datastoreKind,
+    jobName
+  ) => ({
+    REQUEST_CREATE_DLP_JOB: {
+      parent: `projects/${projectId}/locations/global`,
+      inspectJob: {
+        inspectConfig: {
+          infoTypes: [
+            {name: 'EMAIL_ADDRESS'},
+            {name: 'PERSON_NAME'},
+            {name: 'LOCATION'},
+            {name: 'PHONE_NUMBER'},
+          ],
+          minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.UNLIKELY,
+          limits: {
+            maxFindingsPerItem: 100,
+          },
+          includeQuote: true,
+        },
+        storageConfig: {
+          datastoreOptions: {
+            kind: {
+              name: datastoreKind,
+            },
+            partitionId: {
+              projectId: projectId,
+              namespaceId: datastoreNamespace,
+            },
+          },
+        },
+        actions: [
+          {
+            publishSummaryToCscc: {enable: true},
+          },
+        ],
+      },
+    },
+    RESPONSE_GET_DLP_JOB_SUCCESS: [
+      {
+        name: jobName,
+        state: 'DONE',
+        inspectDetails: {
+          result: {
+            infoTypeStats: [
+              {
+                count: 1,
+                infoType: {
+                  name: 'PERSON_NAME',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+    RESPONSE_GET_DLP_JOB_FAILED: [
+      {
+        name: jobName,
+        state: 'FAILED',
+        inspectDetails: {},
+      },
+    ],
+  }),
 };
 
 module.exports = {MOCK_DATA};


### PR DESCRIPTION
## Description

References:- https://cloud.google.com/dlp/docs/sending-results-to-scc.md#bigquery-data
https://cloud.google.com/dlp/docs/sending-results-to-scc.md#cloud-storage-data
https://cloud.google.com/dlp/docs/sending-results-to-scc.md?g=0&l=416#datastore-data

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
