### PR TITLE
fix(docs): Set the assessment.event.expected_action when sending a CreateAssessm…

### DIFF
--- a/recaptcha_enterprise/demosite/app/controllers/controller.js
+++ b/recaptcha_enterprise/demosite/app/controllers/controller.js
@@ -74,7 +74,8 @@ const onHomepageLoad = async (req, res) => {
     const assessmentResponse = await createAssessment(
       context.project_id,
       context.site_key,
-      req.body.token
+      req.body.token,
+      recaptchaAction
     );
 
     // Check if the token is valid, score is above threshold score and the action equals expected.
@@ -117,7 +118,8 @@ const onSignup = async (req, res) => {
     const assessmentResponse = await createAssessment(
       context.project_id,
       context.site_key,
-      req.body.token
+      req.body.token,
+      recaptchaAction
     );
 
     // Check if the token is valid, score is above threshold score and the action equals expected.
@@ -162,7 +164,8 @@ const onLogin = async (req, res) => {
     const assessmentResponse = await createAssessment(
       context.project_id,
       context.site_key,
-      req.body.token
+      req.body.token,
+      recaptchaAction
     );
 
     // Check if the token is valid, score is above threshold score and the action equals expected.
@@ -207,7 +210,8 @@ const onStoreCheckout = async (req, res) => {
     const assessmentResponse = await createAssessment(
       context.project_id,
       context.site_key,
-      req.body.token
+      req.body.token,
+      recaptchaAction
     );
 
     // Check if the token is valid, score is above threshold score and the action equals expected.
@@ -251,7 +255,8 @@ const onCommentSubmit = async (req, res) => {
     const assessmentResponse = await createAssessment(
       context.project_id,
       context.site_key,
-      req.body.token
+      req.body.token,
+      recaptchaAction
     );
 
     // Check if the token is valid, score is above threshold score and the action equals expected.

--- a/recaptcha_enterprise/demosite/app/recaptcha/createAssessment.js
+++ b/recaptcha_enterprise/demosite/app/recaptcha/createAssessment.js
@@ -20,9 +20,15 @@ const {RecaptchaEnterpriseServiceClient} =
  * @param projectId: GCloud Project ID
  * @param recaptchaSiteKey: Site key obtained by registering a domain/app to use recaptcha services.
  * @param token: The token obtained from the client on passing the recaptchaSiteKey.
+ * @param expectedAction: The expected action for this type of event.
  * @returns Assessment
  */
-async function createAssessment(projectId, recaptchaSiteKey, token) {
+async function createAssessment(
+  projectId,
+  recaptchaSiteKey,
+  token,
+  expectedAction
+) {
   // <!-- ATTENTION: reCAPTCHA Example (Server Part 2/2) Starts -->
   const client = new RecaptchaEnterpriseServiceClient();
 
@@ -34,6 +40,7 @@ async function createAssessment(projectId, recaptchaSiteKey, token) {
       event: {
         siteKey: recaptchaSiteKey,
         token: token,
+        expectedAction: expectedAction,
       },
     },
   });


### PR DESCRIPTION
## Description

Demonstrate setting the [`assessment.event.expected_action`](https://cloud.google.com/recaptcha-enterprise/docs/reference/rpc/google.cloud.recaptchaenterprise.v1#event) during the `CreateAssessment` request, so the `action` from the generated `execute` token can be compared on the backend.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
