### PR TITLE
fix(issue-3631): updating samples to all use node v20 (part 3)

### DIFF
--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/appengine/hello-world/flexible/package.json
+++ b/appengine/hello-world/flexible/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/hello-world/standard/package.json
+++ b/appengine/hello-world/standard/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/appengine/storage/flexible/package.json
+++ b/appengine/storage/flexible/package.json
@@ -6,7 +6,7 @@
     "test": "c8 mocha -p -j 2 system-test/*.test.js --exit --timeout=30000"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.0.0",

--- a/appengine/storage/standard/package.json
+++ b/appengine/storage/standard/package.json
@@ -6,7 +6,7 @@
     "test": "c8 mocha -p -j 2 system-test/*.test.js --exit --timeout=30000"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.0.0",

--- a/appengine/websockets/package.json
+++ b/appengine/websockets/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "deploy": "gcloud app deploy",

--- a/asset/snippets/package.json
+++ b/asset/snippets/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/auth/package.json
+++ b/auth/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test:auth": "c8 mocha -p -j 2 system-test/auth.test.js --timeout=30000",

--- a/automl/package.json
+++ b/automl/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-automl",
   "private": true,

--- a/batch/package.json
+++ b/batch/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/cloud-language/package.json
+++ b/cloud-language/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-language",
   "private": true,
