### PR TITLE
chore(workflows): remove redundant variable definitions

### DIFF
--- a/workflows/quickstart/index.js
+++ b/workflows/quickstart/index.js
@@ -26,14 +26,6 @@ const {ExecutionsClient} = require('@google-cloud/workflows');
 const client = new ExecutionsClient();
 
 /**
- * TODO(developer): Uncomment these variables before running the sample.
- */
-// const projectId = 'my-project';
-// const location = 'us-central1';
-// const workflow = 'myFirstWorkflow';
-// const searchTerm = null;
-
-/**
  * Executes a Workflow and waits for the results with exponential backoff.
  * @param {string} projectId The Google Cloud Project containing the workflow
  * @param {string} location The workflow location

--- a/workflows/quickstart/index.ts
+++ b/workflows/quickstart/index.ts
@@ -23,14 +23,6 @@ import {ExecutionsClient} from '@google-cloud/workflows';
 const client: ExecutionsClient = new ExecutionsClient();
 
 /**
- * TODO(developer): Uncomment these variables before running the sample.
- */
-// const projectId = 'my-project';
-// const location = 'us-central1';
-// const workflow = 'myFirstWorkflow';
-// const searchTerm = null;
-
-/**
  * Executes a Workflow and waits for the results with exponential backoff.
  * @param {string} projectId The Google Cloud Project containing the workflow
  * @param {string} location The workflow location


### PR DESCRIPTION
This PR cleans up some comments that instruct the developer to uncomment a couple of lines to define variables. Uncommenting these lines will cause the sample to fail.

This is a small part of the original PR #3458 