### PR TITLE
DLP: Added sample for reidentify text and table using FPE

### DIFF
--- a/dlp/reidentifyTableWithFpe.js
+++ b/dlp/reidentifyTableWithFpe.js
@@ -1,0 +1,110 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Re-identify with FPE
+//  description: Re-identify sensitive data in a string using Format Preserving Encryption (FPE).
+//  usage: node reidentifyTableWithFpe.js my-project alphabet keyName wrappedKey
+async function main(projectId, alphabet, keyName, wrappedKey) {
+  // [START dlp_reidentify_table_fpe]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The set of characters to replace sensitive ones with
+  // For more information, see https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+  // const alphabet = 'ALPHA_NUMERIC';
+
+  // The name of the Cloud KMS key used to encrypt ('wrap') the AES-256 key
+  // const keyName = 'projects/YOUR_GCLOUD_PROJECT/locations/YOUR_LOCATION/keyRings/YOUR_KEYRING_NAME/cryptoKeys/YOUR_KEY_NAME';
+
+  // The encrypted ('wrapped') AES-256 key to use
+  // This key should be encrypted using the Cloud KMS key specified above
+  // const wrappedKey = 'YOUR_ENCRYPTED_AES_256_KEY'
+
+  // The name of the surrogate custom info type to use when reidentifying data
+  // const surrogateType = 'SOME_INFO_TYPE_DEID';
+
+  // Table to re-identify
+  const tablularData = {
+    headers: [{name: 'Employee ID'}],
+    rows: [{values: [{stringValue: '90511'}]}],
+  };
+
+  async function reidentifyTableWithFpe() {
+    // Specify field to be re-identified.
+    const fieldIds = [{name: 'Employee ID'}];
+
+    // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it
+    const cryptoKeyConfig = {
+      kmsWrapped: {
+        wrappedKey: wrappedKey,
+        cryptoKeyName: keyName,
+      },
+    };
+
+    // Associate transformation with crypto key congurations.
+    const primitiveTransformation = {
+      cryptoReplaceFfxFpeConfig: {
+        cryptoKey: cryptoKeyConfig,
+        commonAlphabet: alphabet,
+      },
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        recordTransformations: {
+          fieldTransformations: [
+            {
+              fields: fieldIds,
+              primitiveTransformation: primitiveTransformation,
+            },
+          ],
+        },
+      },
+      item: {
+        table: tablularData,
+      },
+    };
+
+    // Send the request and receive response from the service.
+    const [response] = await dlp.reidentifyContent(request);
+
+    // Print the results.
+    console.log(
+      `Table after re-identification: ${JSON.stringify(response.item.table)}`
+    );
+  }
+  await reidentifyTableWithFpe();
+  // [END dlp_reidentify_table_fpe]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/reidentifyTextWithFpe.js
+++ b/dlp/reidentifyTextWithFpe.js
@@ -1,0 +1,123 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Reidentify with FPE
+//  description: Re-identify text data with format-preserving encryption.
+//  usage: node reidentifyTextWithFpe.js my-project string alphabet surrogateType keyName wrappedKey
+async function main(
+  projectId,
+  string,
+  alphabet,
+  keyName,
+  wrappedKey,
+  surrogateType
+) {
+  // [START dlp_reidentify_text_fpe]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to reidentify
+  // const string = 'My phone number is PHONE_TOKEN(10):9617256398';
+
+  // The set of characters to replace sensitive ones with
+  // For more information, see https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+  // const alphabet = 'NUMERIC';
+
+  // The name of the Cloud KMS key used to encrypt ('wrap') the AES-256 key
+  // const keyName = 'projects/YOUR_GCLOUD_PROJECT/locations/YOUR_LOCATION/keyRings/YOUR_KEYRING_NAME/cryptoKeys/YOUR_KEY_NAME';
+
+  // The encrypted ('wrapped') AES-256 key to use
+  // This key should be encrypted using the Cloud KMS key specified above
+  // const wrappedKey = 'YOUR_ENCRYPTED_AES_256_KEY'
+
+  // The name of the surrogate custom info type to use when reidentifying data
+  // const surrogateType = 'SOME_INFO_TYPE_DEID';
+
+  async function reidentifyTextWithFpe() {
+    // Construct deidentification request
+    const item = {value: string};
+
+    // Construt Crypto Key Configuration
+    const cryptoKeyConfig = {
+      kmsWrapped: {
+        wrappedKey: wrappedKey,
+        cryptoKeyName: keyName,
+      },
+    };
+
+    // Construct primitive transformation configuration
+    const primitiveTransformation = {
+      cryptoReplaceFfxFpeConfig: {
+        cryptoKey: cryptoKeyConfig,
+        commonAlphabet: alphabet,
+        surrogateInfoType: {
+          name: surrogateType,
+        },
+      },
+    };
+
+    // Combine configurations and construct re-identify request
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              primitiveTransformation: primitiveTransformation,
+            },
+          ],
+        },
+      },
+      inspectConfig: {
+        customInfoTypes: [
+          {
+            infoType: {
+              name: surrogateType,
+            },
+            surrogateType: {},
+          },
+        ],
+      },
+      item: item,
+    };
+
+    // Run re-identification request
+    const [response] = await dlp.reidentifyContent(request);
+    const reidentifiedItem = response.item;
+
+    // Print results
+    console.log(reidentifiedItem.value);
+  }
+  await reidentifyTextWithFpe();
+  // [END dlp_reidentify_text_fpe]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -682,4 +682,126 @@ describe('deid', () => {
     }
     assert.include(output, 'INVALID_ARGUMENT');
   });
