### PR TITLE
ci: update h-k workflows to use labeled on pull_request trigger

### DIFF
--- a/.github/workflows/healthcare-consent.yaml
+++ b/.github/workflows/healthcare-consent.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/healthcare-consent.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'healthcare/consent/**'
-    - '.github/workflows/healthcare-consent.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'healthcare/consent/**'
     - '.github/workflows/healthcare-consent.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/healthcare-datasets.yaml
+++ b/.github/workflows/healthcare-datasets.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/healthcare-datasets.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'healthcare/datasets/**'
-    - '.github/workflows/healthcare-datasets.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'healthcare/datasets/**'
     - '.github/workflows/healthcare-datasets.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/healthcare-dicom.yaml
+++ b/.github/workflows/healthcare-dicom.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/healthcare-dicom.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'healthcare/dicom/**'
-    - '.github/workflows/healthcare-dicom.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'healthcare/dicom/**'
     - '.github/workflows/healthcare-dicom.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/healthcare-fhir.yaml
+++ b/.github/workflows/healthcare-fhir.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/healthcare-fhir.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'healthcare/fhir/**'
-    - '.github/workflows/healthcare-fhir.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'healthcare/fhir/**'
     - '.github/workflows/healthcare-fhir.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/healthcare-hl7v2.yaml
+++ b/.github/workflows/healthcare-hl7v2.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/healthcare-hl7v2.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'healthcare/hl7v2/**'
-    - '.github/workflows/healthcare-hl7v2.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'healthcare/hl7v2/**'
     - '.github/workflows/healthcare-hl7v2.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/iam-deny.yaml
+++ b/.github/workflows/iam-deny.yaml
@@ -21,21 +21,21 @@ on:
     - 'iam/deny/**'
     - '.github/workflows/iam-deny.yaml'
   pull_request:
-    paths:
-    - 'iam/deny/**'
-    - '.github/workflows/iam-deny.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'iam/deny/**'
     - '.github/workflows/iam-deny.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
       contents: 'read'
-      id-token: 'write' 
+      id-token: 'write'
     if: github.event.action != 'labeled' || github.event.label.name == 'actions:force-run'
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -44,50 +44,49 @@ jobs:
         working-directory: 'iam/deny'
     steps:
     - uses: actions/checkout@v4.1.0
-      with:
-        ref: ${{github.event.pull_request.head.sha}}
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
     - uses: 'google-github-actions/auth@v1.1.1'
-      with:
-        workload_identity_provider: 'projects/949737848314/locations/global/workloadIdentityPools/iam-deny-test-pool/providers/iam-deny-test-provider'
-        service_account: 'kokoro-ca@isakovf-iam-deny-samples.iam.gserviceaccount.com'
-        create_credentials_file: 'true'
-        access_token_lifetime: 600s
+        with:
+          workload_identity_provider: 'projects/949737848314/locations/global/workloadIdentityPools/iam-deny-test-pool/providers/iam-deny-test-provider'
+          service_account: 'kokoro-ca@isakovf-iam-deny-samples.iam.gserviceaccount.com'
+          create_credentials_file: 'true'
+          access_token_lifetime: 600s
     - uses: actions/setup-node@v4.0.0
-      with:
-        node-version: 16
+        with:
+          node-version: 16
     - name: Get npm cache directory
-      id: npm-cache-dir
-      shell: bash
-      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}        
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
     - uses: actions/cache@v3
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-   
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: "${{ runner.os }}-node-   \n"
     - name: install repo dependencies
-      run: npm install
-      working-directory: .
+        run: npm install
+        working-directory: .
     - name: install directory dependencies
-      run: npm install
+        run: npm install
     - run: npm run build --if-present
     - name: set env vars for scheduled run
-      if: github.event.action == 'schedule'
-      run: |
-        echo "MOCHA_REPORTER_SUITENAME=iam-deny" >> $GITHUB_ENV
-        echo "MOCHA_REPORTER_OUTPUT=${{github.run_id}}_sponge_log.xml" >> $GITHUB_ENV
-        echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
+        if: github.event.action == 'schedule'
+        run: |
+          echo "MOCHA_REPORTER_SUITENAME=iam-deny" >> $GITHUB_ENV
+          echo "MOCHA_REPORTER_OUTPUT=${{github.run_id}}_sponge_log.xml" >> $GITHUB_ENV
+          echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
     - run: npm test
     - name: upload test results for FlakyBot workflow
-      if: github.event.action == 'schedule' && always()
-      uses: actions/upload-artifact@v3
-      env:
-        MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
-      with:
-        name: test-results
-        path: iam/deny/${{ env.MOCHA_REPORTER_OUTPUT }}
-        retention-days: 1        
+        if: github.event.action == 'schedule' && always()
+        uses: actions/upload-artifact@v3
+        env:
+          MOCHA_REPORTER_OUTPUT: "${{github.run_id}}_sponge_log.xml"
+        with:
+          name: test-results
+          path: iam/deny/${{ env.MOCHA_REPORTER_OUTPUT }}
+          retention-days: 1
   flakybot:
     permissions:
       contents: 'read'

--- a/.github/workflows/kms.yaml
+++ b/.github/workflows/kms.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/kms.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'kms/**'
-    - '.github/workflows/kms.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'kms/**'
     - '.github/workflows/kms.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:


### PR DESCRIPTION
## Description

Scoped to Samples workflows with file names starting with h, i, j, or k.

Implementation of https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3747, sibling of https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3748.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
