### PR TITLE
DLP: Added samples for inspect table and string using aumented infotype

### DIFF
--- a/dlp/inspectStringAugmentInfoType.js
+++ b/dlp/inspectStringAugmentInfoType.js
@@ -1,0 +1,98 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspect String using augment info type to the Inspect Request.
+//  description: Uses the Data Loss Prevention API to Inspect String using augment PERSON_NAME infoType to the Inspect Request.
+//  usage: node inspectStringAugmentInfoType.js my-project string words
+function main(projectId, string, words) {
+  words = words ? words.split(',') : [];
+  // [START dlp_inspect_augment_infotypes]
+  // Imports the Google Cloud client library
+  const DLP = require('@google-cloud/dlp');
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to inspect
+  // const string = "The patient's name is quasimodo";
+
+  // Word list
+  // const words = ['quasimodo'];
+
+  async function inspectStringAugmentInfoType() {
+    // Construct item to inspect
+    const byteItem = {
+      type: 'BYTES',
+      data: Buffer.from(string),
+    };
+    const item = {byteItem: byteItem};
+
+    // Construct the custom word list to be detected.
+    const dictionary = {
+      wordList: {
+        words: words,
+      },
+    };
+    const infoType = {name: 'PERSON_NAME'};
+
+    // Construct a custom infotype detector that uses dictionary.
+    const customInfoType = {
+      infoType: infoType,
+      dictionary: dictionary,
+    };
+
+    // Construct the inspect configuration.
+    const inspectConfig = {
+      customInfoTypes: [customInfoType],
+      includeQuote: true,
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings.
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectStringAugmentInfoType();
+  // [END dlp_inspect_augment_infotypes]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/inspectTable.js
+++ b/dlp/inspectTable.js
@@ -1,0 +1,89 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspect a table for sensitive content
+//  description: Inspect a table for sensitive content such as Phone Number.
+//  usage: node inspectTable.js my-project
+function main(projectId) {
+  // [START dlp_inspect_table]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The infoTypes of information to match
+  const infoTypes = [{name: 'PHONE_NUMBER'}];
+
+  // Table data
+  const tableData = {
+    headers: [{name: 'name'}, {name: 'phone'}],
+    rows: [
+      {
+        values: [{stringValue: 'John Doe'}, {stringValue: '(206) 555-0123'}],
+      },
+    ],
+  };
+
+  async function inspectTable() {
+    // Specify the table to be inspected.
+    const item = {
+      table: tableData,
+    };
+
+    // Construct the configuration for the Inspect request.
+    const inspectConfig = {
+      infoTypes: infoTypes,
+      includeQuote: true,
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: item,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print findings.
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectTable();
+  // [END dlp_inspect_table]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/system-test/inspect.test.js
+++ b/dlp/system-test/inspect.test.js
@@ -1175,4 +1175,42 @@ describe('inspect', () => {
       'Job Failed, Please check the configuration.'
     );
   });
+
+  // dlp_inspect_table
+  it('should inspect table with PERSON_NAME infotype', () => {
+    const output = execSync(`node inspectTable.js ${projectId}`);
+    assert.match(output, /Quote: \(206\) 555-0123/);
+    assert.match(output, /Findings: 1/);
+  });
+
+  it('should report any errors while inspecting a table', () => {
+    let output;
+    try {
+      output = execSync('node inspectTable.js BAD_PROJECT_ID');
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
+
+  // dlp_inspect_augment_infotypes
+  it('should inspect a string using augmented infotype', () => {
+    const output = execSync(
+      `node inspectStringAugmentInfoType.js ${projectId} "The patient's name is quasimodo" 'quasimodo'`
+    );
+    assert.match(output, /InfoType: PERSON_NAME/);
+    assert.match(output, /Quote: quasimodo/);
+  });
+
+  it('should handle errors while inspecting the string', () => {
+    let output;
+    try {
+      output = execSync(
+        'node inspectStringAugmentInfoType.js BAD_PROJECT_ID "The patient\'s name is quasimodo" "quasimodo"'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/inspecting-structured-text.md#dlp-inspect-table-java
https://cloud.google.com/dlp/docs/creating-custom-infotypes-dictionary#augment_a_built-in_infotype_detector

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
