### PR TITLE
fix: Typos in samples for tuning text embedding models.

### DIFF
--- a/ai-platform/snippets/embedding-model-tuning.js
+++ b/ai-platform/snippets/embedding-model-tuning.js
@@ -37,7 +37,7 @@ async function main(
 
   const client = new PipelineServiceClient({apiEndpoint});
   const match = apiEndpoint.match(/(?<L>\w+-\w+)/);
-  const location = match ? match.groups.L : 'us-centra11';
+  const location = match ? match.groups.L : 'us-central1';
   const parent = `projects/${project}/locations/${location}`;
   const params = {
     project: project,

--- a/ai-platform/snippets/test/embedding-model-tuning.test.js
+++ b/ai-platform/snippets/test/embedding-model-tuning.test.js
@@ -27,7 +27,7 @@ const cwd = path.join(__dirname, '..');
 const apiEndpoint = 'us-central1-aiplatform.googleapis.com';
 const project = process.env.CAIP_PROJECT_ID;
 const outputDir = 'gs://ucaip-samples-us-central1/training_pipeline_output';
-const job_names = [''];
+const job_names = [null];
 
 describe('AI platform tune text-embedding models', () => {
   it('should make tuned-text embedding models', async () => {
@@ -44,6 +44,6 @@ describe('AI platform tune text-embedding models', () => {
 after(async () => {
   const pipelineClient = new aiplatform.v1.PipelineServiceClient({apiEndpoint});
   pipelineClient.cancelPipelineJob({name: job_names[0]}).then(() => {
-    return pipelineClient.deletePipeline({name: job_names[0]});
+    return pipelineClient.deletePipelineJob({name: job_names[0]});
   });
 });


### PR DESCRIPTION
## Typos in samples for tuning text embedding models.

Fixes: b/329655744

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved