### PR TITLE
test: update GHA flakybot upload action

### DIFF
--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -92,6 +92,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: ai-platform/snippets/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/automl.yaml
+++ b/.github/workflows/automl.yaml
@@ -90,6 +90,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: automl/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/dialogflow-cx.yaml
+++ b/.github/workflows/dialogflow-cx.yaml
@@ -96,6 +96,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: dialogflow-cx/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -92,6 +92,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: functions/slack/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/iam-deny.yaml
+++ b/.github/workflows/iam-deny.yaml
@@ -83,6 +83,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: iam/deny/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/security-center-snippets.yaml
+++ b/.github/workflows/security-center-snippets.yaml
@@ -85,6 +85,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: security-center/snippets/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -95,6 +95,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: storagetransfer/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,10 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: ${{ inputs.path }}/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/.github/workflows/utils/ci-secrets.yaml.njk
+++ b/.github/workflows/utils/ci-secrets.yaml.njk
@@ -94,6 +94,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: {{ path }}/${% raw %}{{ env.MOCHA_REPORTER_OUTPUT }}{% endraw %}

--- a/.github/workflows/vision.yaml
+++ b/.github/workflows/vision.yaml
@@ -90,6 +90,8 @@ jobs:
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
+      env:
+        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
       with:
         name: test-results
         path: vision/${{ env.MOCHA_REPORTER_OUTPUT }}

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -10,7 +10,7 @@
     "*.js"
   ],
   "scripts": {
-    "test": "c8 mocha --parallel --timeout 2400000 test/*.js"
+    "test": "c8 mocha --timeout 2400000 test/*.js"
   },
   "dependencies": {
     "@google-cloud/aiplatform": "^2.3.0",

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -10,7 +10,7 @@
     "*.js"
   ],
   "scripts": {
-    "test": "c8 mocha --timeout 2400000 test/*.js"
+    "test": "c8 mocha --parallel --timeout 2400000 test/*.js"
   },
   "dependencies": {
     "@google-cloud/aiplatform": "^2.3.0",


### PR DESCRIPTION
FlakyBot issues aren't being uploaded regularly. I believe this is because the upload action is referencing an OS environment variable with the log, and needs to access the GHA env var.