### PR TITLE
fix(functions): Functions Slack sample test errors

### DIFF
--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -87,7 +87,7 @@ jobs:
     - run: npm test
       env:
         SLACK_SECRET: ${{ steps.secrets.outputs.slack_secret }}
-        API_KEY: ${{ steps.secrets.outputs.kg_api_key }}
+        KG_API_KEY: ${{ steps.secrets.outputs.kg_api_key }}
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -61,46 +61,46 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     assert.ok(result.title.toLowerCase().includes('kolach'));
   });
 
-  // it('handles non-existent query', async () => {
-  //   const query = 'g1bb3r1shhhhhhh';
+  it('handles non-existent query', async () => {
+    const query = 'g1bb3r1shhhhhhh';
 
-  //   const server = functionsFramework.getTestServer('kgSearch');
-  //   const response = await supertest(server)
-  //     .post('/')
-  //     .set({
-  //       'x-slack-signature': generateSignature(query),
-  //       'x-slack-request-timestamp': SLACK_TIMESTAMP,
-  //     })
-  //     .send({text: query})
-  //     .expect(200);
+    const server = functionsFramework.getTestServer('kgSearch');
+    const response = await supertest(server)
+      .post('/')
+      .set({
+        'x-slack-signature': generateSignature(query),
+        'x-slack-request-timestamp': SLACK_TIMESTAMP,
+      })
+      .send({text: query})
+      .expect(200);
 
-  //   const results = response.body && response.body.attachments;
-  //   assert.ok(results);
+    const results = response.body && response.body.attachments;
+    assert.ok(results);
 
-  //   const result = results[0];
-  //   assert.ok(result);
-  //   assert.ok(result.text);
-  //   assert.ok(result.text.includes('No results'));
-  // });
+    const result = results[0];
+    assert.ok(result);
+    assert.ok(result.text);
+    assert.ok(result.text.includes('No results'));
+  });
 
-  // it('handles empty query', async () => {
-  //   const query = '';
+  it('handles empty query', async () => {
+    const query = '';
 
-  //   const server = functionsFramework.getTestServer('kgSearch');
-  //   await supertest(server)
-  //     .post('/')
-  //     .set({
-  //       'x-slack-signature': generateSignature(query),
-  //       'x-slack-request-timestamp': SLACK_TIMESTAMP,
-  //     })
-  //     .send({text: query})
-  //     .expect(400);
-  // });
+    const server = functionsFramework.getTestServer('kgSearch');
+    await supertest(server)
+      .post('/')
+      .set({
+        'x-slack-signature': generateSignature(query),
+        'x-slack-request-timestamp': SLACK_TIMESTAMP,
+      })
+      .send({text: query})
+      .expect(400);
+  });
 
-  // it('fails on missing signature', async () => {
-  //   const query = 'kolach';
+  it('fails on missing signature', async () => {
+    const query = 'kolach';
 
-  //   const server = functionsFramework.getTestServer('kgSearch');
-  //   await supertest(server).post('/').send({text: query}).expect(500);
-  // });
+    const server = functionsFramework.getTestServer('kgSearch');
+    await supertest(server).post('/').send({text: query}).expect(500);
+  });
 });

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -19,7 +19,7 @@ const crypto = require('crypto');
 const supertest = require('supertest');
 const functionsFramework = require('@google-cloud/functions-framework/testing');
 
-const {SLACK_SECRET, API_KEY} = process.env;
+const {SLACK_SECRET} = process.env;
 const SLACK_TIMESTAMP = Date.now();
 
 require('../index');

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -38,7 +38,6 @@ const generateSignature = query => {
 };
 
 describe('functions_slack_format functions_slack_request functions_slack_search functions_verify_webhook', () => {
-  process.env.KG_API_KEY = API_KEY;
   it('returns search results', async () => {
     const query = 'kolach';
     const server = functionsFramework.getTestServer('kgSearch');
@@ -62,46 +61,46 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     assert.ok(result.title.toLowerCase().includes('kolach'));
   });
 
-  it('handles non-existent query', async () => {
-    const query = 'g1bb3r1shhhhhhh';
+  // it('handles non-existent query', async () => {
+  //   const query = 'g1bb3r1shhhhhhh';
 
-    const server = functionsFramework.getTestServer('kgSearch');
-    const response = await supertest(server)
-      .post('/')
-      .set({
-        'x-slack-signature': generateSignature(query),
-        'x-slack-request-timestamp': SLACK_TIMESTAMP,
-      })
-      .send({text: query})
-      .expect(200);
+  //   const server = functionsFramework.getTestServer('kgSearch');
+  //   const response = await supertest(server)
+  //     .post('/')
+  //     .set({
+  //       'x-slack-signature': generateSignature(query),
+  //       'x-slack-request-timestamp': SLACK_TIMESTAMP,
+  //     })
+  //     .send({text: query})
+  //     .expect(200);
 
-    const results = response.body && response.body.attachments;
-    assert.ok(results);
+  //   const results = response.body && response.body.attachments;
+  //   assert.ok(results);
 
-    const result = results[0];
-    assert.ok(result);
-    assert.ok(result.text);
-    assert.ok(result.text.includes('No results'));
-  });
+  //   const result = results[0];
+  //   assert.ok(result);
+  //   assert.ok(result.text);
+  //   assert.ok(result.text.includes('No results'));
+  // });
 
-  it('handles empty query', async () => {
-    const query = '';
+  // it('handles empty query', async () => {
+  //   const query = '';
 
-    const server = functionsFramework.getTestServer('kgSearch');
-    await supertest(server)
-      .post('/')
-      .set({
-        'x-slack-signature': generateSignature(query),
-        'x-slack-request-timestamp': SLACK_TIMESTAMP,
-      })
-      .send({text: query})
-      .expect(400);
-  });
+  //   const server = functionsFramework.getTestServer('kgSearch');
+  //   await supertest(server)
+  //     .post('/')
+  //     .set({
+  //       'x-slack-signature': generateSignature(query),
+  //       'x-slack-request-timestamp': SLACK_TIMESTAMP,
+  //     })
+  //     .send({text: query})
+  //     .expect(400);
+  // });
 
-  it('fails on missing signature', async () => {
-    const query = 'kolach';
+  // it('fails on missing signature', async () => {
+  //   const query = 'kolach';
 
-    const server = functionsFramework.getTestServer('kgSearch');
-    await supertest(server).post('/').send({text: query}).expect(500);
-  });
+  //   const server = functionsFramework.getTestServer('kgSearch');
+  //   await supertest(server).post('/').send({text: query}).expect(500);
+  // });
 });

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -104,7 +104,7 @@ afterEach(restoreConsole);
 
 describe('functions_slack_search', () => {
   before(async () => {
-    await import("../index.js");
+    require('../index.js');
   });
   it('Send fails if not a POST request', async () => {
     const error = new Error('Only POST requests are accepted');

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -103,6 +103,9 @@ beforeEach(stubConsole);
 afterEach(restoreConsole);
 
 describe('functions_slack_search', () => {
+  before(async () => {
+    await import("../index.js");
+  });
   it('Send fails if not a POST request', async () => {
     const error = new Error('Only POST requests are accepted');
     error.code = 405;


### PR DESCRIPTION
## Description

Fixes Functions Slack testing. 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
