### PR TITLE
fix(issue-3631): update deps with neutral or unknown confidence (part 2)

### DIFF
--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -43,14 +43,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           caip_id:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id

--- a/.github/workflows/dialogflow-cx.yaml
+++ b/.github/workflows/dialogflow-cx.yaml
@@ -43,14 +43,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           agent_id:nodejs-docs-samples-tests/nodejs-docs-samples-dialogflow-cx-agent-id

--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -43,14 +43,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           slack_secret:nodejs-docs-samples-tests/nodejs-docs-samples-slack-secret

--- a/.github/workflows/generative-ai-snippets.yaml
+++ b/.github/workflows/generative-ai-snippets.yaml
@@ -46,14 +46,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           caip_id:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id

--- a/.github/workflows/iam-deny.yaml
+++ b/.github/workflows/iam-deny.yaml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/949737848314/locations/global/workloadIdentityPools/iam-deny-test-pool/providers/iam-deny-test-provider'
         service_account: 'kokoro-ca@isakovf-iam-deny-samples.iam.gserviceaccount.com'

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/github-script@v6
+    - uses: actions/@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/security-center-snippets.yaml
+++ b/.github/workflows/security-center-snippets.yaml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'

--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -46,14 +46,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           sts_aws_secret:nodejs-docs-samples-tests/nodejs-docs-samples-storagetransfer-aws

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'

--- a/.github/workflows/utils/ci-secrets.yaml.njk
+++ b/.github/workflows/utils/ci-secrets.yaml.njk
@@ -43,14 +43,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${% raw %}{{github.event.pull_request.head.sha}}{% endraw %}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           # TODO: Update secrets

--- a/.github/workflows/vision.yaml
+++ b/.github/workflows/vision.yaml
@@ -46,14 +46,14 @@ jobs:
     - uses: actions/checkout@v4.1.0
       with:
         ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v2.1.1'
       with:
         workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           vision:nodejs-docs-samples-tests/nodejs-docs-samples-vision

--- a/appengine/typescript/package.json
+++ b/appengine/typescript/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
-    "@types/node": "^18.13.0",
+    "@types/node": "^20.0.0",
     "c8": "^8.0.0",
     "chai": "^4.3.7",
     "gts": "^5.0.0",

--- a/automl/package.json
+++ b/automl/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "@google-cloud/automl": "^4.0.0",
-    "mathjs": "^11.0.0"
+    "mathjs": "^12.0.0"
   },
   "devDependencies": {
     "@google-cloud/storage": "^7.0.0",

--- a/cloud-sql/sqlserver/tedious/package.json
+++ b/cloud-sql/sqlserver/tedious/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/secret-manager": "^5.0.0",
     "express": "^4.17.1",
     "pug": "^3.0.0",
-    "tedious": "^16.1.0",
+    "tedious": "^17.0.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/cloud-tasks/snippets/package.json
+++ b/cloud-tasks/snippets/package.json
@@ -15,7 +15,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@google-cloud/tasks": "^4.0.0",
+    "@google-cloud/tasks": "^5.0.0",
     "express": "^4.16.3"
   },
   "devDependencies": {

--- a/cloud-tasks/tutorial-gcf/app/package.json
+++ b/cloud-tasks/tutorial-gcf/app/package.json
@@ -11,7 +11,7 @@
     "test": "c8 mocha -p -j 2 --timeout 10000"
   },
   "dependencies": {
-    "@google-cloud/tasks": "^4.0.0",
+    "@google-cloud/tasks": "^5.0.0",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/cloud-tasks/tutorial-gcf/function/package.json
+++ b/cloud-tasks/tutorial-gcf/function/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@google-cloud/secret-manager": "^5.0.0",
-    "@sendgrid/mail": "^7.0.0"
+    "@sendgrid/mail": "^8.0.0"
   },
   "devDependencies": {
     "c8": "^8.0.0",

--- a/compute/package.json
+++ b/compute/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@google-cloud/compute": "^4.0.0",
-    "@sendgrid/mail": "^7.0.0",
+    "@sendgrid/mail": "^8.0.0",
     "nodemailer": "^6.0.0",
     "nodemailer-smtp-transport": "^2.7.4"
   },

--- a/document-warehouse/package.json
+++ b/document-warehouse/package.json
@@ -7,7 +7,7 @@
         "test": "c8 mocha test/*.test.js --timeout 600000"
     },
     "dependencies": {
-        "@google-cloud/contentwarehouse": "^0.5.1",
+        "@google-cloud/contentwarehouse": "^1.0.0",
         "@google-cloud/iam": "^1.0.0",
         "@google-cloud/resource-manager": "^5.0.0"
     },

--- a/functions/helloworld/package.json
+++ b/functions/helloworld/package.json
@@ -12,7 +12,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@google-cloud/debug-agent": "^8.0.0",
+    "@google-cloud/debug-agent": "^9.0.0",
     "@google-cloud/functions-framework": "^3.1.0",
     "escape-html": "^1.0.3"
   },

--- a/healthcare/consent/package.json
+++ b/healthcare/consent/package.json
@@ -17,6 +17,6 @@
     "uuid": "^9.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^10.0.0"
+    "@googleapis/healthcare": "^13.0.0"
   }
 }

--- a/healthcare/datasets/package.json
+++ b/healthcare/datasets/package.json
@@ -17,6 +17,6 @@
     "uuid": "^9.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^10.0.0"
+    "@googleapis/healthcare": "^13.0.0"
   }
 }

--- a/healthcare/dicom/package.json
+++ b/healthcare/dicom/package.json
@@ -19,6 +19,6 @@
     "uuid": "^9.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^10.0.0"
+    "@googleapis/healthcare": "^13.0.0"
   }
 }

--- a/healthcare/fhir/package.json
+++ b/healthcare/fhir/package.json
@@ -20,6 +20,6 @@
     "uuid": "^9.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^10.0.0"
+    "@googleapis/healthcare": "^13.0.0"
   }
 }

--- a/healthcare/hl7v2/package.json
+++ b/healthcare/hl7v2/package.json
@@ -18,6 +18,6 @@
     "uuid": "^9.0.0"
   },
   "dependencies": {
-    "@googleapis/healthcare": "^10.0.0"
+    "@googleapis/healthcare": "^13.0.0"
   }
 }

--- a/recaptcha_enterprise/snippets/package.json
+++ b/recaptcha_enterprise/snippets/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.0.0",
     "@types/yargs": "^17.0.19",
     "c8": "^8.0.0",
     "eslint": "^8.34.0",

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.13.0",
+    "@types/node": "^20.0.0",
     "c8": "^8.0.0",
     "chai": "^4.3.7",
     "gts": "^5.0.0",

--- a/talent/package.json
+++ b/talent/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^16.0.0",
+    "@types/node": "^20.0.0",
     "c8": "^8.0.0",
     "chai": "^4.2.0",
     "mocha": "^10.0.0",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.14.6",
+    "@types/node": "^20.0.0",
     "c8": "^8.0.0",
     "gts": "^5.0.0",
     "mocha": "^10.2.0",

--- a/workflows/quickstart/package.json
+++ b/workflows/quickstart/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.14.6",
+    "@types/node": "^20.0.0",
     "gts": "^5.0.0",
     "mocha": "^10.2.0"
   }


### PR DESCRIPTION
## Description

Refactoring manually from #3631, the deps with neutral confidence scores from dependabot 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