+
+  // dlp_reidentify_table_fpe
+  it('should re-identify table using Format Preserving Encryption (FPE)', async () => {
+    const CONSTANT_DATA = MOCK_DATA.REIDENTIFY_TABLE_WITH_FPE(
+      projectId,
+      'NUMERIC',
+      keyName,
+      wrappedKey
+    );
+
+    const mockReidentifyContent = sinon
+      .stub()
+      .resolves(CONSTANT_DATA.RESPONSE_REIDENTIFY_CONTENT);
+
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'reidentifyContent',
+      mockReidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const reIdentifyTableWithFpe = proxyquire('../reidentifyTableWithFpe', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    await reIdentifyTableWithFpe(projectId, 'NUMERIC', keyName, wrappedKey);
+
+    sinon.assert.calledOnceWithExactly(
+      mockReidentifyContent,
+      CONSTANT_DATA.REQUEST_REIDENTIFY_CONTENT
+    );
+  });
+
+  it('should handle re-identification errors', async () => {
+    const mockReidentifyContent = sinon.stub().rejects(new Error('Failed'));
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'reidentifyContent',
+      mockReidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const reIdentifyTableWithFpe = proxyquire('../reidentifyTableWithFpe', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    try {
+      await reIdentifyTableWithFpe(projectId, 'NUMERIC', keyName, wrappedKey);
+    } catch (error) {
+      assert.equal(error.message, 'Failed');
+    }
+  });
+
+  // dlp_reidentify_text_fpe
+  it('should re-identify text using Format Preserving Encryption (FPE)', async () => {
+    const text = 'My phone number is PHONE_TOKEN(10):9617256398';
+    const CONSTANT_DATA = MOCK_DATA.REIDENTIFY_TEXT_WITH_FPE(
+      projectId,
+      text,
+      'NUMERIC',
+      keyName,
+      wrappedKey,
+      'PHONE_TOKEN'
+    );
+
+    const mockReidentifyContent = sinon
+      .stub()
+      .resolves(CONSTANT_DATA.RESPONSE_REIDENTIFY_CONTENT);
+
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'reidentifyContent',
+      mockReidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const reIdentifyTextWithFpe = proxyquire('../reidentifyTextWithFpe', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    await reIdentifyTextWithFpe(
+      projectId,
+      text,
+      'NUMERIC',
+      keyName,
+      wrappedKey,
+      'PHONE_TOKEN'
+    );
+
+    sinon.assert.calledOnceWithExactly(
+      mockReidentifyContent,
+      CONSTANT_DATA.REQUEST_REIDENTIFY_CONTENT
+    );
+  });
+
+  it('should handle re-identification errors', async () => {
+    const mockReidentifyContent = sinon.stub().rejects(new Error('Failed'));
+    const text = 'My phone number is PHONE_TOKEN(10):9617256398';
+    sinon.replace(
+      DLP.DlpServiceClient.prototype,
+      'reidentifyContent',
+      mockReidentifyContent
+    );
+    sinon.replace(console, 'log', () => sinon.stub());
+
+    const reIdentifyTextWithFpe = proxyquire('../reidentifyTextWithFpe', {
+      '@google-cloud/dlp': {DLP: DLP},
+    });
+
+    try {
+      await reIdentifyTextWithFpe(
+        projectId,
+        text,
+        'NUMERIC',
+        keyName,
+        wrappedKey,
+        'PHONE_TOKEN'
+      );
+    } catch (error) {
+      assert.equal(error.message, 'Failed');
+    }
+  });
 });

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -286,6 +286,84 @@ const MOCK_DATA = {
     },
     RESPONSE_REIDENTIFY_CONTENT: [{item: {value: ''}}],
   }),
