### PR TITLE
test: update permissions on remove_label jobs

### DIFF
--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -20,8 +20,8 @@ on:
 jobs:
   remove_label:
     permissions:
-      contents: 'read'
       id-token: 'write'
+      pull-requests: 'write'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
The remove label job now fails on every execution. In #3279 the workflow was scoped to permissions that did not include updating the PR.

More info: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs