### PR TITLE
refactor: preserving semver ranges 

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -173,5 +173,3 @@ for d in dirs:
     f = typeless_samples_hermetic(targets=d)
     # Remove extra characters
     trim(files=f)
-    # Fix formatting
-    fix_hermetic(targets=d)

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "config:semverAllMonthly"
   ],
   "baseBranches": ["main"],
   "packageRules": [
@@ -20,12 +21,9 @@
       "node": "< 15.0.0"
     }
   },
-  "prConcurrentLimit": 0,
   "dependencyDashboardAutoclose": true,  
   "schedule": "after 11am every 3 weeks on Monday",
-  "timezone": "America/Los_Angeles",
   "stabilityDays": 15,
-  "rangeStrategy": "pin",
   "pinVersions": false,
-  "rebaseStalePrs": false
+  "rebaseStalePrs": true
 }

--- a/run/logging-manual/app.js
+++ b/run/logging-manual/app.js
@@ -1,6 +1,16 @@
-// Copyright 2023 Google LLC. All rights reserved.
-// Use of this source code is governed by the Apache 2.0
-// license that can be found in the LICENSE file.
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const express = require('express');
 const app = express();

--- a/run/logging-manual/app.js
+++ b/run/logging-manual/app.js
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC. All rights reserved.
+// Copyright 2023 Google LLC. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 

--- a/run/logging-manual/app.js
+++ b/run/logging-manual/app.js
@@ -23,9 +23,8 @@ app.get('/', (req, res) => {
     const traceHeader = req.header('X-Cloud-Trace-Context');
     if (traceHeader && project) {
       const [trace] = traceHeader.split('/');
-      globalLogFields[
-        'logging.googleapis.com/trace'
-      ] = `projects/${project}/traces/${trace}`;
+      globalLogFields['logging.googleapis.com/trace'] =
+        `projects/${project}/traces/${trace}`;
     }
   }
 


### PR DESCRIPTION
## Description

Fixes the following:
* Updating renovate-bot to preserve semver ranges and update monthly rather than pinning. (#3522)
* Current `ci lint` error see in other PRs is being caused by collision from owlbot + `gts fix` (credit to: @muncus) 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
