### PR TITLE
ci: remove use of pull_request_target (part 1)

### DIFF
--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -21,11 +21,11 @@ on:
     - 'ai-platform/snippets/**'
     - '.github/workflows/ai-platform-snippets.yaml'
   pull_request:
-    paths:
-    - 'ai-platform/snippets/**'
-    - '.github/workflows/ai-platform-snippets.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'ai-platform/snippets/**'
     - '.github/workflows/ai-platform-snippets.yaml'

--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -21,11 +21,11 @@ on:
     - 'ai-platform/snippets/**'
     - '.github/workflows/ai-platform-snippets.yaml'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - synchronize
-    - labeled
+    paths:
+    - 'ai-platform/snippets/**'
+    - '.github/workflows/ai-platform-snippets.yaml'
+  pull_request_target:
+    types: [labeled]
     paths:
     - 'ai-platform/snippets/**'
     - '.github/workflows/ai-platform-snippets.yaml'

--- a/.github/workflows/functions-env_vars.yaml
+++ b/.github/workflows/functions-env_vars.yaml
@@ -22,12 +22,11 @@ on:
     - '.github/workflows/functions-env_vars.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'functions/env_vars/**'
-    - '.github/workflows/functions-env_vars.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'functions/env_vars/**'
     - '.github/workflows/functions-env_vars.yaml'

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -24,4 +24,4 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - run: echo "Skipping label removal for reduced permissions. Please remove the 'actions:force-run' label manually."
+    - run: echo "Label removal is currently skipped. Please remove the 'actions:force-run' label manually. See b/354216420"

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -17,30 +17,11 @@ name: Remove Label
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   remove_label:
-    permissions:
-      contents: 'read'
-      id-token: 'write'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          try {
-            const event = JSON.parse(
-              require("fs").readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")
-            );
-            await github.rest.issues.removeLabel({
-              name: "actions:force-run",
-              owner: "GoogleCloudPlatform",
-              repo: "nodejs-docs-samples",
-              issue_number: event.pull_request.number,
-            });
-          } catch (e) {
-            if (!e.message.includes("Label does not exist")) {
-              throw e;
-            }
-          }
+    - run: echo "Skipping label removal for reduced permissions. Please remove the 'actions:force-run' label manually."

--- a/.github/workflows/utils/ci-matrix.yaml.njk
+++ b/.github/workflows/utils/ci-matrix.yaml.njk
@@ -21,11 +21,11 @@ on:
     - '{{path}}/**'
     - '.github/workflows/{{name}}.yaml'
   pull_request:
-    paths:
-    - '{{path}}/**'
-    - '.github/workflows/{{name}}.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - '{{path}}/**'
     - '.github/workflows/{{name}}.yaml'

--- a/.github/workflows/utils/ci-secrets.yaml.njk
+++ b/.github/workflows/utils/ci-secrets.yaml.njk
@@ -21,11 +21,11 @@ on:
     - '{{ path }}/**'
     - '.github/workflows/{{ name }}.yaml'
   pull_request:
-    paths:
-    - '{{ path }}/**'
-    - '.github/workflows/{{ name }}.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - '{{ path }}/**'
     - '.github/workflows/{{ name }}.yaml'

--- a/.github/workflows/utils/ci.yaml.njk
+++ b/.github/workflows/utils/ci.yaml.njk
@@ -21,11 +21,11 @@ on:
     - '{{path}}/**'
     - '.github/workflows/{{name}}.yaml'
   pull_request:
-    paths:
-    - '{{path}}/**'
-    - '.github/workflows/{{name}}.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - '{{path}}/**'
     - '.github/workflows/{{name}}.yaml'
@@ -42,16 +42,6 @@ jobs:
     with:
       name: '{{name}}'
       path: '{{path}}'
-  remove_label:
-    # Ref: https://github.com/google-github-actions/auth#usage
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    if: |
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'actions:force-run' &&
-      always()
-    uses: ./.github/workflows/remove-label.yaml
   flakybot:
     # Ref: https://github.com/google-github-actions/auth#usage
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ When a Pull Request is opened, reopened, or has new commits pushed the tests wil
 
 If the tests for a sample change do not run, they can be triggered by adding the `actions:force-run` label.
 
-If tests need to be triggered a second time, manually remove and re-add this label.
+If tests need to be triggered multiple times, manually remove `actions:force-run` and then re-add this label.
 
 The label will not be automatically removed. Please remove it before merging the Pull Request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,9 @@ a great sample but it is not used in Google's official documentation, there are
 better suited places to publish it such as a [community
 tutorial](https://cloud.google.com/community/).
 
-## Run the tests for a single sample
+## Run the tests
+
+### Run the tests locally for a single sample
 
 1. Obtain authentication credentials. Depending on the sample, you need to
 enable the appropriate APIs in the [Cloud
@@ -28,6 +30,16 @@ Console](https://console.cloud.google.com/apis/library).
 1. Run the tests.
 
         npm test
+
+### Running the tests for a Pull Request
+
+When a Pull Request is opened, reopened, or has new commits pushed the tests will be run.
+
+If the tests for a sample change do not run, they can be triggered by adding the `actions:force-run` label.
+
+If tests need to be triggered a second time, manually remove and re-add this label.
+
+The label will not be automatically removed. Please remove it before merging the Pull Request.
 
 ## Adding new samples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Console](https://console.cloud.google.com/apis/library).
 
 ### Running the tests for a Pull Request
 
-When a Pull Request is opened, reopened, or has new commits pushed the tests will be run.
+When a Pull Request is opened, reopened, or has new commits pushed the sample tests (unit, integration, end-to-end) will be run.
 
 If the tests for a sample change do not run, they can be triggered by adding the `actions:force-run` label.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If the tests for a sample change do not run, they can be triggered by adding the
 
 If tests need to be triggered multiple times, manually remove `actions:force-run` and then re-add this label.
 
-The label will not be automatically removed. Please remove it before merging the Pull Request.
+The automatic clean-up of labels is currently disabled. Please remove the actions:force-run before merging the Pull Request.
 
 ## Adding new samples
 


### PR DESCRIPTION
## Description

This change is the start on removing `pull_request_target` from sample testing workflows.

1. Templates are updated to add the labeled type to the `pull_request` trigger, and remove the `pull_request_target`.
2. The ai-platform-snippets.yaml workflow is updated to match
3. The reused remove-label.yaml workflow is converted to a no-op echo statement providing maintainer guidance
4. CONTRIBUTING.md is updated to note this behavior around PR testing controls

Workshop the pattern and guidance here, then migrate remaining workflows to this trigger configuration in follow-up.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
