### PR TITLE
Revert "test: update permissions on remove_label jobs"

### DIFF
--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -20,8 +20,8 @@ on:
 jobs:
   remove_label:
     permissions:
+      contents: 'read'
       id-token: 'write'
-      pull-requests: 'write'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/nodejs-docs-samples#3374

Workflow is failing because the `pull-requests: 'write'` isn't allowed if the calling workflow doesn't have it. Will need to look at potentially adding it there.