### PR TITLE
chore: Update runtimes for App Engine standard

### DIFF
--- a/appengine/analytics/app.standard.yaml
+++ b/appengine/analytics/app.standard.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017, Google, Inc.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs16
+runtime: nodejs20
 
 # [START gae_analytics_env_variables]
 env_variables:

--- a/appengine/datastore/app.standard.yaml
+++ b/appengine/datastore/app.standard.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017, Google, Inc.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs16
+runtime: nodejs20

--- a/appengine/hello-world/standard/app.yaml
+++ b/appengine/hello-world/standard/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017, Google, Inc.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,5 +12,5 @@
 # limitations under the License.
 
 # [START gae_quickstart_yaml]
-runtime: nodejs16
+runtime: nodejs20
 # [END gae_quickstart_yaml]

--- a/appengine/memcached/app.standard.yaml
+++ b/appengine/memcached/app.standard.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2016 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs16
+runtime: nodejs20
 
 # [START gae_redislabs_memcache_yaml]
 # The following env variables may contain sensitive information that grants

--- a/appengine/metadata/standard/app.yaml
+++ b/appengine/metadata/standard/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2016 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs16
+runtime: nodejs20

--- a/appengine/pubsub/app.standard.yaml
+++ b/appengine/pubsub/app.standard.yaml
@@ -1,5 +1,5 @@
 
-# Copyright 2015-2016, Google, Inc.
+# Copyright 2015-2016 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs16
+runtime: nodejs20
 
 instance_class: F2
 

--- a/appengine/static-files/app.standard.yaml
+++ b/appengine/static-files/app.standard.yaml
@@ -1,4 +1,4 @@
-# Copyright 2015-2016, Google, Inc.
+# Copyright 2015-2016 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs16
+runtime: nodejs20
 
 handlers:
   - url: /static

--- a/appengine/storage/standard/app.yaml
+++ b/appengine/storage/standard/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2015-2016, Google, Inc.
+# Copyright 2015-2016 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # [START gae_storage_yaml]
-runtime: nodejs16
+runtime: nodejs20
 
 env_variables:
   GCLOUD_STORAGE_BUCKET: YOUR_BUCKET_NAME


### PR DESCRIPTION
Node.js 10, 12, 14, and 16 have reached end of
support on January 30, 2024. Existing
applications using these versions will continue
to run and receive traffic. This update to
samples ensures new deploys will work as
expected.

## Description

Fixes #3645 
Fixes #3642 
Replaces #3643 

## Checklist

- [X] Please **merge** this PR for me once it is approved
