### PR TITLE
test: use --if-present rather than failing on build

### DIFF
--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -77,8 +77,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/automl.yaml
+++ b/.github/workflows/automl.yaml
@@ -76,8 +76,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/dialogflow-cx.yaml
+++ b/.github/workflows/dialogflow-cx.yaml
@@ -80,8 +80,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -77,8 +77,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/iam-deny.yaml
+++ b/.github/workflows/iam-deny.yaml
@@ -71,8 +71,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/security-center-snippets.yaml
+++ b/.github/workflows/security-center-snippets.yaml
@@ -71,8 +71,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -77,8 +77,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,8 +62,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/utils/ci-secrets.yaml.njk
+++ b/.github/workflows/utils/ci-secrets.yaml.njk
@@ -78,8 +78,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |

--- a/.github/workflows/vision.yaml
+++ b/.github/workflows/vision.yaml
@@ -76,8 +76,7 @@ jobs:
       working-directory: .
     - name: install directory dependencies
       run: npm install
-    - run: npm run build
-      continue-on-error: true
+    - run: npm run build --if-present
     - name: set env vars for scheduled run
       if: github.event.action == 'schedule'
       run: |


### PR DESCRIPTION
Currently GHA workflows allow an error on `npm run build`, as not all samples have this command in `package.json`. This change uses the `--if-present` flag to avoid throwing and catching the error in the first place.