### PR TITLE
chore: update Dockerfiles to use modern images

### DIFF
--- a/cloud-sql/mysql/mysql/Dockerfile
+++ b/cloud-sql/mysql/mysql/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
+FROM node:20-slim
 
 # Create and change to the app directory.
 WORKDIR /app
@@ -15,9 +15,14 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy any certificates if present.
 COPY ./certs /app/certs

--- a/cloud-sql/mysql/mysql/Dockerfile
+++ b/cloud-sql/mysql/mysql/Dockerfile
@@ -20,7 +20,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/cloud-sql/mysql/mysql2/Dockerfile
+++ b/cloud-sql/mysql/mysql2/Dockerfile
@@ -4,8 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -15,9 +14,14 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy any certificates if present.
 COPY ./certs /app/certs

--- a/cloud-sql/mysql/mysql2/Dockerfile
+++ b/cloud-sql/mysql/mysql2/Dockerfile
@@ -19,7 +19,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/cloud-sql/postgres/knex/Dockerfile
+++ b/cloud-sql/postgres/knex/Dockerfile
@@ -4,8 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -15,9 +14,14 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy any certificates if present.
 COPY ./certs /app/certs

--- a/cloud-sql/postgres/knex/Dockerfile
+++ b/cloud-sql/postgres/knex/Dockerfile
@@ -19,7 +19,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/cloud-sql/sqlserver/mssql/Dockerfile
+++ b/cloud-sql/sqlserver/mssql/Dockerfile
@@ -15,8 +15,7 @@
 # Use the official lightweight Node.js image.
 
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -26,9 +25,14 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./

--- a/cloud-sql/sqlserver/mssql/Dockerfile
+++ b/cloud-sql/sqlserver/mssql/Dockerfile
@@ -30,7 +30,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/cloud-sql/sqlserver/tedious/Dockerfile
+++ b/cloud-sql/sqlserver/tedious/Dockerfile
@@ -15,8 +15,7 @@
 # Use the official lightweight Node.js image.
 
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -26,9 +25,14 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./

--- a/cloud-sql/sqlserver/tedious/Dockerfile
+++ b/cloud-sql/sqlserver/tedious/Dockerfile
@@ -30,7 +30,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/cloud-tasks/snippets/Dockerfile
+++ b/cloud-tasks/snippets/Dockerfile
@@ -1,6 +1,6 @@
-# Use the official Node.js 10 image.
+# Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:10
+FROM node:20-slim
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -10,8 +10,15 @@ WORKDIR /usr/src/app
 # Copying this separately prevents re-running npm install on every code change.
 COPY package.json package*.json ./
 
-# Install production dependencies.
-RUN npm install --only=production
+# Install dependencies.
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/cloud-tasks/snippets/Dockerfile
+++ b/cloud-tasks/snippets/Dockerfile
@@ -16,7 +16,7 @@ COPY package.json package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/eventarc/audit-storage/Dockerfile
+++ b/eventarc/audit-storage/Dockerfile
@@ -16,8 +16,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -27,9 +26,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/eventarc/audit-storage/Dockerfile
+++ b/eventarc/audit-storage/Dockerfile
@@ -31,7 +31,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -16,8 +16,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -27,9 +26,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -31,7 +31,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -16,8 +16,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -27,9 +26,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -31,7 +31,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -10,8 +9,15 @@ WORKDIR /usr/src/app
 # Copying this separately prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
-RUN npm install --only=production
+# Install dependencies.
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -15,7 +15,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -17,8 +17,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -27,10 +26,15 @@ WORKDIR /usr/src/app
 # Copying this first prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
-# If you add a package-lock.json, speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --only=production
+# Install dependencies.
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -32,7 +32,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -27,9 +27,14 @@ WORKDIR /usr/src/app
 # Copying this first prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
-# If you add a package-lock.json, speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
+# Install dependencies.
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
 RUN npm install --omit=dev
 
 # Copy local code to the container image.

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -33,7 +33,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -33,7 +33,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -4,8 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # [START cloudrun_imageproc_dockerfile_imagemagick]
 # [START run_imageproc_dockerfile_imagemagick]
 
@@ -29,9 +28,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -4,8 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -15,9 +14,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -19,7 +19,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -29,7 +29,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -14,8 +14,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -24,8 +23,15 @@ WORKDIR /usr/src/app
 # Copying this separately prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
-RUN npm install --only=production
+# Install dependencies.
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -29,7 +29,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 # Copy local code to the container image.

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -14,8 +14,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -24,9 +23,15 @@ WORKDIR /usr/src/app
 # Copying this separately prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
-RUN npm install --only=production
+# Install dependencies.
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
 
+RUN npm install --omit=dev
 # Copy local code to the container image.
 COPY . ./
 

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -7,8 +7,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM node:18-slim
-
+FROM node:20-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
@@ -18,9 +17,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
+# if you need a deterministic and repeatable build create a 
+# package-lock.json file and use npm ci:
+# RUN npm ci --omit=dev
+# if you need to include development dependencies during development
+# of your application, use:
+# RUN npm install -dev
+
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . .

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -22,7 +22,7 @@ COPY package*.json ./
 # RUN npm ci --omit=dev
 # if you need to include development dependencies during development
 # of your application, use:
-# RUN npm install -dev
+# RUN npm install --dev
 
 RUN npm install --omit=dev
 


### PR DESCRIPTION
* update to use node:20-slim
* resolves warning that comes up with npm WARN
* update comment to clarify difference between using ci (clean install) over install which isn't necessarily faster (and can be in fact slower) and the context of why production.

This PR intentionally does not resolve some other
remaining Docker issues as there are remaining
issues to resolve including appropriate fonts
with Alpine image use.

This does resolve a chunk of the Dockerfile
updates. Many of these are exactly the same
and there may be room to centralize and
standardize rather than having separate files.

I did go in and build docker images to verify these worked. 

## Checklist

- [X ] Please **merge** this PR for me once it is approved