@@ -17,7 +17,7 @@
   "dependencies": {
     "@google-cloud/language": "^6.1.0",
     "@google-cloud/storage": "^7.0.0",
-    "mathjs": "^11.0.0",
+    "mathjs": "^12.0.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/cloud-sql/mysql/mysql/package.json
+++ b/cloud-sql/mysql/mysql/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node server/server.js",

--- a/cloud-sql/mysql/mysql2/package.json
+++ b/cloud-sql/mysql/mysql2/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node server/server.js",

--- a/cloud-sql/postgres/knex/package.json
+++ b/cloud-sql/postgres/knex/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node server/server.js",

--- a/cloud-sql/sqlserver/mssql/package.json
+++ b/cloud-sql/sqlserver/mssql/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node server/server.js",

--- a/cloud-sql/sqlserver/tedious/package.json
+++ b/cloud-sql/sqlserver/tedious/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node server/server.js",

--- a/cloud-tasks/snippets/package.json
+++ b/cloud-tasks/snippets/package.json
@@ -5,7 +5,7 @@
   "author": "Google Inc.",
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/cloud-tasks/tutorial-gcf/app/package.json
+++ b/cloud-tasks/tutorial-gcf/app/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/cloud-tasks/tutorial-gcf/function/package.json
+++ b/cloud-tasks/tutorial-gcf/function/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/cloudbuild/package.json
+++ b/cloudbuild/package.json
@@ -9,7 +9,7 @@
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-cloudbuild",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test --timeout=800000"

--- a/composer/functions/composer-storage-trigger/package.json
+++ b/composer/functions/composer-storage-trigger/package.json
@@ -6,7 +6,7 @@
     "node-fetch": "^2.2.0"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "private": true,
   "license": "Apache-2.0",

--- a/composer/package.json
+++ b/composer/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --exit test/*.test.js"

--- a/compute/package.json
+++ b/compute/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-compute",
   "private": true,

--- a/contact-center-insights/package.json
+++ b/contact-center-insights/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/container-analysis/snippets/package.json
+++ b/container-analysis/snippets/package.json
@@ -8,7 +8,7 @@
     "*.js"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --timeout 100000 test/**.test.js"

--- a/container/package.json
+++ b/container/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-cloud-container",
   "private": true,

--- a/datacatalog/cloud-client/package.json
+++ b/datacatalog/cloud-client/package.json
@@ -7,7 +7,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/datacatalog/quickstart/package.json
+++ b/datacatalog/quickstart/package.json
@@ -7,7 +7,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/datacatalog/snippets/package.json
+++ b/datacatalog/snippets/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-datacatalog",
   "private": true,

--- a/datalabeling/package.json
+++ b/datalabeling/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js",

--- a/dataproc/package.json
+++ b/dataproc/package.json
@@ -6,7 +6,7 @@
     "*.js"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-dataproc",
   "private": true,

--- a/datastore/functions/package.json
+++ b/datastore/functions/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=5000"

--- a/dialogflow-cx/package.json
+++ b/dialogflow-cx/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/dialogflow/package.json
+++ b/dialogflow/package.json
@@ -9,7 +9,7 @@
     "resources"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test --timeout=600000"

--- a/discoveryengine/package.json
+++ b/discoveryengine/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/dlp/package.json
+++ b/dlp/package.json
@@ -9,7 +9,7 @@
     "*.js"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=600000"

--- a/document-ai/package.json
+++ b/document-ai/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/endpoints/getting-started-grpc/package.json
+++ b/endpoints/getting-started-grpc/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node server.js",

--- a/endpoints/getting-started/package.json
+++ b/endpoints/getting-started/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/error-reporting/package.json
+++ b/error-reporting/package.json
@@ -9,7 +9,7 @@
     "!test/"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --timeout=600000"

--- a/eventarc/audit-storage/package.json
+++ b/eventarc/audit-storage/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/eventarc/generic/package.json
+++ b/eventarc/generic/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/eventarc/pubsub/package.json
+++ b/eventarc/pubsub/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/functions/billing/package.json
+++ b/functions/billing/package.json
@@ -5,7 +5,7 @@
   "description": "Examples of integrating Cloud Functions with billing",
   "main": "index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "compute-test": "c8 mocha -p -j 2 test/periodic.test.js --timeout=600000",

--- a/functions/concepts/afterResponse/package.json
+++ b/functions/concepts/afterResponse/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3"

--- a/functions/concepts/afterTimeout/package.json
+++ b/functions/concepts/afterTimeout/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3"

--- a/functions/concepts/backgroundTermination/package.json
+++ b/functions/concepts/backgroundTermination/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "echo \"No tests exist for this sample.\""

--- a/functions/concepts/filesystem/package.json
+++ b/functions/concepts/filesystem/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.2"

--- a/functions/concepts/httpTermination/package.json
+++ b/functions/concepts/httpTermination/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3"

--- a/functions/concepts/package.json
+++ b/functions/concepts/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "node-fetch": "^2.6.0"

--- a/functions/concepts/requests/package.json
+++ b/functions/concepts/requests/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3",

--- a/functions/concepts/stateless/package.json
+++ b/functions/concepts/stateless/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3"

--- a/functions/env_vars/package.json
+++ b/functions/env_vars/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/firebase/helloAnalytics/package.json
+++ b/functions/firebase/helloAnalytics/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/firebase/helloAuth/package.json
+++ b/functions/firebase/helloAuth/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/firebase/helloFirestore/package.json
+++ b/functions/firebase/helloFirestore/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/firebase/helloRTDB/package.json
+++ b/functions/firebase/helloRTDB/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/firebase/helloRemoteConfig/package.json
+++ b/functions/firebase/helloRemoteConfig/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/firebase/makeUpperCase/package.json
+++ b/functions/firebase/makeUpperCase/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/firebase/package.json
+++ b/functions/firebase/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "mocha": "^10.0.0",

--- a/functions/helloworld/helloError/package.json
+++ b/functions/helloworld/helloError/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --exit"

--- a/functions/helloworld/helloGCS/package.json
+++ b/functions/helloworld/helloGCS/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "unit-test": "c8 mocha -p -j 2 test/*unit*test.js test/*integration*test.js --timeout=6000 --exit",

--- a/functions/helloworld/helloPubSub/package.json
+++ b/functions/helloworld/helloPubSub/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "unit-test": "c8 mocha -p -j 2 test/*unit*test.js test/*integration*test.js --timeout=6000 --exit",

--- a/functions/helloworld/helloworldGet/package.json
+++ b/functions/helloworld/helloworldGet/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=6000 --exit"

--- a/functions/helloworld/helloworldHttp/package.json
+++ b/functions/helloworld/helloworldHttp/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "unit-test": "c8 mocha -p -j 2 test/index.test.js test/*unit*test.js test/*integration*test.js --timeout=6000 --exit",

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/debug-agent": "^8.0.0",

--- a/functions/http/corsEnabledFunction/package.json
+++ b/functions/http/corsEnabledFunction/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/http/corsEnabledFunctionAuth/package.json
+++ b/functions/http/corsEnabledFunctionAuth/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/http/httpContent/package.json
+++ b/functions/http/httpContent/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/http/httpMethods/package.json
+++ b/functions/http/httpMethods/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/http/package.json
+++ b/functions/http/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "mocha": "^10.0.0",

--- a/functions/http/parseXML/package.json
+++ b/functions/http/parseXML/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=6000 --exit"

--- a/functions/http/uploadFile/package.json
+++ b/functions/http/uploadFile/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3",

--- a/functions/imagemagick/package.json
+++ b/functions/imagemagick/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000 --exit"

--- a/functions/log/helloWorld/package.json
+++ b/functions/log/helloWorld/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/log/package.json
+++ b/functions/log/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "mocha": "^10.0.0",

--- a/functions/log/processEntry/package.json
+++ b/functions/log/processEntry/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/memorystore/redis/package.json
+++ b/functions/memorystore/redis/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "main": "index.js",
   "scripts": {

--- a/functions/ocr/app/package.json
+++ b/functions/ocr/app/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/pubsub/package.json
+++ b/functions/pubsub/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/pubsub": "^4.0.0"

--- a/functions/pubsub/publish/package.json
+++ b/functions/pubsub/publish/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000 --exit"

--- a/functions/pubsub/subscribe/package.json
+++ b/functions/pubsub/subscribe/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000 --exit"

--- a/functions/scheduleinstance/package.json
+++ b/functions/scheduleinstance/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/security/package.json
+++ b/functions/security/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js"

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000 --exit"

--- a/functions/spanner/package.json
+++ b/functions/spanner/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/speech-to-speech/functions/package.json
+++ b/functions/speech-to-speech/functions/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/functions/tips/avoidInfiniteRetries/package.json
+++ b/functions/tips/avoidInfiniteRetries/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "echo \"No tests exist for this sample.\""

--- a/functions/tips/connectionPools/package.json
+++ b/functions/tips/connectionPools/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.2",

--- a/functions/tips/gcpApiCall/package.json
+++ b/functions/tips/gcpApiCall/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000 --exit"

--- a/functions/tips/lazyGlobals/package.json
+++ b/functions/tips/lazyGlobals/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.3"

--- a/functions/tips/package.json
+++ b/functions/tips/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "echo \"Notice: tests moved into topic sub-directories\" && exit 0"

--- a/functions/tips/retry/package.json
+++ b/functions/tips/retry/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000 --exit"

--- a/functions/tips/scopeDemo/package.json
+++ b/functions/tips/scopeDemo/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/v2/autoLabelInstance/package.json
+++ b/functions/v2/autoLabelInstance/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/index.test.js",

--- a/functions/v2/cloudEventLogging/package.json
+++ b/functions/v2/cloudEventLogging/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "main": "index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js"

--- a/functions/v2/firebase/firestore/helloFirestore/package.json
+++ b/functions/v2/firebase/firestore/helloFirestore/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/v2/firebase/firestore/makeUpperCase/package.json
+++ b/functions/v2/firebase/firestore/makeUpperCase/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/v2/firebase/remote-config/helloRemoteConfig/package.json
+++ b/functions/v2/firebase/remote-config/helloRemoteConfig/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/v2/firebase/rtdb/helloRTDB/package.json
+++ b/functions/v2/firebase/rtdb/helloRTDB/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 -T 30s test/*.test.js"

--- a/functions/v2/helloAuditLog/package.json
+++ b/functions/v2/helloAuditLog/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/v2/helloBigQuery/package.json
+++ b/functions/v2/helloBigQuery/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000 --exit"

--- a/functions/v2/helloGCS/package.json
+++ b/functions/v2/helloGCS/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/v2/helloPubSub/package.json
+++ b/functions/v2/helloPubSub/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/v2/httpLogging/package.json
+++ b/functions/v2/httpLogging/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "main": "index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js",

--- a/functions/v2/imagemagick/package.json
+++ b/functions/v2/imagemagick/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000 --exit"

--- a/functions/v2/log/processEntry/package.json
+++ b/functions/v2/log/processEntry/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/v2/ocr/app/package.json
+++ b/functions/v2/ocr/app/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/v2/responseStreaming/package.json
+++ b/functions/v2/responseStreaming/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=20000"

--- a/functions/v2/tips/avoidInfiniteRetries/package.json
+++ b/functions/v2/tips/avoidInfiniteRetries/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/functions/v2/tips/retry/package.json
+++ b/functions/v2/tips/retry/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000 --exit"

--- a/game-servers/snippets/package.json
+++ b/game-servers/snippets/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/generative-ai/snippets/package.json
+++ b/generative-ai/snippets/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/healthcare/consent/package.json
+++ b/healthcare/consent/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/healthcare/datasets/package.json
+++ b/healthcare/datasets/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/healthcare/dicom/package.json
+++ b/healthcare/dicom/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/healthcare/fhir/package.json
+++ b/healthcare/fhir/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/healthcare/hl7v2/package.json
+++ b/healthcare/hl7v2/package.json
@@ -6,7 +6,7 @@
   "author": "Google LLC",
   "repository": "GoogleCloudPlatform/nodejs-docs-samples",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/*.test.js --timeout=60000"

--- a/iam/deny/package.json
+++ b/iam/deny/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
     },
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "test": "c8 mocha -p -j 2 test/*.test.js --timeout=60000"

--- a/kms/package.json
+++ b/kms/package.json
@@ -8,7 +8,7 @@
   "author": "Google LLC",
   "repository": "googleapis/nodejs-kms",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --recursive test/ --timeout=800000"

--- a/media/livestream/package.json
+++ b/media/livestream/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/media/transcoder/package.json
+++ b/media/transcoder/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js",

--- a/mediatranslation/package.json
+++ b/mediatranslation/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/memorystore/redis/package.json
+++ b/memorystore/redis/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "redis": "^4.0.0"

--- a/monitoring/snippets/package.json
+++ b/monitoring/snippets/package.json
@@ -8,7 +8,7 @@
     "*.js"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --timeout 600000"

--- a/opencensus/package.json
+++ b/opencensus/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node metrics-quickstart.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",
@@ -18,8 +18,8 @@
     "generate-ci": "node .github/workflows/utils/generate.js"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "c8": "^8.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/recaptcha_enterprise/demosite/app/package.json
+++ b/recaptcha_enterprise/demosite/app/package.json
@@ -8,7 +8,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
     },
     "repository": {
         "type": "git",

--- a/recaptcha_enterprise/snippets/package.json
+++ b/recaptcha_enterprise/snippets/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js",

--- a/retail/package.json
+++ b/retail/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"
@@ -13,7 +13,7 @@
     "test": "c8 mocha -p -j 2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^7.0.0",

--- a/run/filesystem/package.json
+++ b/run/filesystem/package.json
@@ -9,7 +9,7 @@
     "system-test": "c8 mocha -p -j 2 test/system.test.js --timeout=360000 --exit"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/run/hello-broken/package.json
+++ b/run/hello-broken/package.json
@@ -10,7 +10,7 @@
     "system-test": "NAME=Cloud c8 mocha -p -j 2 test/system.test.js --timeout=360000 --exit"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/run/helloworld/package.docs.json
+++ b/run/helloworld/package.docs.json
@@ -9,7 +9,7 @@
     "start": "node index.js"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/run/helloworld/package.json
+++ b/run/helloworld/package.json
@@ -11,7 +11,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/run/idp-sql/package.json
+++ b/run/idp-sql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/run/image-processing/package.json
+++ b/run/image-processing/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/run/jobs/package.docs.json
+++ b/run/jobs/package.docs.json
@@ -7,7 +7,7 @@
         "start": "node index.js"
     },
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
     },
     "author": "Google LLC",
     "license": "Apache-2.0"

--- a/run/jobs/package.json
+++ b/run/jobs/package.json
@@ -9,7 +9,7 @@
     "system-test": "c8 mocha -p -j 2 test/system.test.js --timeout=600000 --exit"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/run/logging-manual/package.json
+++ b/run/logging-manual/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/run/markdown-preview/editor/package.json
+++ b/run/markdown-preview/editor/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "main": "main.js",
   "scripts": {

--- a/run/markdown-preview/renderer/package.json
+++ b/run/markdown-preview/renderer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "main": "index.js",
   "scripts": {

--- a/run/pubsub/package.json
+++ b/run/pubsub/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/run/system-package/package.json
+++ b/run/system-package/package.json
@@ -10,7 +10,7 @@
     "system-test": "c8 mocha -p -j 2 test/system.test.js --timeout=360000 --exit"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "express": "^4.17.1"

--- a/run/websockets/package.json
+++ b/run/websockets/package.json
@@ -11,7 +11,7 @@
     "system-test": "c8 mocha -p -j 2 test/system.test.js --timeout=420000 --exit"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.1.0",

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "quickstart.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js",

--- a/secret-manager/package.json
+++ b/secret-manager/package.json
@@ -8,7 +8,7 @@
   "author": "Google LLC",
   "repository": "googleapis/nodejs-secret-manager",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --recursive test/ --timeout=800000"

--- a/security-center/snippets/package.json
+++ b/security-center/snippets/package.json
@@ -6,7 +6,7 @@
     "!system-test/"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test/ --recursive --timeout 6000000"

--- a/service-directory/snippets/package.json
+++ b/service-directory/snippets/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/speech/package.json
+++ b/speech/package.json
@@ -5,7 +5,7 @@
   "author": "Google LLC",
   "repository": "googleapis/nodejs-speech",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js",

--- a/storagetransfer/package.json
+++ b/storagetransfer/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/talent/package.json
+++ b/talent/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "repository": "googleapis/nodejs-talent",
   "private": true,

--- a/texttospeech/package.json
+++ b/texttospeech/package.json
@@ -8,7 +8,7 @@
     "*.js"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --timeout=60000"

--- a/translate/package.json
+++ b/translate/package.json
@@ -8,7 +8,7 @@
     "!test/"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 --recursive --timeout 240000"

--- a/video-intelligence/package.json
+++ b/video-intelligence/package.json
@@ -9,7 +9,7 @@
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-video-intelligence",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 system-test --timeout=800000"

--- a/vision/package.json
+++ b/vision/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "*.js"

--- a/workflows/invoke-private-endpoint/package.json
+++ b/workflows/invoke-private-endpoint/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/workflows/quickstart/package.json
+++ b/workflows/quickstart/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
## Description

Issue #3631 Refactoring out from original PR to manually updating node to latest stable v20
Part 2 to #3617 update from @iennae.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
