### PR TITLE
ci: update s-z workflows to use labeled on pull_request trigger

### DIFF
--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/scheduler.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'scheduler/**'
-    - '.github/workflows/scheduler.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'scheduler/**'
     - '.github/workflows/scheduler.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/secret-manager.yaml
+++ b/.github/workflows/secret-manager.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/secret-manager.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'secret-manager/**'
-    - '.github/workflows/secret-manager.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'secret-manager/**'
     - '.github/workflows/secret-manager.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/security-center-snippets.yaml
+++ b/.github/workflows/security-center-snippets.yaml
@@ -22,18 +22,17 @@ on:
     - 'security-center/snippets/package.json'
     - '.github/workflows/security-center-snippets.yaml'
   pull_request:
-    paths:
-    - 'security-center/snippets/v1/**'
-    - 'security-center/snippets/package.json'
-    - '.github/workflows/security-center-snippets.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'security-center/snippets/v1/**'
     - 'security-center/snippets/package.json'
     - '.github/workflows/security-center-snippets.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/service-directory-snippets.yaml
+++ b/.github/workflows/service-directory-snippets.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/service-directory-snippets.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'service-directory/snippets/**'
-    - '.github/workflows/service-directory-snippets.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'service-directory/snippets/**'
     - '.github/workflows/service-directory-snippets.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/speech.yaml
+++ b/.github/workflows/speech.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/speech.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'speech/**'
-    - '.github/workflows/speech.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'speech/**'
     - '.github/workflows/speech.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -21,16 +21,16 @@ on:
     - 'storagetransfer/**'
     - '.github/workflows/storagetransfer.yaml'
   pull_request:
-    paths:
-    - 'storagetransfer/**'
-    - '.github/workflows/storagetransfer.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'storagetransfer/**'
     - '.github/workflows/storagetransfer.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -64,14 +64,13 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash
-      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}        
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
     - uses: actions/cache@v3
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-   
+        restore-keys: "${{ runner.os }}-node-   \n"
     - name: install repo dependencies
       run: npm install
       working-directory: .
@@ -86,7 +85,7 @@ jobs:
         echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
     - run: npm test
       env:
-        AWS_ACCESS_KEY_ID : ${{ fromJSON(steps.secrets.outputs.sts_aws_secret).AccessKeyId }}
+        AWS_ACCESS_KEY_ID: ${{ fromJSON(steps.secrets.outputs.sts_aws_secret).AccessKeyId }}
         AWS_SECRET_ACCESS_KEY: ${{ fromJSON(steps.secrets.outputs.sts_aws_secret).SecretAccessKey }}
         AZURE_STORAGE_ACCOUNT: ${{ fromJSON(steps.secrets.outputs.sts_azure_secret).StorageAccount }}
         AZURE_CONNECTION_STRING: ${{ fromJSON(steps.secrets.outputs.sts_azure_secret).ConnectionString }}
@@ -99,7 +98,7 @@ jobs:
       with:
         name: test-results
         path: storagetransfer/${{ env.MOCHA_REPORTER_OUTPUT }}
-        retention-days: 1        
+        retention-days: 1
   flakybot:
     permissions:
       contents: 'read'

--- a/.github/workflows/talent.yaml
+++ b/.github/workflows/talent.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/talent.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'talent/**'
-    - '.github/workflows/talent.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'talent/**'
     - '.github/workflows/talent.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/texttospeech.yaml
+++ b/.github/workflows/texttospeech.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/texttospeech.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'texttospeech/**'
-    - '.github/workflows/texttospeech.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'texttospeech/**'
     - '.github/workflows/texttospeech.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/translate.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'translate/**'
-    - '.github/workflows/translate.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'translate/**'
     - '.github/workflows/translate.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/video-intelligence.yaml
+++ b/.github/workflows/video-intelligence.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/video-intelligence.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'video-intelligence/**'
-    - '.github/workflows/video-intelligence.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'video-intelligence/**'
     - '.github/workflows/video-intelligence.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/vision-productSearch.yaml
+++ b/.github/workflows/vision-productSearch.yaml
@@ -22,18 +22,17 @@ on:
     - '.github/workflows/vision-productSearch.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'vision/productSearch/**'
-    - '.github/workflows/vision-productSearch.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'vision/productSearch/**'
     - '.github/workflows/vision-productSearch.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:

--- a/.github/workflows/vision.yaml
+++ b/.github/workflows/vision.yaml
@@ -21,16 +21,16 @@ on:
     - 'vision/**'
     - '.github/workflows/vision.yaml'
   pull_request:
-    paths:
-    - 'vision/**'
-    - '.github/workflows/vision.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'vision/**'
     - '.github/workflows/vision.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
 jobs:
   test:
     permissions:
@@ -63,14 +63,13 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash
-      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}        
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
     - uses: actions/cache@v3
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-   
+        restore-keys: "${{ runner.os }}-node-   \n"
     - name: install repo dependencies
       run: npm install
       working-directory: .
@@ -85,7 +84,7 @@ jobs:
         echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
     - run: npm test
       env:
-         REDIS_HOST: ${{ steps.secrets.outputs.vision.REDIS_HOST }}
+        REDIS_HOST: ${{ steps.secrets.outputs.vision.REDIS_HOST }}
     - name: upload test results for FlakyBot workflow
       if: github.event.action == 'schedule' && always()
       uses: actions/upload-artifact@v3
@@ -94,7 +93,7 @@ jobs:
       with:
         name: test-results
         path: vision/${{ env.MOCHA_REPORTER_OUTPUT }}
-        retention-days: 1        
+        retention-days: 1
   flakybot:
     permissions:
       contents: 'read'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: workflows
+name: cloudworkflows
 on:
   push:
     branches:
@@ -22,18 +22,18 @@ on:
     - '.github/workflows/workflows.yaml'
     - '.github/workflows/test.yaml'
   pull_request:
-    paths:
-    - 'workflows/**'
-    - '.github/workflows/workflows.yaml'
-    - '.github/workflows/test.yaml'
-  pull_request_target:
-    types: [labeled]
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
     paths:
     - 'workflows/**'
     - '.github/workflows/workflows.yaml'
     - '.github/workflows/test.yaml'
   schedule:
-  - cron:  '0 0 * * 0'
+  - cron: '0 0 * * 0'
+
 jobs:
   test:
     permissions:


### PR DESCRIPTION
## Description

Scoped to Samples workflows with file names starting with s-z.

Implementation of https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3747, sibling of https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3748.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