+  REIDENTIFY_TABLE_WITH_FPE: (projectId, alphabet, keyName, wrappedKey) => ({
+    REQUEST_REIDENTIFY_CONTENT: {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        recordTransformations: {
+          fieldTransformations: [
+            {
+              fields: [{name: 'Employee ID'}],
+              primitiveTransformation: {
+                cryptoReplaceFfxFpeConfig: {
+                  cryptoKey: {
+                    kmsWrapped: {
+                      wrappedKey: wrappedKey,
+                      cryptoKeyName: keyName,
+                    },
+                  },
+                  commonAlphabet: alphabet,
+                },
+              },
+            },
+          ],
+        },
+      },
+      item: {
+        table: {
+          headers: [{name: 'Employee ID'}],
+          rows: [{values: [{stringValue: '90511'}]}],
+        },
+      },
+    },
+    RESPONSE_REIDENTIFY_CONTENT: [{item: {table: {}}}],
+  }),
+  REIDENTIFY_TEXT_WITH_FPE: (
+    projectId,
+    text,
+    alphabet,
+    keyName,
+    wrappedKey,
+    surrogateType
+  ) => ({
+    REQUEST_REIDENTIFY_CONTENT: {
+      parent: `projects/${projectId}/locations/global`,
+      reidentifyConfig: {
+        infoTypeTransformations: {
+          transformations: [
+            {
+              primitiveTransformation: {
+                cryptoReplaceFfxFpeConfig: {
+                  cryptoKey: {
+                    kmsWrapped: {
+                      wrappedKey: wrappedKey,
+                      cryptoKeyName: keyName,
+                    },
+                  },
+                  commonAlphabet: alphabet,
+                  surrogateInfoType: {
+                    name: surrogateType,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      inspectConfig: {
+        customInfoTypes: [
+          {
+            infoType: {
+              name: surrogateType,
+            },
+            surrogateType: {},
+          },
+        ],
+      },
+      item: {value: text},
+    },
+    RESPONSE_REIDENTIFY_CONTENT: [{item: {value: ''}}],
+  }),
 };
 
 module.exports = {MOCK_DATA};


### PR DESCRIPTION
## Description

References:- https://cloud.google.com/dlp/docs/samples/dlp-reidentify-text-fpe
https://cloud.google.com/dlp/docs/samples/dlp-reidentify-table-fpe

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
