### PR TITLE
feat: Make embedding tuning sample reference new v1.1.3 tuning pipeline

### DIFF
--- a/ai-platform/snippets/embedding-model-tuning.js
+++ b/ai-platform/snippets/embedding-model-tuning.js
@@ -22,14 +22,16 @@ async function main(
   project,
   outputDir,
   pipelineJobDisplayName = 'embedding-customization-pipeline-sample',
-  baseModelVersionId = 'textembedding-gecko@003',
+  baseModelVersionId = 'text-embedding-004',
   taskType = 'DEFAULT',
   queriesPath = 'gs://embedding-customization-pipeline/dataset/queries.jsonl',
   corpusPath = 'gs://embedding-customization-pipeline/dataset/corpus.jsonl',
   trainLabelPath = 'gs://embedding-customization-pipeline/dataset/train.tsv',
   testLabelPath = 'gs://embedding-customization-pipeline/dataset/test.tsv',
+  outputDimensionality = 768,
+  learningRateMultiplier = 1.0,
   batchSize = 128,
-  iterations = 1000
+  trainSteps = 1000
 ) {
   const aiplatform = require('@google-cloud/aiplatform');
   const {PipelineServiceClient} = aiplatform.v1;
@@ -40,8 +42,6 @@ async function main(
   const location = match ? match.groups.L : 'us-central1';
   const parent = `projects/${project}/locations/${location}`;
   const params = {
-    project: project,
-    location: location,
     base_model_version_id: baseModelVersionId,
     task_type: taskType,
     queries_path: queriesPath,
@@ -49,7 +49,9 @@ async function main(
     train_label_path: trainLabelPath,
     test_label_path: testLabelPath,
     batch_size: batchSize,
-    iterations: iterations,
+    train_steps: trainSteps,
+    output_dimensionality: outputDimensionality,
+    learning_rate_multiplier: learningRateMultiplier,
   };
   const runtimeConfig = {
     gcsOutputDirectory: outputDir,
@@ -59,7 +61,7 @@ async function main(
   };
   const pipelineJob = {
     templateUri:
-      'https://us-kfp.pkg.dev/ml-pipeline/llm-text-embedding/tune-text-embedding-model/v1.1.2',
+      'https://us-kfp.pkg.dev/ml-pipeline/llm-text-embedding/tune-text-embedding-model/v1.1.3',
     displayName: pipelineJobDisplayName,
     runtimeConfig,
   };


### PR DESCRIPTION
## Description

Copy of https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3699 but from a branch off the original repo instead of a fork.

BUG=b/340594864

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample)) -- Affected test passes
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
