### PR TITLE
fix: fix npm run build in recaptcha

### DIFF
--- a/recaptcha_enterprise/snippets/package.json
+++ b/recaptcha_enterprise/snippets/package.json
@@ -24,13 +24,10 @@
     "recaptcha-password-check-helpers": "^1.0.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.4",
     "@types/express": "^4.17.17",
-    "@types/mocha": "^10.0.1",
     "@types/node": "^18.15.11",
     "@types/yargs": "^17.0.19",
     "c8": "^8.0.0",
-    "chai": "^4.3.7",
     "eslint": "^8.34.0",
     "gts": "^5.0.0",
     "mocha": "^10.2.0",

--- a/recaptcha_enterprise/snippets/test/test.passwordleak.ts
+++ b/recaptcha_enterprise/snippets/test/test.passwordleak.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import {assert} from 'chai';
-import {it} from 'mocha';
 import * as cp from 'child_process';
+import {it} from 'mocha';
+import {strict as assert} from 'node:assert';
 
 const execSync = (cmd: string) => cp.execSync(cmd, {encoding: 'utf-8'});
 


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
