### PR TITLE
chore: pin gts version to fix errors in lint ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.0.0-alpha.1",
-    "gts": "^5.0.1",
+    "gts": "5.3.0",
     "mocha": "^10.2.0",
     "nunjucks": "^3.2.4",
     "prettier": "^3.0.3",


### PR DESCRIPTION
This is a temporary pinning of gts version until we can decide how to handle CommonJS vs ESM for samples in this repository.

See: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/actions/runs/9600101597
https://github.com/google/gts/releases/tag/v5.3.1