### PR TITLE
DLP: Added sample for deidentify table with bucketing and dictionary replacement

### DIFF
--- a/dlp/deIdentifyTableWithBucketingConfig.js
+++ b/dlp/deIdentifyTableWithBucketingConfig.js
@@ -1,0 +1,130 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Deidentifying the table using bucketing transformations.
+//  description: Uses the Data Loss Prevention API to De-identifying the table using bucketing transformations.
+//  usage: node deIdentifyTableWithBucketingConfig.js my-project
+function main(projectId) {
+  // [START dlp_deidentify_table_primitive_bucketing]
+  // Imports the Google Cloud client library
+  const DLP = require('@google-cloud/dlp');
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'your-project-id';
+
+  // Construct the tabular data
+  const tablularData = {
+    headers: [{name: 'AGE'}, {name: 'PATIENT'}, {name: 'HAPPINESS SCORE'}],
+    rows: [
+      {
+        values: [
+          {stringValue: '101'},
+          {stringValue: 'Charles Dickens'},
+          {integerValue: 95},
+        ],
+      },
+      {
+        values: [
+          {stringValue: '22'},
+          {stringValue: 'Jane Austen'},
+          {integerValue: 21},
+        ],
+      },
+      {
+        values: [
+          {stringValue: '55'},
+          {stringValue: 'Mark Twain'},
+          {integerValue: 75},
+        ],
+      },
+    ],
+  };
+
+  async function deIdentifyTableBucketing() {
+    // Construct bucket confiugrations
+    const buckets = [
+      {
+        min: {integerValue: 0},
+        max: {integerValue: 25},
+        replacementValue: {stringValue: 'Low'},
+      },
+      {
+        min: {integerValue: 25},
+        max: {integerValue: 75},
+        replacementValue: {stringValue: 'Medium'},
+      },
+      {
+        min: {integerValue: 75},
+        max: {integerValue: 100},
+        replacementValue: {stringValue: 'High'},
+      },
+    ];
+
+    const bucketingConfig = {
+      buckets: buckets,
+    };
+
+    // The list of fields to be transformed.
+    const fieldIds = [{name: 'HAPPINESS SCORE'}];
+
+    // Associate fields with bucketing configuration.
+    const fieldTransformations = [
+      {
+        primitiveTransformation: {bucketingConfig: bucketingConfig},
+        fields: fieldIds,
+      },
+    ];
+
+    // Specify de-identify configuration using transformation object.
+    const deidentifyConfig = {
+      recordTransformations: {
+        fieldTransformations: fieldTransformations,
+      },
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: deidentifyConfig,
+      item: {
+        table: tablularData,
+      },
+    };
+    // Send the request and receive response from the service.
+    const [response] = await dlp.deidentifyContent(request);
+
+    // Print the results.
+    console.log(
+      `Table after de-identification: ${JSON.stringify(
+        response.item.table,
+        null,
+        2
+      )}`
+    );
+  }
+  deIdentifyTableBucketing();
+  // [END dlp_deidentify_table_primitive_bucketing]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/deidentifyWithDictionaryReplacement.js
+++ b/dlp/deidentifyWithDictionaryReplacement.js
@@ -1,0 +1,105 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: De-identify with Dictionary Replacement
+//  description: De-identify sensitive data in a string by replacing it with a random list of replacement string.
+//  usage: node deidentifyWithDictionaryReplacement.js my-project string infoTypes words
+function main(projectId, string, infoTypes, words) {
+  [infoTypes, words] = transformCLI(infoTypes, words);
+  // [START dlp_deidentify_dictionary_replacement]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under
+  // const projectId = 'my-project';
+
+  // The string to de-identify
+  // const string = 'My name is Alicia Abernathy, and my email address is aabernathy@example.com.';
+
+  // The infoTypes of information to match
+  // const infoTypes = [{ name: 'EMAIL_ADDRESS' }];
+
+  // The words to replace sensitive information with
+  // const words = ['izumi@example.com', 'alex@example.com', 'tal@example.com'];
+
+  async function deidentifyWithDictionaryReplacement() {
+    // Construct word list to be used for replacement
+    const wordList = {
+      words: words,
+    };
+    // Construct item to de-identify
+    const item = {value: string};
+
+    // Specify replacement dictionary config using word list.
+    const replaceDictionaryConfig = {
+      wordList: wordList,
+    };
+
+    // Associate replacement dictionary config with infotype transformation.
+    const infoTypeTransformations = {
+      transformations: [
+        {
+          infoTypes: infoTypes,
+          primitiveTransformation: {
+            replaceDictionaryConfig: replaceDictionaryConfig,
+          },
+        },
+      ],
+    };
+
+    // Combine configurations into a request for the service.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      deidentifyConfig: {
+        infoTypeTransformations: infoTypeTransformations,
+      },
+      item: item,
+    };
+
+    // Run de-identification request.
+    const [response] = await dlp.deidentifyContent(request);
+    const deidentifiedItem = response.item;
+
+    // Print results.
+    console.log(deidentifiedItem.value);
+  }
+
+  deidentifyWithDictionaryReplacement();
+  // [END dlp_deidentify_dictionary_replacement]
+}
+
+main(...process.argv.slice(2));
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+function transformCLI(infoTypes, excludedWords) {
+  infoTypes = infoTypes
+    ? infoTypes.split(',').map(type => {
+        return {name: type};
+      })
+    : undefined;
+
+  excludedWords = excludedWords ? excludedWords.split(',') : [];
+
+  return [infoTypes, excludedWords];
+}

