### PR TITLE
feat: add new optional accelerator_type parameter

### DIFF
--- a/ai-platform/snippets/tuning.js
+++ b/ai-platform/snippets/tuning.js
@@ -57,6 +57,7 @@ async function main(
       dataset_uri: helpers.toValue(datasetUri),
       large_model_reference: helpers.toValue(model),
       model_display_name: helpers.toValue(modelDisplayName),
+      accelerator_type: helpers.toValue('GPU'), // Optional: GPU or TPU
     };
 
     const runtimeConfig = {


### PR DESCRIPTION
## Description

Fixes b/306723063

New optional accelerator_type = "GPU/TPU" parameter for the text model tuning pipeline job.
Public docs: https://cloud.devsite.corp.google.com/vertex-ai/docs/generative-ai/models/tune-text-models-supervised#generative-ai-tune-model-nodejs