### PR TITLE
fix: remove hardcoded index.ts from npm start line in workflows sample

### DIFF
--- a/workflows/quickstart/package.json
+++ b/workflows/quickstart/package.json
@@ -7,7 +7,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "start": "node --loader=ts-node/esm index.ts",
+    "start": "node --loader=ts-node/esm",
     "build": "tsc -p .",
     "fix": "gts fix",
     "lint": "gts lint",


### PR DESCRIPTION
## Description

This PR updates the workflows quickstart sample `npm start` to exclude `index.ts`. This change will allow TS and JS samples to be run identically i.e. `npm start index.js <arguments>` and `npm start index.ts <arguments>`