--- a/dlp/system-test/deid.test.js
+++ b/dlp/system-test/deid.test.js
@@ -804,4 +804,75 @@ describe('deid', () => {
       assert.equal(error.message, 'Failed');
     }
   });
+
+  // dlp_deidentify_dictionary_replacement
+  it('should replace sensitive data with replacement dict', () => {
+    let output;
+    const string =
+      'My name is Alicia Abernathy, and my email address is aabernathy@example.com.';
+    const replacementDict = [
+      'izumi@example.com',
+      'alex@example.com',
+      'tal@example.com',
+    ];
+    try {
+      output = execSync(
+        `node deidentifyWithDictionaryReplacement.js ${projectId} "${string}" EMAIL_ADDRESS "${replacementDict.join(
+          ','
+        )}"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.match(output, new RegExp(`${replacementDict.join('|')}`));
+  });
+
+  it('should handle de-identification errors', () => {
+    let output;
+    const replacementDict = [
+      'izumi@example.com',
+      'alex@example.com',
+      'tal@example.com',
+    ];
+    const string =
+      'My name is Alicia Abernathy, and my email address is aabernathy@example.com.';
+    try {
+      output = execSync(
+        `node deidentifyWithDictionaryReplacement.js ${projectId} "${string}" BAD_TYPE "${replacementDict.join(
+          ','
+        )}"`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
+
+  // dlp_deidentify_table_primitive_bucketing
+  it('should de-identify table using bucketing configuration', () => {
+    let output;
+    try {
+      output = execSync(
+        `node deIdentifyTableWithBucketingConfig.js ${projectId}`
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.match(output, /"stringValue": "High"/);
+    assert.match(output, /"stringValue": "Low"/);
+    assert.notMatch(output, /"stringValue": "Medium"/);
+    assert.notInclude(output, 'integerValue: 95');
+  });
+
+  it('should handle de-identification errors', () => {
+    let output;
+    try {
+      output = execSync(
+        'node deIdentifyTableWithBucketingConfig.js BAD_PROJECT_ID'
+      );
+    } catch (err) {
+      output = err.message;
+    }
+    assert.include(output, 'INVALID_ARGUMENT');
+  });
 });


### PR DESCRIPTION
Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/concepts-bucketing
https://cloud.google.com/dlp/docs/transformations-reference#dictionary-replacement

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
