### PR TITLE
fix: Remove the docs step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,17 +31,6 @@ jobs:
           node-version: 18
       - run: npm install
       - run: npm run lint
-  docs:
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.5.3
-      - uses: JustinBeckwith/linkinator-action@v1
-        with:
-          paths: "**/*.md"
-          linksToSkip: "localhost"
   region-tags:
     permissions:
       contents: 'read'


### PR DESCRIPTION
While this is a useful action (validates links in the README and markdown files), it's pulling from a previous Googlers personal actions which is against the current policy. We can revisit doing this in the future and unblock current CI by removing it for now.

- [X] Please **merge** this PR for me once it is approved
