### PR TITLE
test: pin security center path to version (v1)

### DIFF
--- a/.github/workflows/security-center-snippets.yaml
+++ b/.github/workflows/security-center-snippets.yaml
@@ -18,16 +18,19 @@ on:
     branches:
     - main
     paths:
-    - 'security-center/snippets/**'
+    - 'security-center/snippets/v1/**'
+    - 'security-center/snippets/package.json'
     - '.github/workflows/security-center-snippets.yaml'
   pull_request:
     paths:
-    - 'security-center/snippets/**'
+    - 'security-center/snippets/v1/**'
+    - 'security-center/snippets/package.json'
     - '.github/workflows/security-center-snippets.yaml'
   pull_request_target:
     types: [labeled]
     paths:
-    - 'security-center/snippets/**'
+    - 'security-center/snippets/v1/**'
+    - 'security-center/snippets/package.json'
     - '.github/workflows/security-center-snippets.yaml'
   schedule:
   - cron:  '0 0 * * 0'
@@ -58,14 +61,14 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash
-      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}        
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
     - uses: actions/cache@v3
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-   
+          ${{ runner.os }}-node-
     - name: install repo dependencies
       run: npm install
       working-directory: .
@@ -89,7 +92,7 @@ jobs:
       with:
         name: test-results
         path: security-center/snippets/${{ env.MOCHA_REPORTER_OUTPUT }}
-        retention-days: 1        
+        retention-days: 1
   flakybot:
     permissions:
       contents: 'read'


### PR DESCRIPTION
## Description

Pinning the path to v1 will make it easier to isolate and analyze v2 test failures related to #3722 (for example, see https://github.com/GoogleCloudPlatform/nodejs-docs-samples/actions/runs/9982328259/job/27587826930?pr=3743).

Note: #3722 adds [.github/workflows/security-center-snippets-v2.yaml](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3722/files#diff-b666080e3aae69df576b5d7312730719f7bf9a3f5a3918c6493365dc4740b593) to cover the security-center v2 snippets/tests.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [x] Please **merge** this PR for me once it is approved
