### PR TITLE
fix(healthcare): specify V3 parser version when creating HL7v2 store

### DIFF
--- a/healthcare/hl7v2/createHl7v2Store.js
+++ b/healthcare/hl7v2/createHl7v2Store.js
@@ -36,7 +36,15 @@ const main = (
     // const datasetId = 'my-dataset';
     // const hl7v2StoreId = 'my-hl7v2-store';
     const parent = `projects/${projectId}/locations/${cloudRegion}/datasets/${datasetId}`;
-    const request = {parent, hl7V2StoreId: hl7v2StoreId};
+    const request = {
+      parent,
+      hl7V2StoreId: hl7v2StoreId,
+      resource: {
+        parserConfig: {
+          version: 'V3'
+        }
+      }
+    };
 
     await healthcare.projects.locations.datasets.hl7V2Stores.create(request);
     console.log(`Created HL7v2 store: ${hl7v2StoreId}`);


### PR DESCRIPTION
## Description

Fixes b/253274073

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] Please **merge** this PR for me once it is approved
