### PR TITLE
refactor(workflows): use `npm start` to run JS variant 

### DIFF
--- a/workflows/quickstart/package.json
+++ b/workflows/quickstart/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@google-cloud/workflows": "^2.3.1",
-    "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   },
   "devDependencies": {

--- a/workflows/quickstart/package.json
+++ b/workflows/quickstart/package.json
@@ -7,7 +7,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "start": "node --loader=ts-node/esm index.ts",
+    "start": "node index.js",
     "build": "tsc -p .",
     "fix": "gts fix",
     "lint": "gts lint",

--- a/workflows/quickstart/tsconfig.json
+++ b/workflows/quickstart/tsconfig.json
@@ -4,6 +4,7 @@
     "strict": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "module": "commonjs"
   }
 }


### PR DESCRIPTION
## Description

This PR will:
- will redefine `npm start` to run the JavaScript variant of the sample
- add an option to `tsconfig` to allow `npm start` to run the generated JS file after compiling

With this change, you can run the js sample with:
1. `npm install`
2. `npm start`

Run the ts sample with:
1. `npm install && npm run build`
2. `npm start`

[Documentation](https://cloud.google.com/workflows/docs/executing-workflow#workflows_install-typescript) will be updated to reflect changes to these steps.