### PR TITLE
fix: resolve WARNs and Update version of Node.js used

### DIFF
--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -17,7 +17,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
+FROM node:20-slim
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -30,7 +30,7 @@ COPY package*.json ./
 # Install production dependencies.
 # If you add a package-lock.json, speed your build by switching to 'npm ci'.
 # RUN npm ci --only=production
-RUN npm install --only=production
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./


### PR DESCRIPTION
* update to use node:20-slim
* resolves warning that comes up  npm WARN config only Use `--omit=dev` https://docs.npmjs.com/cli/v9/commands/npm-ci#omit

I've tested locally and not making any major changes

- [X] Please **merge** this PR for me once it is approved
