### PR TITLE
chore(docs): update mysql readme

### DIFF
--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -1,6 +1,5 @@
 # Connecting to Cloud SQL - MySQL
 
-
 ## Before you begin
 
 1. If you haven't already, set up a Node.js Development Environment by following

--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -7,7 +7,7 @@
    [create a
    project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
 
-1. Create a 2nd Gen Cloud SQL Instance by following these
+1. Create a Cloud SQL Instance by following these
    [instructions](https://cloud.google.com/sql/docs/mysql/create-instance). Note
    the instance connection name, database user, and database password that you
    create.

--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -1,5 +1,6 @@
 # Connecting to Cloud SQL - MySQL
 
+
 ## Before you begin
 
 1. If you haven't already, set up a Node.js Development Environment by following


### PR DESCRIPTION
This PR just removes "2nd gen" from the Cloud SQL README. This is because 1st gen has been [decommissioned as of March 2020](https://cloud.google.com/sql/docs/mysql/deprecation-notice) and 2nd gen is the default and only option.