### PR TITLE
chore: use Cloud SQL Proxy v2 in README

### DIFF
--- a/cloud-sql/mysql/mysql/README.md
+++ b/cloud-sql/mysql/mysql/README.md
@@ -16,21 +16,18 @@
    [instructions](https://cloud.google.com/sql/docs/mysql/create-manage-databases).
    Note the database name.
 
-1. Create a service account following these
-   [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating),
-   and then grant the `roles/cloudsql.client` role following these
-   [instructions](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-   Download a JSON key to use to authenticate your connection.
+1. Set up [Application Default Credentials][adc]
 
 1. Use the information noted in the previous steps:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='my-db-user'
 export DB_PASS='my-db-pass'
 export DB_NAME='my_db'
 ```
+
+[adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 
 Note: Defining credentials in environment variables is convenient, but not
 secure. For a more secure solution, use [Secret
@@ -61,7 +58,6 @@ launch the proxy as shown below.
 Use these terminal commands to initialize environment variables:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_HOST='127.0.0.1'
 export DB_PORT='3306'
 export DB_USER='<DB_USER_NAME>'
@@ -72,7 +68,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -instances=<project-id>:<region>:<instance-name>=tcp:3306 -credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --port=3306 "$INSTANCE_CONNECTION_NAME" &
 ```
 
 #### Windows/PowerShell
@@ -80,7 +76,6 @@ Then use this command to launch the proxy in the background:
 Use these PowerShell commands to initialize environment variables:
 
 ```powershell
-$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
 $env:INSTANCE_HOST="127.0.0.1"
 $env:DB_PORT="3306"
 $env:DB_USER="<DB_USER_NAME>"
@@ -91,7 +86,7 @@ $env:DB_NAME="<DB_NAME>"
 Then use this command to launch the proxy in a separate PowerShell session:
 
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:3306 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "<project-id>:<region>:<instance-name> --port=3306"
 ```
 
 ### Launch proxy with Unix Domain Socket
@@ -110,7 +105,6 @@ sudo chown -R $USER ./cloudsql
 Use these terminal commands to initialize other environment variables as well:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_UNIX_SOCKET='./cloudsql/<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
@@ -120,7 +114,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -dir=./cloudsql --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --unix-socket=./cloudsql "$INSTANCE_CONNECTION_NAME" &
 ```
 
 ### Testing the application

--- a/cloud-sql/mysql/mysql2/README.md
+++ b/cloud-sql/mysql/mysql2/README.md
@@ -25,11 +25,9 @@ as a npm package. See [`@google-cloud/cloud-sql-connector`](https://www.npmjs.co
    [instructions](https://cloud.google.com/sql/docs/mysql/create-manage-databases).
    Note the database name.
 
-1. Create a service account following these
-   [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating),
-   and then grant the `roles/cloudsql.client` role following these
-   [instructions](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-   Download a JSON key to use to authenticate your connection.
+1. Set up [Application Default Credentials][adc]
+
+[adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 
 Note: Defining credentials in environment variables is convenient, but not
 secure. For a more secure solution, use [Secret
@@ -222,7 +220,7 @@ gcloud functions deploy votes --gen2 --runtime nodejs18 --trigger-http \
 You may optionally download and install the `cloud_sql_proxy` by
 [following the
 instructions](https://cloud.google.com/sql/docs/mysql/sql-proxy#install) as an
-alternative to using the 
+alternative to using the
 [Cloud SQL Node.js Connector](https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector).
 
 Instructions are provided below for using the proxy with a TCP connection or a
@@ -239,7 +237,6 @@ launch the proxy as shown below.
 Use these terminal commands to initialize environment variables:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_HOST='127.0.0.1'
 export DB_PORT='3306'
 export DB_USER='<DB_USER_NAME>'
@@ -250,7 +247,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -instances=<project-id>:<region>:<instance-name>=tcp:3306 -credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy $INSTANCE_CONNECTION_NAME --port 3306 &
 ```
 
 #### Windows/PowerShell
@@ -258,7 +255,6 @@ Then use this command to launch the proxy in the background:
 Use these PowerShell commands to initialize environment variables:
 
 ```powershell
-$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
 $env:INSTANCE_HOST="127.0.0.1"
 $env:DB_PORT="3306"
 $env:DB_USER="<DB_USER_NAME>"
@@ -269,7 +265,7 @@ $env:DB_NAME="<DB_NAME>"
 Then use this command to launch the proxy in a separate PowerShell session:
 
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:3306 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "<project-id>:<region>:<instance-name> --port=3306"
 ```
 
 ### Launch proxy with Unix Domain Socket
@@ -288,7 +284,6 @@ sudo chown -R $USER ./cloudsql
 Use these terminal commands to initialize other environment variables as well:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_UNIX_SOCKET='./cloudsql/<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
@@ -298,7 +293,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -dir=./cloudsql --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --unix-socket=./cloudsql $INSTANCE_CONNECTION_NAME &
 ```
 
 ### Testing the application

--- a/cloud-sql/postgres/knex/README.md
+++ b/cloud-sql/postgres/knex/README.md
@@ -28,11 +28,9 @@ user](https://cloud.google.com/sql/docs/postgres/create-manage-users#creating).
    [instructions](https://cloud.google.com/sql/docs/postgres/create-manage-databases).
    Note the database name.
 
-1. Create a service account following these
-   [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating),
-   and then grant the `roles/cloudsql.client` role following these
-   [instructions](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-   Download a JSON key to use to authenticate your connection.
+1. Set up [Application Default Credentials][adc]
+
+[adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 
 Note: Defining credentials in environment variables is convenient, but not
 secure. For a more secure solution, use [Secret
@@ -243,7 +241,6 @@ launch the proxy as shown below.
 Use these terminal commands to initialize environment variables:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_HOST='127.0.0.1'
 export DB_PORT='5432'
 export DB_USER='<DB_USER_NAME>'
@@ -254,7 +251,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -instances=<project-id>:<region>:<instance-name>=tcp:5432 -credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --port=5342 "$INSTANCE_CONNECTION_NAME" &
 ```
 
 #### Windows/PowerShell
@@ -273,7 +270,7 @@ $env:DB_NAME="<DB_NAME>"
 Then use this command to launch the proxy in a separate PowerShell session:
 
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:5432 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "<project-id>:<region>:<instance-name> --port=5342"
 ```
 
 ### Launch proxy with Unix Domain Socket
@@ -292,7 +289,6 @@ sudo chown -R $USER ./cloudsql
 Use these terminal commands to initialize other environment variables as well:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_UNIX_SOCKET='./cloudsql/<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
@@ -302,7 +298,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud_sql_proxy -dir=./cloudsql --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud_sql_proxy --unix-socket=./cloudsql $INSTANCE_CONNECTION_NAME &
 ```
 
 ### Testing the application

--- a/cloud-sql/sqlserver/mssql/README.md
+++ b/cloud-sql/sqlserver/mssql/README.md
@@ -20,11 +20,9 @@ project](https://cloud.google.com/resource-manager/docs/creating-managing-projec
 
     1. Click **CREATE**.
 
-1. Create a service account following these
-   [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating),
-   and then grant the `roles/cloudsql.client` role following these
-   [instructions](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-   Download a JSON key to use to authenticate your connection.
+1. Set up [Application Default Credentials][adc]
+
+[adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 
 ## Running locally
 
@@ -32,7 +30,6 @@ Use the information noted in the previous steps to set the following environment
 variables:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export INSTANCE_HOST='127.0.0.1'
 export DB_PORT='1433'
@@ -56,7 +53,7 @@ Download and install the `cloud_sql_proxy` by following the instructions
 Then, use the following command to start the proxy in the background using TCP:
 
 ```bash
-./cloud_sql_proxy -instances=${INSTANCE_CONNECTION_NAME}=tcp:1433 sqlserver -u ${DB_USER} --host 127.0.0.1
+./cloud-sql-proxy --port=1433 "$INSTANCE_CONNECTION_NAME" &
 ```
 
 Next, setup install the requirements with `npm`:

--- a/cloud-sql/sqlserver/tedious/README.md
+++ b/cloud-sql/sqlserver/tedious/README.md
@@ -33,11 +33,9 @@ project](https://cloud.google.com/resource-manager/docs/creating-managing-projec
 
     1. Click **CREATE**.
 
-1. Create a service account following these
-   [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating),
-   and then grant the `roles/cloudsql.client` role following these
-   [instructions](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-   Download a JSON key to use to authenticate your connection.
+1. Set up [Application Default Credentials][adc]
+
+[adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 
 Note: Defining credentials in environment variables is convenient, but not
 secure. For a more secure solution, use [Secret
@@ -243,7 +241,6 @@ launch the proxy as shown below.
 Use these terminal commands to initialize environment variables:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS='/path/to/service/account/key.json'
 export INSTANCE_HOST='127.0.0.1'
 export DB_PORT='1433'
 export DB_USER='<DB_USER_NAME>'
@@ -254,7 +251,7 @@ export DB_NAME='<DB_NAME>'
 Then use this command to launch the proxy in the background:
 
 ```bash
-./cloud-sql-proxy <PROJECT_ID>:<INSTANCE_REGION>:<INSTANCE_NAME> &
+./cloud-sql-proxy --port=1433 <PROJECT_ID>:<INSTANCE_REGION>:<INSTANCE_NAME> &
 ```
 
 #### Windows/PowerShell
@@ -262,7 +259,6 @@ Then use this command to launch the proxy in the background:
 Use these PowerShell commands to initialize environment variables:
 
 ```powershell
-$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
 $env:INSTANCE_HOST="127.0.0.1"
 $env:DB_PORT="1433"
 $env:DB_USER="<DB_USER_NAME>"
@@ -273,7 +269,7 @@ $env:DB_NAME="<DB_NAME>"
 Then use this command to launch the proxy in a separate PowerShell session:
 
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:1433 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "<project-id>:<region>:<instance-name> --port=1433"
 ```
 
 ### Testing the application


### PR DESCRIPTION
Also, remove all reference to service account keys in favor of Application Default Credentials.

Fixes #3634
Fixes #3635