### PR TITLE
feat(workflows): add runtime arguments to workflows TS sample

### DIFF
--- a/workflows/quickstart/index.js
+++ b/workflows/quickstart/index.js
@@ -19,6 +19,7 @@
 const projectId = process.argv[2] || process.env.GOOGLE_CLOUD_PROJECT;
 const location = process.argv[3] || 'us-central1';
 const workflowName = process.argv[4] || 'myFirstWorkflow';
+const searchTerm = process.argv[5] || null;
 
 // [START workflows_api_quickstart]
 const {ExecutionsClient} = require('@google-cloud/workflows');
@@ -30,12 +31,14 @@ const client = new ExecutionsClient();
 // const projectId = 'my-project';
 // const location = 'us-central1';
 // const workflow = 'myFirstWorkflow';
+// const searchTerm = null;
 
 /**
  * Executes a Workflow and waits for the results with exponential backoff.
  * @param {string} projectId The Google Cloud Project containing the workflow
  * @param {string} location The workflow location
  * @param {string} workflow The workflow name
+ * @param {string} searchTerm Optional search term to pass as runtime argument to Workflow
  */
 async function executeWorkflow(projectId, location, workflow) {
   /**
@@ -50,10 +53,12 @@ async function executeWorkflow(projectId, location, workflow) {
 
   // Execute workflow
   try {
+    const runtimeArgs = searchTerm ? {searchTerm: searchTerm} : {};
     const createExecutionRes = await client.createExecution({
       parent: client.workflowPath(projectId, location, workflow),
       execution: {
-        argument: JSON.stringify({}),
+        // Provide runtime arguments as a JSON string
+        argument: JSON.stringify(runtimeArgs),
       },
     });
     const executionName = createExecutionRes[0].name;

--- a/workflows/quickstart/index.ts
+++ b/workflows/quickstart/index.ts
@@ -16,6 +16,7 @@ const projectId =
   process.argv[2] || (process.env.GOOGLE_CLOUD_PROJECT as string);
 const location = process.argv[3] || 'us-central1';
 const workflowName = process.argv[4] || 'myFirstWorkflow';
+const searchTerm = process.argv[5] || null;
 
 // [START workflows_api_quickstart]
 import {ExecutionsClient} from '@google-cloud/workflows';
@@ -27,12 +28,14 @@ const client: ExecutionsClient = new ExecutionsClient();
 // const projectId = 'my-project';
 // const location = 'us-central1';
 // const workflow = 'myFirstWorkflow';
+// const searchTerm = null;
 
 /**
  * Executes a Workflow and waits for the results with exponential backoff.
  * @param {string} projectId The Google Cloud Project containing the workflow
  * @param {string} location The workflow location
  * @param {string} workflow The workflow name
+ * @param {string} searchTerm Optional search term to pass as runtime argument to Workflow
  */
 async function executeWorkflow(
   projectId: string,
@@ -51,10 +54,12 @@ async function executeWorkflow(
 
   // Execute workflow
   try {
+    const runtimeArgs = searchTerm ? {searchTerm: searchTerm} : {};
     const createExecutionRes = await client.createExecution({
       parent: client.workflowPath(projectId, location, workflow),
       execution: {
-        argument: JSON.stringify({}),
+        // Provide runtime arguments as a JSON string
+        argument: JSON.stringify(runtimeArgs),
       },
     });
     const executionName = createExecutionRes[0].name;


### PR DESCRIPTION
## Description

This PR adds an optional `searchTerm` argument to the WorkFlows Quickstart sample. This will illustrate how to pass runtime arguments to a workflow via JavaScript on [Execute a Workflow documentation page](https://cloud.google.com/workflows/docs/executing-workflow).  


Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
