### PR TITLE
DLP: Added sample for inspect with stored infotype and inspect with custom hotword

### DIFF
--- a/dlp/inspectWithCustomHotwords.js
+++ b/dlp/inspectWithCustomHotwords.js
@@ -1,0 +1,121 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspect table using custom hotword rule
+//  description: Uses the Data Loss Prevention API to inspect a table excluding findings from an entire column.
+//  usage: node inspectWithCustomHotwords.js projectId
+function main(projectId) {
+  // [START dlp_inspect_column_values_w_custom_hotwords]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under.
+  // const projectId = "your-project-id";
+
+  // Table to inspect
+  const tableToInspect = {
+    headers: [
+      {name: 'Fake Social Security Number'},
+      {name: 'Real Social Security Number'},
+    ],
+    rows: [
+      {
+        values: [{stringValue: '111-11-1111'}, {stringValue: '222-22-2222'}],
+      },
+    ],
+  };
+
+  async function inspectWithCustomHotwords() {
+    // Specify the regex pattern to be detected.
+    const hotwordRegexPattern = '(Fake Social Security Number)';
+
+    // Specify what content you want the service to de-identify.
+    const contentItem = {
+      table: tableToInspect,
+    };
+
+    // Specify the type of info the inspection will look for.
+    const infoTypes = [{name: 'US_SOCIAL_SECURITY_NUMBER'}];
+
+    // Construct hotword rule.
+    const hotwordRule = {
+      hotwordRegex: {
+        pattern: hotwordRegexPattern,
+      },
+      likelihoodAdjustment: {
+        fixedLikelihood:
+          DLP.protos.google.privacy.dlp.v2.Likelihood.VERY_UNLIKELY,
+      },
+      proximity: {
+        windowBefore: 1,
+      },
+    };
+
+    // Construct rule set for the inspect configuration.
+    const inspectionRuleSet = {
+      infoTypes: infoTypes,
+      rules: [
+        {
+          hotwordRule: hotwordRule,
+        },
+      ],
+    };
+
+    // Construct the configuration for the Inspect request.
+    const config = {
+      infoTypes: infoTypes,
+      ruleSet: [inspectionRuleSet],
+      minLikelihood: DLP.protos.google.privacy.dlp.v2.Likelihood.POSSIBLE,
+      includeQuote: true,
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      item: contentItem,
+      inspectConfig: config,
+    };
+
+    // Use the client to send the API request.
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings.
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  inspectWithCustomHotwords();
+  // [END dlp_inspect_column_values_w_custom_hotwords]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/dlp/inspectWithStoredInfotype.js
+++ b/dlp/inspectWithStoredInfotype.js
@@ -1,0 +1,91 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// sample-metadata:
+//  title: Inspect the provided text using stored infoType.
+//  description: Uses the Data Loss Prevention API to Inspect the provided text using stored infoType.
+//  usage: node inspectWithStoredInfotype.js projectId, infoTypeId, string
+async function main(projectId, infoTypeId, string) {
+  // [START dlp_inspect_with_stored_infotype]
+  // Imports the Google Cloud Data Loss Prevention library
+  const DLP = require('@google-cloud/dlp');
+
+  // Instantiates a client
+  const dlp = new DLP.DlpServiceClient();
+
+  // The project ID to run the API call under.
+  // const projectId = 'your-project-id';
+
+  // The custom info-type id created and stored in the bucket.
+  // const infoTypeId = 'your-info-type-id';
+
+  // The string to inspect.
+  // const string = 'My phone number is (223) 456-7890 and my email address is gary@example.com.';
+
+  async function inspectWithStoredInfotype() {
+    // Reference to the existing StoredInfoType to inspect the data.
+    const customInfoType = {
+      infoType: {
+        name: 'GITHUB_LOGINS',
+      },
+      storedType: {
+        name: infoTypeId,
+      },
+    };
+
+    // Construct the configuration for the Inspect request.
+    const inspectConfig = {
+      customInfoTypes: [customInfoType],
+      includeQuote: true,
+    };
+
+    // Construct the Inspect request to be sent by the client.
+    const request = {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: inspectConfig,
+      item: {
+        value: string,
+      },
+    };
+    // Run request
+    const [response] = await dlp.inspectContent(request);
+
+    // Print Findings
+    const findings = response.result.findings;
+    if (findings.length > 0) {
+      console.log(`Findings: ${findings.length}\n`);
+      findings.forEach(finding => {
+        console.log(`InfoType: ${finding.infoType.name}`);
+        console.log(`\tQuote: ${finding.quote}`);
+        console.log(`\tLikelihood: ${finding.likelihood} \n`);
+      });
+    } else {
+      console.log('No findings.');
+    }
+  }
+  await inspectWithStoredInfotype();
+  // [END dlp_inspect_with_stored_infotype]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+// TODO(developer): Please uncomment below line before running sample
+// main(...process.argv.slice(2));
+
+module.exports = main;

--- a/dlp/system-test/mockdata.js
+++ b/dlp/system-test/mockdata.js
@@ -549,6 +549,42 @@ const MOCK_DATA = {
       },
     ],
   }),
+  INSPECT_WITH_STORED_INFOTYPE: (projectId, string, infoTypeId) => ({
+    REQUEST_INSPECT_CONTENT: {
+      parent: `projects/${projectId}/locations/global`,
+      inspectConfig: {
+        customInfoTypes: [
+          {
+            infoType: {
+              name: 'GITHUB_LOGINS',
+            },
+            storedType: {
+              name: infoTypeId,
+            },
+          },
+        ],
+        includeQuote: true,
+      },
+      item: {
+        value: string,
+      },
+    },
+    RESPONSE_INSPECT_CONTENT: [
+      {
+        result: {
+          findings: [
+            {
+              infoType: {
+                name: infoTypeId,
+              },
+              quote: '(223) 456-7890',
+              likelihood: 'VERY_LIKELY',
+            },
+          ],
+        },
+      },
+    ],
+  }),
 };
 
 module.exports = {MOCK_DATA};


### PR DESCRIPTION
Added unit test cases for same

## Description

References:- https://cloud.google.com/dlp/docs/creating-custom-infotypes-likelihood.md#match-column-values
https://cloud.google.com/dlp/docs/creating-stored-infotypes#scan-with-large-custom-infotype

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
