### PR TITLE
ci(functions): update tests to use labeled on pull_request trigger

### DIFF
--- a/.github/workflows/functions-concepts.yaml
+++ b/.github/workflows/functions-concepts.yaml
@@ -16,23 +16,23 @@ name: functions-concepts
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/concepts/**'
-      - '.github/workflows/functions-concepts.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/concepts/**'
+    - '.github/workflows/functions-concepts.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/concepts/**'
-      - '.github/workflows/functions-concepts.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/concepts/**'
+    - '.github/workflows/functions-concepts.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -42,13 +42,13 @@ jobs:
     strategy:
       matrix:
         path:
-          - 'functions/concepts/afterResponse'
-          - 'functions/concepts/afterTimeout'
-          - 'functions/concepts/backgroundTermination'
-          - 'functions/concepts/filesystem'
-          - 'functions/concepts/httpTermination'
-          - 'functions/concepts/requests'
-          - 'functions/concepts/stateless'
+        - 'functions/concepts/afterResponse'
+        - 'functions/concepts/afterTimeout'
+        - 'functions/concepts/backgroundTermination'
+        - 'functions/concepts/filesystem'
+        - 'functions/concepts/httpTermination'
+        - 'functions/concepts/requests'
+        - 'functions/concepts/stateless'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-concepts'

--- a/.github/workflows/functions-concepts.yaml
+++ b/.github/workflows/functions-concepts.yaml
@@ -16,24 +16,23 @@ name: functions-concepts
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/concepts/**'
-    - '.github/workflows/functions-concepts.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/concepts/**'
+      - '.github/workflows/functions-concepts.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/concepts/**'
-    - '.github/workflows/functions-concepts.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/concepts/**'
-    - '.github/workflows/functions-concepts.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/concepts/**'
+      - '.github/workflows/functions-concepts.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -49,7 +48,7 @@ jobs:
           - 'functions/concepts/filesystem'
           - 'functions/concepts/httpTermination'
           - 'functions/concepts/requests'
-          - 'functions/concepts/stateless'        
+          - 'functions/concepts/stateless'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-concepts'

--- a/.github/workflows/functions-firebase.yaml
+++ b/.github/workflows/functions-firebase.yaml
@@ -16,24 +16,23 @@ name: functions-firebase
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/firebase/**'
-    - '.github/workflows/functions-firebase.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/firebase/**'
+      - '.github/workflows/functions-firebase.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/firebase/**'
-    - '.github/workflows/functions-firebase.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/firebase/**'
-    - '.github/workflows/functions-firebase.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/firebase/**'
+      - '.github/workflows/functions-firebase.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-firebase.yaml
+++ b/.github/workflows/functions-firebase.yaml
@@ -16,23 +16,23 @@ name: functions-firebase
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/firebase/**'
-      - '.github/workflows/functions-firebase.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/firebase/**'
+    - '.github/workflows/functions-firebase.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/firebase/**'
-      - '.github/workflows/functions-firebase.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/firebase/**'
+    - '.github/workflows/functions-firebase.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -42,12 +42,12 @@ jobs:
     strategy:
       matrix:
         path:
-          - 'functions/firebase/helloAnalytics'
-          - 'functions/firebase/helloAuth'
-          - 'functions/firebase/helloFirestore'
-          - 'functions/firebase/helloRemoteConfig'
-          - 'functions/firebase/helloRTDB'
-          - 'functions/firebase/makeUpperCase'
+        - 'functions/firebase/helloAnalytics'
+        - 'functions/firebase/helloAuth'
+        - 'functions/firebase/helloFirestore'
+        - 'functions/firebase/helloRemoteConfig'
+        - 'functions/firebase/helloRTDB'
+        - 'functions/firebase/makeUpperCase'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-firebase'

--- a/.github/workflows/functions-helloworld.yaml
+++ b/.github/workflows/functions-helloworld.yaml
@@ -16,24 +16,23 @@ name: functions-helloworld
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/helloworld/**'
-    - '.github/workflows/functions-helloworld.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/helloworld/**'
+      - '.github/workflows/functions-helloworld.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/helloworld/**'
-    - '.github/workflows/functions-helloworld.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/helloworld/**'
-    - '.github/workflows/functions-helloworld.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/helloworld/**'
+      - '.github/workflows/functions-helloworld.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-helloworld.yaml
+++ b/.github/workflows/functions-helloworld.yaml
@@ -16,23 +16,23 @@ name: functions-helloworld
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/helloworld/**'
-      - '.github/workflows/functions-helloworld.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/helloworld/**'
+    - '.github/workflows/functions-helloworld.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/helloworld/**'
-      - '.github/workflows/functions-helloworld.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/helloworld/**'
+    - '.github/workflows/functions-helloworld.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -42,11 +42,11 @@ jobs:
     strategy:
       matrix:
         path:
-          - 'functions/helloworld/helloError'
-          - 'functions/helloworld/helloGCS'
-          - 'functions/helloworld/helloPubSub'
-          - 'functions/helloworld/helloworldGet'
-          - 'functions/helloworld/helloworldHttp'
+        - 'functions/helloworld/helloError'
+        - 'functions/helloworld/helloGCS'
+        - 'functions/helloworld/helloPubSub'
+        - 'functions/helloworld/helloworldGet'
+        - 'functions/helloworld/helloworldHttp'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-helloworld'

--- a/.github/workflows/functions-http.yaml
+++ b/.github/workflows/functions-http.yaml
@@ -16,24 +16,23 @@ name: functions-http
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/http/**'
-    - '.github/workflows/functions-http.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/http/**'
+      - '.github/workflows/functions-http.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/http/**'
-    - '.github/workflows/functions-http.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/http/**'
-    - '.github/workflows/functions-http.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/http/**'
+      - '.github/workflows/functions-http.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-http.yaml
+++ b/.github/workflows/functions-http.yaml
@@ -16,23 +16,23 @@ name: functions-http
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/http/**'
-      - '.github/workflows/functions-http.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/http/**'
+    - '.github/workflows/functions-http.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/http/**'
-      - '.github/workflows/functions-http.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/http/**'
+    - '.github/workflows/functions-http.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -42,10 +42,10 @@ jobs:
     strategy:
       matrix:
         path:
-          - 'functions/http/corsEnabledFunction'
-          - 'functions/http/corsEnabledFunctionAuth'
-          - 'functions/http/httpContent'
-          - 'functions/http/httpMethods'
+        - 'functions/http/corsEnabledFunction'
+        - 'functions/http/corsEnabledFunctionAuth'
+        - 'functions/http/httpContent'
+        - 'functions/http/httpMethods'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-http'

--- a/.github/workflows/functions-log-helloWorld.yaml
+++ b/.github/workflows/functions-log-helloWorld.yaml
@@ -34,6 +34,11 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    permissions: { }
+    steps:
+    - run: echo "${{github.event.action}} - ${{github.event.label.name}}"
   test:
     permissions:
       contents: 'read'

--- a/.github/workflows/functions-log-helloWorld.yaml
+++ b/.github/workflows/functions-log-helloWorld.yaml
@@ -34,11 +34,6 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 jobs:
-  inspect:
-    runs-on: ubuntu-latest
-    permissions: { }
-    steps:
-    - run: echo "${{github.event.action}} - ${{github.event.label.name}}"
   test:
     permissions:
       contents: 'read'

--- a/.github/workflows/functions-log-helloWorld.yaml
+++ b/.github/workflows/functions-log-helloWorld.yaml
@@ -16,24 +16,23 @@ name: functions-log-helloWorld
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/log/helloWorld/**'
-    - '.github/workflows/functions-log-helloWorld.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/log/helloWorld/**'
+      - '.github/workflows/functions-log-helloWorld.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/log/helloWorld/**'
-    - '.github/workflows/functions-log-helloWorld.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/log/helloWorld/**'
-    - '.github/workflows/functions-log-helloWorld.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/log/helloWorld/**'
+      - '.github/workflows/functions-log-helloWorld.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-log-helloWorld.yaml
+++ b/.github/workflows/functions-log-helloWorld.yaml
@@ -16,23 +16,23 @@ name: functions-log-helloWorld
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/log/helloWorld/**'
-      - '.github/workflows/functions-log-helloWorld.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/log/helloWorld/**'
+    - '.github/workflows/functions-log-helloWorld.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/log/helloWorld/**'
-      - '.github/workflows/functions-log-helloWorld.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/log/helloWorld/**'
+    - '.github/workflows/functions-log-helloWorld.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-log-processEntry.yaml
+++ b/.github/workflows/functions-log-processEntry.yaml
@@ -16,24 +16,23 @@ name: functions-log-processEntry
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/log/processEntry/**'
-    - '.github/workflows/functions-log-processEntry.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/log/processEntry/**'
+      - '.github/workflows/functions-log-processEntry.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/log/processEntry/**'
-    - '.github/workflows/functions-log-processEntry.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/log/processEntry/**'
-    - '.github/workflows/functions-log-processEntry.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/log/processEntry/**'
+      - '.github/workflows/functions-log-processEntry.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-log-processEntry.yaml
+++ b/.github/workflows/functions-log-processEntry.yaml
@@ -16,23 +16,23 @@ name: functions-log-processEntry
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/log/processEntry/**'
-      - '.github/workflows/functions-log-processEntry.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/log/processEntry/**'
+    - '.github/workflows/functions-log-processEntry.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/log/processEntry/**'
-      - '.github/workflows/functions-log-processEntry.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/log/processEntry/**'
+    - '.github/workflows/functions-log-processEntry.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-memorystore-redis.yaml
+++ b/.github/workflows/functions-memorystore-redis.yaml
@@ -16,24 +16,23 @@ name: functions-memorystore-redis
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/memorystore/redis/**'
-    - '.github/workflows/functions-memorystore-redis.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/memorystore/redis/**'
+      - '.github/workflows/functions-memorystore-redis.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/memorystore/redis/**'
-    - '.github/workflows/functions-memorystore-redis.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/memorystore/redis/**'
-    - '.github/workflows/functions-memorystore-redis.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/memorystore/redis/**'
+      - '.github/workflows/functions-memorystore-redis.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-memorystore-redis.yaml
+++ b/.github/workflows/functions-memorystore-redis.yaml
@@ -16,23 +16,23 @@ name: functions-memorystore-redis
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/memorystore/redis/**'
-      - '.github/workflows/functions-memorystore-redis.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/memorystore/redis/**'
+    - '.github/workflows/functions-memorystore-redis.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/memorystore/redis/**'
-      - '.github/workflows/functions-memorystore-redis.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/memorystore/redis/**'
+    - '.github/workflows/functions-memorystore-redis.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-pubsub.yaml
+++ b/.github/workflows/functions-pubsub.yaml
@@ -16,23 +16,23 @@ name: functions-pubsub
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/pubsub/**'
-      - '.github/workflows/functions-pubsub.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/pubsub/**'
+    - '.github/workflows/functions-pubsub.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/pubsub/**'
-      - '.github/workflows/functions-pubsub.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/pubsub/**'
+    - '.github/workflows/functions-pubsub.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -42,8 +42,8 @@ jobs:
     strategy:
       matrix:
         path:
-          - 'functions/pubsub/publish'
-          - 'functions/pubsub/subscribe'
+        - 'functions/pubsub/publish'
+        - 'functions/pubsub/subscribe'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-pubsub'

--- a/.github/workflows/functions-pubsub.yaml
+++ b/.github/workflows/functions-pubsub.yaml
@@ -16,24 +16,23 @@ name: functions-pubsub
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/pubsub/**'
-    - '.github/workflows/functions-pubsub.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/pubsub/**'
+      - '.github/workflows/functions-pubsub.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/pubsub/**'
-    - '.github/workflows/functions-pubsub.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/pubsub/**'
-    - '.github/workflows/functions-pubsub.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/pubsub/**'
+      - '.github/workflows/functions-pubsub.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-scheduleinstance.yaml
+++ b/.github/workflows/functions-scheduleinstance.yaml
@@ -16,23 +16,23 @@ name: functions-scheduleinstance
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/scheduleinstance/**'
-      - '.github/workflows/functions-scheduleinstance.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/scheduleinstance/**'
+    - '.github/workflows/functions-scheduleinstance.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/scheduleinstance/**'
-      - '.github/workflows/functions-scheduleinstance.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/scheduleinstance/**'
+    - '.github/workflows/functions-scheduleinstance.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-scheduleinstance.yaml
+++ b/.github/workflows/functions-scheduleinstance.yaml
@@ -16,24 +16,23 @@ name: functions-scheduleinstance
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/scheduleinstance/**'
-    - '.github/workflows/functions-scheduleinstance.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/scheduleinstance/**'
+      - '.github/workflows/functions-scheduleinstance.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/scheduleinstance/**'
-    - '.github/workflows/functions-scheduleinstance.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/scheduleinstance/**'
-    - '.github/workflows/functions-scheduleinstance.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/scheduleinstance/**'
+      - '.github/workflows/functions-scheduleinstance.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-security.yaml
+++ b/.github/workflows/functions-security.yaml
@@ -16,24 +16,23 @@ name: functions-security
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/security/**'
-    - '.github/workflows/functions-security.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/security/**'
+      - '.github/workflows/functions-security.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/security/**'
-    - '.github/workflows/functions-security.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/security/**'
-    - '.github/workflows/functions-security.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/security/**'
+      - '.github/workflows/functions-security.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-security.yaml
+++ b/.github/workflows/functions-security.yaml
@@ -16,23 +16,23 @@ name: functions-security
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/security/**'
-      - '.github/workflows/functions-security.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/security/**'
+    - '.github/workflows/functions-security.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/security/**'
-      - '.github/workflows/functions-security.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/security/**'
+    - '.github/workflows/functions-security.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -16,21 +16,21 @@ name: functions-slack
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/slack/**'
-    - '.github/workflows/functions-slack.yaml'
+      - 'functions/slack/**'
+      - '.github/workflows/functions-slack.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/slack/**'
-    - '.github/workflows/functions-slack.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/slack/**'
-    - '.github/workflows/functions-slack.yaml'
+      - 'functions/slack/**'
+      - '.github/workflows/functions-slack.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -40,56 +40,56 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4.1.0
-      with:
-        ref: ${{github.event.pull_request.head.sha}}
-    - uses: 'google-github-actions/auth@v1.1.1'
-      with:
-        workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
-        service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
-        create_credentials_file: 'true'
-        access_token_lifetime: 600s
-    - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@v1'
-      with:
-        secrets: |-
-          slack_secret:nodejs-docs-samples-tests/nodejs-docs-samples-slack-secret
-          kg_api_key:nodejs-docs-samples-tests/nodejs-docs-samples-kg-api-key
-    - uses: actions/setup-node@v4.0.0
-      with:
-        node-version: 16
-    - name: Get npm cache directory
-      id: npm-cache-dir
-      shell: bash
-      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-    - uses: actions/cache@v3
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - name: set env vars for scheduled run
-      if: github.event.action == 'schedule'
-      run: |
-        echo "MOCHA_REPORTER_SUITENAME=functions-slack" >> $GITHUB_ENV
-        echo "MOCHA_REPORTER_OUTPUT=${{github.run_id}}_sponge_log.xml" >> $GITHUB_ENV
-        echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
-    - name: Run Tests
-      run: make test dir=functions/slack
-      env:
-        GOOGLE_SAMPLES_PROJECT: "long-door-651"
-        SLACK_SECRET: ${{ steps.secrets.outputs.slack_secret }}
-        KG_API_KEY: ${{ steps.secrets.outputs.kg_api_key }}
-    - name: upload test results for FlakyBot workflow
-      if: github.event.action == 'schedule' && always()
-      uses: actions/upload-artifact@v3
-      env:
-        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
-      with:
-        name: test-results
-        path: functions/slack/${{ env.MOCHA_REPORTER_OUTPUT }}
-        retention-days: 1
+      - uses: actions/checkout@v4.1.0
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+      - uses: 'google-github-actions/auth@v1.1.1'
+        with:
+          workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
+          create_credentials_file: 'true'
+          access_token_lifetime: 600s
+      - id: secrets
+        uses: 'google-github-actions/get-secretmanager-secrets@v1'
+        with:
+          secrets: |-
+            slack_secret:nodejs-docs-samples-tests/nodejs-docs-samples-slack-secret
+            kg_api_key:nodejs-docs-samples-tests/nodejs-docs-samples-kg-api-key
+      - uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 16
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+      - uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: set env vars for scheduled run
+        if: github.event.action == 'schedule'
+        run: |
+          echo "MOCHA_REPORTER_SUITENAME=functions-slack" >> $GITHUB_ENV
+          echo "MOCHA_REPORTER_OUTPUT=${{github.run_id}}_sponge_log.xml" >> $GITHUB_ENV
+          echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
+      - name: Run Tests
+        run: make test dir=functions/slack
+        env:
+          GOOGLE_SAMPLES_PROJECT: "long-door-651"
+          SLACK_SECRET: ${{ steps.secrets.outputs.slack_secret }}
+          KG_API_KEY: ${{ steps.secrets.outputs.kg_api_key }}
+      - name: upload test results for FlakyBot workflow
+        if: github.event.action == 'schedule' && always()
+        uses: actions/upload-artifact@v3
+        env:
+          MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
+        with:
+          name: test-results
+          path: functions/slack/${{ env.MOCHA_REPORTER_OUTPUT }}
+          retention-days: 1
   flakybot:
     permissions:
       contents: 'read'

--- a/.github/workflows/functions-slack.yaml
+++ b/.github/workflows/functions-slack.yaml
@@ -16,21 +16,21 @@ name: functions-slack
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/slack/**'
-      - '.github/workflows/functions-slack.yaml'
+    - 'functions/slack/**'
+    - '.github/workflows/functions-slack.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/slack/**'
-      - '.github/workflows/functions-slack.yaml'
+    - 'functions/slack/**'
+    - '.github/workflows/functions-slack.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -40,48 +40,48 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v4.1.0
         with:
           ref: ${{github.event.pull_request.head.sha}}
-      - uses: 'google-github-actions/auth@v1.1.1'
+    - uses: 'google-github-actions/auth@v1.1.1'
         with:
           workload_identity_provider: 'projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
           service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
           create_credentials_file: 'true'
           access_token_lifetime: 600s
-      - id: secrets
+    - id: secrets
         uses: 'google-github-actions/get-secretmanager-secrets@v1'
         with:
           secrets: |-
             slack_secret:nodejs-docs-samples-tests/nodejs-docs-samples-slack-secret
             kg_api_key:nodejs-docs-samples-tests/nodejs-docs-samples-kg-api-key
-      - uses: actions/setup-node@v4.0.0
+    - uses: actions/setup-node@v4.0.0
         with:
           node-version: 16
-      - name: Get npm cache directory
+    - name: Get npm cache directory
         id: npm-cache-dir
         shell: bash
         run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      - uses: actions/cache@v3
+    - uses: actions/cache@v3
         id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: set env vars for scheduled run
+    - name: set env vars for scheduled run
         if: github.event.action == 'schedule'
         run: |
           echo "MOCHA_REPORTER_SUITENAME=functions-slack" >> $GITHUB_ENV
           echo "MOCHA_REPORTER_OUTPUT=${{github.run_id}}_sponge_log.xml" >> $GITHUB_ENV
           echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
-      - name: Run Tests
+    - name: Run Tests
         run: make test dir=functions/slack
         env:
           GOOGLE_SAMPLES_PROJECT: "long-door-651"
           SLACK_SECRET: ${{ steps.secrets.outputs.slack_secret }}
           KG_API_KEY: ${{ steps.secrets.outputs.kg_api_key }}
-      - name: upload test results for FlakyBot workflow
+    - name: upload test results for FlakyBot workflow
         if: github.event.action == 'schedule' && always()
         uses: actions/upload-artifact@v3
         env:

--- a/.github/workflows/functions-spanner.yaml
+++ b/.github/workflows/functions-spanner.yaml
@@ -16,23 +16,23 @@ name: functions-spanner
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/spanner/**'
-      - '.github/workflows/functions-spanner.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/spanner/**'
+    - '.github/workflows/functions-spanner.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/spanner/**'
-      - '.github/workflows/functions-spanner.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/spanner/**'
+    - '.github/workflows/functions-spanner.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-spanner.yaml
+++ b/.github/workflows/functions-spanner.yaml
@@ -16,24 +16,23 @@ name: functions-spanner
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/spanner/**'
-    - '.github/workflows/functions-spanner.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/spanner/**'
+      - '.github/workflows/functions-spanner.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/spanner/**'
-    - '.github/workflows/functions-spanner.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/spanner/**'
-    - '.github/workflows/functions-spanner.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/spanner/**'
+      - '.github/workflows/functions-spanner.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-speech-to-speech-functions.yaml
+++ b/.github/workflows/functions-speech-to-speech-functions.yaml
@@ -16,23 +16,23 @@ name: functions-speech-to-speech-functions
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/speech-to-speech/functions/**'
-      - '.github/workflows/functions-speech-to-speech-functions.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/speech-to-speech/functions/**'
+    - '.github/workflows/functions-speech-to-speech-functions.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/speech-to-speech/functions/**'
-      - '.github/workflows/functions-speech-to-speech-functions.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/speech-to-speech/functions/**'
+    - '.github/workflows/functions-speech-to-speech-functions.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-speech-to-speech-functions.yaml
+++ b/.github/workflows/functions-speech-to-speech-functions.yaml
@@ -16,24 +16,23 @@ name: functions-speech-to-speech-functions
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/speech-to-speech/functions/**'
-    - '.github/workflows/functions-speech-to-speech-functions.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/speech-to-speech/functions/**'
+      - '.github/workflows/functions-speech-to-speech-functions.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/speech-to-speech/functions/**'
-    - '.github/workflows/functions-speech-to-speech-functions.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/speech-to-speech/functions/**'
-    - '.github/workflows/functions-speech-to-speech-functions.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/speech-to-speech/functions/**'
+      - '.github/workflows/functions-speech-to-speech-functions.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-tips.yaml
+++ b/.github/workflows/functions-tips.yaml
@@ -16,23 +16,23 @@ name: functions-tips
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/tips/**'
-      - '.github/workflows/functions-tips.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/tips/**'
+    - '.github/workflows/functions-tips.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/tips/**'
-      - '.github/workflows/functions-tips.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/tips/**'
+    - '.github/workflows/functions-tips.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -42,12 +42,12 @@ jobs:
     strategy:
       matrix:
         path:
-          - 'functions/tips/avoidInfiniteRetries'
-          - 'functions/tips/connectionPools'
-          - 'functions/tips/gcpApiCall'
-          - 'functions/tips/lazyGlobals'
-          - 'functions/tips/retry'
-          - 'functions/tips/scopeDemo'
+        - 'functions/tips/avoidInfiniteRetries'
+        - 'functions/tips/connectionPools'
+        - 'functions/tips/gcpApiCall'
+        - 'functions/tips/lazyGlobals'
+        - 'functions/tips/retry'
+        - 'functions/tips/scopeDemo'
     uses: ./.github/workflows/test.yaml
     with:
       name: 'functions-tips'

--- a/.github/workflows/functions-tips.yaml
+++ b/.github/workflows/functions-tips.yaml
@@ -16,24 +16,23 @@ name: functions-tips
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/tips/**'
-    - '.github/workflows/functions-tips.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/tips/**'
+      - '.github/workflows/functions-tips.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/tips/**'
-    - '.github/workflows/functions-tips.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/tips/**'
-    - '.github/workflows/functions-tips.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/tips/**'
+      - '.github/workflows/functions-tips.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-autolabelinstance.yaml
+++ b/.github/workflows/functions-v2-autolabelinstance.yaml
@@ -16,24 +16,23 @@ name: functions-v2-autoLabelInstance
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/autoLabelInstance/**'
-    - '.github/workflows/functions-v2-autoLabelInstance.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/autoLabelInstance/**'
+      - '.github/workflows/functions-v2-autoLabelInstance.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/autoLabelInstance/**'
-    - '.github/workflows/functions-v2-autoLabelInstance.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/autoLabelInstance/**'
-    - '.github/workflows/functions-v2-autoLabelInstance.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/autoLabelInstance/**'
+      - '.github/workflows/functions-v2-autoLabelInstance.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-autolabelinstance.yaml
+++ b/.github/workflows/functions-v2-autolabelinstance.yaml
@@ -16,23 +16,23 @@ name: functions-v2-autoLabelInstance
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/autoLabelInstance/**'
-      - '.github/workflows/functions-v2-autoLabelInstance.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/autoLabelInstance/**'
+    - '.github/workflows/functions-v2-autoLabelInstance.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/autoLabelInstance/**'
-      - '.github/workflows/functions-v2-autoLabelInstance.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/autoLabelInstance/**'
+    - '.github/workflows/functions-v2-autoLabelInstance.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-cloudeventlogging.yaml
+++ b/.github/workflows/functions-v2-cloudeventlogging.yaml
@@ -16,24 +16,23 @@ name: functions-v2-cloudEventLogging
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/cloudEventLogging/**'
-    - '.github/workflows/functions-v2-cloudEventLogging.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/cloudEventLogging/**'
+      - '.github/workflows/functions-v2-cloudEventLogging.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/cloudEventLogging/**'
-    - '.github/workflows/functions-v2-cloudEventLogging.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/cloudEventLogging/**'
-    - '.github/workflows/functions-v2-cloudEventLogging.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/cloudEventLogging/**'
+      - '.github/workflows/functions-v2-cloudEventLogging.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-cloudeventlogging.yaml
+++ b/.github/workflows/functions-v2-cloudeventlogging.yaml
@@ -16,23 +16,23 @@ name: functions-v2-cloudEventLogging
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/cloudEventLogging/**'
-      - '.github/workflows/functions-v2-cloudEventLogging.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/cloudEventLogging/**'
+    - '.github/workflows/functions-v2-cloudEventLogging.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/cloudEventLogging/**'
-      - '.github/workflows/functions-v2-cloudEventLogging.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/cloudEventLogging/**'
+    - '.github/workflows/functions-v2-cloudEventLogging.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml
+++ b/.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml
@@ -16,23 +16,23 @@ name: functions-v2-firebase-firestore-helloFirestore
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/firebase/firestore/helloFirestore/**'
-      - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/firestore/helloFirestore/**'
+    - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/firebase/firestore/helloFirestore/**'
-      - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/firestore/helloFirestore/**'
+    - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml
+++ b/.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml
@@ -16,24 +16,23 @@ name: functions-v2-firebase-firestore-helloFirestore
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/firebase/firestore/helloFirestore/**'
-    - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/firestore/helloFirestore/**'
+      - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/firebase/firestore/helloFirestore/**'
-    - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/firebase/firestore/helloFirestore/**'
-    - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/firestore/helloFirestore/**'
+      - '.github/workflows/functions-v2-firebase-firestore-helloFirestore.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml
+++ b/.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml
@@ -16,23 +16,23 @@ name: functions-v2-firebase-firestore-makeUpperCase
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/firebase/firestore/makeUpperCase/**'
-      - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/firestore/makeUpperCase/**'
+    - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/firebase/firestore/makeUpperCase/**'
-      - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/firestore/makeUpperCase/**'
+    - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml
+++ b/.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml
@@ -16,24 +16,23 @@ name: functions-v2-firebase-firestore-makeUpperCase
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/firebase/firestore/makeUpperCase/**'
-    - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/firestore/makeUpperCase/**'
+      - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/firebase/firestore/makeUpperCase/**'
-    - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/firebase/firestore/makeUpperCase/**'
-    - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/firestore/makeUpperCase/**'
+      - '.github/workflows/functions-v2-firebase-firestore-makeUpperCase.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml
+++ b/.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml
@@ -16,23 +16,23 @@ name: functions-v2-firebase-remote-config-helloRemoteConfig
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
-      - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
+    - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
-      - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
+    - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml
+++ b/.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml
@@ -16,24 +16,23 @@ name: functions-v2-firebase-remote-config-helloRemoteConfig
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
-    - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
+      - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
-    - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
-    - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/remote-config/helloRemoteConfig/**'
+      - '.github/workflows/functions-v2-firebase-remote-config-helloRemoteConfig.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml
+++ b/.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml
@@ -16,24 +16,23 @@ name: functions-v2-firebase-rtdb-helloRTDB
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/firebase/rtdb/helloRTDB/**'
-    - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/rtdb/helloRTDB/**'
+      - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/firebase/rtdb/helloRTDB/**'
-    - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/firebase/rtdb/helloRTDB/**'
-    - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/firebase/rtdb/helloRTDB/**'
+      - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml
+++ b/.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml
@@ -16,23 +16,23 @@ name: functions-v2-firebase-rtdb-helloRTDB
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/firebase/rtdb/helloRTDB/**'
-      - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/rtdb/helloRTDB/**'
+    - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/firebase/rtdb/helloRTDB/**'
-      - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/firebase/rtdb/helloRTDB/**'
+    - '.github/workflows/functions-v2-firebase-rtdb-helloRTDB.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-helloauditlog.yaml
+++ b/.github/workflows/functions-v2-helloauditlog.yaml
@@ -16,24 +16,23 @@ name: functions-v2-helloAuditLog
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/helloAuditLog/**'
-    - '.github/workflows/functions-v2-helloAuditLog.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloAuditLog/**'
+      - '.github/workflows/functions-v2-helloAuditLog.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/helloAuditLog/**'
-    - '.github/workflows/functions-v2-helloAuditLog.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/helloAuditLog/**'
-    - '.github/workflows/functions-v2-helloAuditLog.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloAuditLog/**'
+      - '.github/workflows/functions-v2-helloAuditLog.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-helloauditlog.yaml
+++ b/.github/workflows/functions-v2-helloauditlog.yaml
@@ -16,23 +16,23 @@ name: functions-v2-helloAuditLog
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/helloAuditLog/**'
-      - '.github/workflows/functions-v2-helloAuditLog.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloAuditLog/**'
+    - '.github/workflows/functions-v2-helloAuditLog.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/helloAuditLog/**'
-      - '.github/workflows/functions-v2-helloAuditLog.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloAuditLog/**'
+    - '.github/workflows/functions-v2-helloAuditLog.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-hellobigquery.yaml
+++ b/.github/workflows/functions-v2-hellobigquery.yaml
@@ -16,24 +16,23 @@ name: functions-v2-helloBigQuery
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/helloBigQuery/**'
-    - '.github/workflows/functions-v2-helloBigQuery.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloBigQuery/**'
+      - '.github/workflows/functions-v2-helloBigQuery.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/helloBigQuery/**'
-    - '.github/workflows/functions-v2-helloBigQuery.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/helloBigQuery/**'
-    - '.github/workflows/functions-v2-helloBigQuery.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloBigQuery/**'
+      - '.github/workflows/functions-v2-helloBigQuery.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-hellobigquery.yaml
+++ b/.github/workflows/functions-v2-hellobigquery.yaml
@@ -16,23 +16,23 @@ name: functions-v2-helloBigQuery
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/helloBigQuery/**'
-      - '.github/workflows/functions-v2-helloBigQuery.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloBigQuery/**'
+    - '.github/workflows/functions-v2-helloBigQuery.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/helloBigQuery/**'
-      - '.github/workflows/functions-v2-helloBigQuery.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloBigQuery/**'
+    - '.github/workflows/functions-v2-helloBigQuery.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-hellogcs.yaml
+++ b/.github/workflows/functions-v2-hellogcs.yaml
@@ -16,23 +16,23 @@ name: functions-v2-helloGCS
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/helloGCS/**'
-      - '.github/workflows/functions-v2-helloGCS.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloGCS/**'
+    - '.github/workflows/functions-v2-helloGCS.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/helloGCS/**'
-      - '.github/workflows/functions-v2-helloGCS.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloGCS/**'
+    - '.github/workflows/functions-v2-helloGCS.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-hellogcs.yaml
+++ b/.github/workflows/functions-v2-hellogcs.yaml
@@ -16,24 +16,23 @@ name: functions-v2-helloGCS
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/helloGCS/**'
-    - '.github/workflows/functions-v2-helloGCS.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloGCS/**'
+      - '.github/workflows/functions-v2-helloGCS.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/helloGCS/**'
-    - '.github/workflows/functions-v2-helloGCS.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/helloGCS/**'
-    - '.github/workflows/functions-v2-helloGCS.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloGCS/**'
+      - '.github/workflows/functions-v2-helloGCS.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-hellopubsub.yaml
+++ b/.github/workflows/functions-v2-hellopubsub.yaml
@@ -16,24 +16,23 @@ name: functions-v2-helloPubSub
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/helloPubSub/**'
-    - '.github/workflows/functions-v2-helloPubSub.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloPubSub/**'
+      - '.github/workflows/functions-v2-helloPubSub.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/helloPubSub/**'
-    - '.github/workflows/functions-v2-helloPubSub.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/helloPubSub/**'
-    - '.github/workflows/functions-v2-helloPubSub.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/helloPubSub/**'
+      - '.github/workflows/functions-v2-helloPubSub.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-hellopubsub.yaml
+++ b/.github/workflows/functions-v2-hellopubsub.yaml
@@ -16,23 +16,23 @@ name: functions-v2-helloPubSub
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/helloPubSub/**'
-      - '.github/workflows/functions-v2-helloPubSub.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloPubSub/**'
+    - '.github/workflows/functions-v2-helloPubSub.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/helloPubSub/**'
-      - '.github/workflows/functions-v2-helloPubSub.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/helloPubSub/**'
+    - '.github/workflows/functions-v2-helloPubSub.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-httplogging.yaml
+++ b/.github/workflows/functions-v2-httplogging.yaml
@@ -16,24 +16,23 @@ name: functions-v2-httpLogging
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/httpLogging/**'
-    - '.github/workflows/functions-v2-httpLogging.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/httpLogging/**'
+      - '.github/workflows/functions-v2-httpLogging.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/httpLogging/**'
-    - '.github/workflows/functions-v2-httpLogging.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/httpLogging/**'
-    - '.github/workflows/functions-v2-httpLogging.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/httpLogging/**'
+      - '.github/workflows/functions-v2-httpLogging.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-httplogging.yaml
+++ b/.github/workflows/functions-v2-httplogging.yaml
@@ -16,23 +16,23 @@ name: functions-v2-httpLogging
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/httpLogging/**'
-      - '.github/workflows/functions-v2-httpLogging.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/httpLogging/**'
+    - '.github/workflows/functions-v2-httpLogging.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/httpLogging/**'
-      - '.github/workflows/functions-v2-httpLogging.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/httpLogging/**'
+    - '.github/workflows/functions-v2-httpLogging.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-log-processEntry.yaml
+++ b/.github/workflows/functions-v2-log-processEntry.yaml
@@ -16,23 +16,23 @@ name: functions-v2-log-processEntry
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/log/processEntry/**'
-      - '.github/workflows/functions-v2-log-processEntry.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/log/processEntry/**'
+    - '.github/workflows/functions-v2-log-processEntry.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/log/processEntry/**'
-      - '.github/workflows/functions-v2-log-processEntry.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/log/processEntry/**'
+    - '.github/workflows/functions-v2-log-processEntry.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-log-processEntry.yaml
+++ b/.github/workflows/functions-v2-log-processEntry.yaml
@@ -16,24 +16,23 @@ name: functions-v2-log-processEntry
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/log/processEntry/**'
-    - '.github/workflows/functions-v2-log-processEntry.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/log/processEntry/**'
+      - '.github/workflows/functions-v2-log-processEntry.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/log/processEntry/**'
-    - '.github/workflows/functions-v2-log-processEntry.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/log/processEntry/**'
-    - '.github/workflows/functions-v2-log-processEntry.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/log/processEntry/**'
+      - '.github/workflows/functions-v2-log-processEntry.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-ocr-app.yaml
+++ b/.github/workflows/functions-v2-ocr-app.yaml
@@ -16,23 +16,23 @@ name: functions-v2-ocr-app
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/ocr/app/**'
-      - '.github/workflows/functions-v2-ocr-app.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/ocr/app/**'
+    - '.github/workflows/functions-v2-ocr-app.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/ocr/app/**'
-      - '.github/workflows/functions-v2-ocr-app.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/ocr/app/**'
+    - '.github/workflows/functions-v2-ocr-app.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-ocr-app.yaml
+++ b/.github/workflows/functions-v2-ocr-app.yaml
@@ -16,24 +16,23 @@ name: functions-v2-ocr-app
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/ocr/app/**'
-    - '.github/workflows/functions-v2-ocr-app.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/ocr/app/**'
+      - '.github/workflows/functions-v2-ocr-app.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/ocr/app/**'
-    - '.github/workflows/functions-v2-ocr-app.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/ocr/app/**'
-    - '.github/workflows/functions-v2-ocr-app.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/ocr/app/**'
+      - '.github/workflows/functions-v2-ocr-app.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml
+++ b/.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml
@@ -16,24 +16,23 @@ name: functions-v2-tips-avoidInfiniteRetries
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/tips/avoidInfiniteRetries/**'
-    - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/tips/avoidInfiniteRetries/**'
+      - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/tips/avoidInfiniteRetries/**'
-    - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/tips/avoidInfiniteRetries/**'
-    - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/tips/avoidInfiniteRetries/**'
+      - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml
+++ b/.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml
@@ -16,23 +16,23 @@ name: functions-v2-tips-avoidInfiniteRetries
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/tips/avoidInfiniteRetries/**'
-      - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/tips/avoidInfiniteRetries/**'
+    - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/tips/avoidInfiniteRetries/**'
-      - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/tips/avoidInfiniteRetries/**'
+    - '.github/workflows/functions-v2-tips-avoidInfiniteRetries.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-tips-retry.yaml
+++ b/.github/workflows/functions-v2-tips-retry.yaml
@@ -16,23 +16,23 @@ name: functions-v2-tips-retry
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/tips/retry/**'
-      - '.github/workflows/functions-v2-tips-retry.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/tips/retry/**'
+    - '.github/workflows/functions-v2-tips-retry.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/tips/retry/**'
-      - '.github/workflows/functions-v2-tips-retry.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/tips/retry/**'
+    - '.github/workflows/functions-v2-tips-retry.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-tips-retry.yaml
+++ b/.github/workflows/functions-v2-tips-retry.yaml
@@ -16,24 +16,23 @@ name: functions-v2-tips-retry
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/tips/retry/**'
-    - '.github/workflows/functions-v2-tips-retry.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/tips/retry/**'
+      - '.github/workflows/functions-v2-tips-retry.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/tips/retry/**'
-    - '.github/workflows/functions-v2-tips-retry.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/tips/retry/**'
-    - '.github/workflows/functions-v2-tips-retry.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/tips/retry/**'
+      - '.github/workflows/functions-v2-tips-retry.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/functions-v2-typed-googlechatbot.yaml
+++ b/.github/workflows/functions-v2-typed-googlechatbot.yaml
@@ -16,24 +16,23 @@ name: functions-v2-typed-googlechatbot
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/typed/googlechatbot/**'
-    - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/typed/googlechatbot/**'
+      - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/typed/googlechatbot/**'
-    - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/typed/googlechatbot/**'
-    - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/typed/googlechatbot/**'
+      - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     # Ref: https://github.com/google-github-actions/auth#usage

--- a/.github/workflows/functions-v2-typed-googlechatbot.yaml
+++ b/.github/workflows/functions-v2-typed-googlechatbot.yaml
@@ -16,23 +16,23 @@ name: functions-v2-typed-googlechatbot
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/typed/googlechatbot/**'
-      - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/typed/googlechatbot/**'
+    - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/typed/googlechatbot/**'
-      - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/typed/googlechatbot/**'
+    - '.github/workflows/functions-v2-typed-googlechatbot.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     # Ref: https://github.com/google-github-actions/auth#usage

--- a/.github/workflows/functions-v2-typed-greeting.yaml
+++ b/.github/workflows/functions-v2-typed-greeting.yaml
@@ -16,24 +16,23 @@ name: functions-v2-typed-greeting
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'functions/v2/typed/greeting/**'
-    - '.github/workflows/functions-v2-typed-greeting.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/typed/greeting/**'
+      - '.github/workflows/functions-v2-typed-greeting.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
-    - 'functions/v2/typed/greeting/**'
-    - '.github/workflows/functions-v2-typed-greeting.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
-    paths:
-    - 'functions/v2/typed/greeting/**'
-    - '.github/workflows/functions-v2-typed-greeting.yaml'
-    - '.github/workflows/test.yaml'
+      - 'functions/v2/typed/greeting/**'
+      - '.github/workflows/functions-v2-typed-greeting.yaml'
+      - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     # Ref: https://github.com/google-github-actions/auth#usage

--- a/.github/workflows/functions-v2-typed-greeting.yaml
+++ b/.github/workflows/functions-v2-typed-greeting.yaml
@@ -16,23 +16,23 @@ name: functions-v2-typed-greeting
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'functions/v2/typed/greeting/**'
-      - '.github/workflows/functions-v2-typed-greeting.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/typed/greeting/**'
+    - '.github/workflows/functions-v2-typed-greeting.yaml'
+    - '.github/workflows/test.yaml'
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
-      - 'functions/v2/typed/greeting/**'
-      - '.github/workflows/functions-v2-typed-greeting.yaml'
-      - '.github/workflows/test.yaml'
+    - 'functions/v2/typed/greeting/**'
+    - '.github/workflows/functions-v2-typed-greeting.yaml'
+    - '.github/workflows/test.yaml'
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     # Ref: https://github.com/google-github-actions/auth#usage


### PR DESCRIPTION
## Description

This change applies the new triggering pattern defined in #3747 to the workflows with filenames prefixed with functions*.

Looking at the checks, there are some big numbers:
- These workflows are running on `pull_request` for a number of samples
- flakybot jobs are skipped in PRs
- remove-label jobs are skipped when a label isn't used to trigger

In the middle of iterating this PR, I tested using the label trigger. As expected, this double-triggered, because it activated both the `pull_request` trigger in this PR and the `pull_request_target` trigger merged to main.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
