### PR TITLE
fix: configure express to know about Cloud Run's proxy

### DIFF
--- a/run/filesystem/index.js
+++ b/run/filesystem/index.js
@@ -38,7 +38,7 @@ app.use(limit);
 app.use(mntDir, express.static(mntDir));
 
 // configure express to know about Cloud Run's proxy
-app.set('trust proxy', 1)
+app.set('trust proxy', 1);
 
 app.listen(port, () => {
   console.log(`Listening on port ${port}`);

--- a/run/filesystem/index.js
+++ b/run/filesystem/index.js
@@ -37,6 +37,9 @@ const limit = rateLimit({
 app.use(limit);
 app.use(mntDir, express.static(mntDir));
 
+// configure express to know about Cloud Run's proxy
+app.set('trust proxy', 1)
+
 app.listen(port, () => {
   console.log(`Listening on port ${port}`);
 });


### PR DESCRIPTION
## Description

Fixes #3583 

Cloud Run provides it's own proxy, so for rate limiting purposes, the actual IP of the user (not the proxy itself) is required. From suggestions in https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues, using `1` for "1 layer of proxies" should ensure the rate limiting code works. 


## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [x] Please **merge** this PR for me once it is approved
