### PR TITLE
docs(generativeai): add region tags for code samples

### DIFF
--- a/ai-platform/snippets/embedding-model-tuning.js
+++ b/ai-platform/snippets/embedding-model-tuning.js
@@ -17,6 +17,7 @@
 'use strict';
 
 // [START aiplatform_genai_code_model_tuning]
+// [START generativeaionvertexai_genai_code_model_tuning]
 async function main(
   apiEndpoint,
   project,
@@ -74,6 +75,7 @@ async function main(
   await createTuneJob();
 }
 // [END aiplatform_genai_code_model_tuning]
+// [END generativeaionvertexai_genai_code_model_tuning]
 
 process.on('unhandledRejection', err => {
   console.error(err.message);

--- a/ai-platform/snippets/predict-chat-prompt.js
+++ b/ai-platform/snippets/predict-chat-prompt.js
@@ -18,6 +18,7 @@
 
 async function main(project, location = 'us-central1') {
   // [START aiplatform_sdk_chat]
+  // [START generativeaionvertexai_sdk_chat]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -93,6 +94,7 @@ async function main(project, location = 'us-central1') {
 
   callPredict();
   // [END aiplatform_sdk_chat]
+  // [END generativeaionvertexai_sdk_chat]
 }
 
 process.on('unhandledRejection', err => {

--- a/ai-platform/snippets/predict-code-chat.js
+++ b/ai-platform/snippets/predict-code-chat.js
@@ -18,6 +18,7 @@
 
 async function main(project, location = 'us-central1') {
   // [START aiplatform_sdk_code_chat]
+  // [START generativeaionvertexai_sdk_code_chat]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -92,6 +93,7 @@ async function main(project, location = 'us-central1') {
 
   callPredict();
   // [END aiplatform_sdk_code_chat]
+  // [END generativeaionvertexai_sdk_code_chat]
 }
 
 process.on('unhandledRejection', err => {

--- a/ai-platform/snippets/predict-code-completion-comment.js
+++ b/ai-platform/snippets/predict-code-completion-comment.js
@@ -18,6 +18,7 @@
 
 async function main(project, location = 'us-central1') {
   // [START aiplatform_sdk_code_completion_comment]
+  // [START generativeaionvertexai_sdk_code_completion_comment]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -79,6 +80,7 @@ async function main(project, location = 'us-central1') {
 
   callPredict();
   // [END aiplatform_sdk_code_completion_comment]
+  // [END generativeaionvertexai_sdk_code_completion_comment]
 }
 
 process.on('unhandledRejection', err => {

--- a/ai-platform/snippets/predict-code-generation-function.js
+++ b/ai-platform/snippets/predict-code-generation-function.js
@@ -18,6 +18,7 @@
 
 async function main(project, location = 'us-central1') {
   // [START aiplatform_sdk_code_generation_function]
+  // [START generativeaionvertexai_sdk_code_generation_function]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -76,6 +77,7 @@ async function main(project, location = 'us-central1') {
 
   callPredict();
   // [END aiplatform_sdk_code_generation_function]
+  // [END generativeaionvertexai_sdk_code_generation_function]
 }
 
 process.on('unhandledRejection', err => {

--- a/ai-platform/snippets/predict-image-from-image-and-text.js
+++ b/ai-platform/snippets/predict-image-from-image-and-text.js
@@ -23,6 +23,7 @@ async function main(
   textPrompt
 ) {
   // [START aiplatform_sdk_text_image_embedding]
+  // [START generativeaionvertexai_sdk_text_image_embedding]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -91,6 +92,7 @@ async function main(
 
   await predictImageFromImageAndText();
   // [END aiplatform_sdk_text_image_embedding]
+  // [END generativeaionvertexai_sdk_text_image_embedding]
 }
 
 exports.predictImageFromImageAndText = main;

--- a/ai-platform/snippets/predict-text-embeddings.js
+++ b/ai-platform/snippets/predict-text-embeddings.js
@@ -17,6 +17,7 @@
 'use strict';
 
 // [START aiplatform_sdk_embedding]
+// [START generativeaionvertexai_sdk_embedding]
 async function main(
   project,
   model = 'text-embedding-004',
@@ -54,6 +55,7 @@ async function main(
   callPredict();
 }
 // [END aiplatform_sdk_embedding]
+// [END generativeaionvertexai_sdk_embedding]
 
 process.on('unhandledRejection', err => {
   console.error(err.message);

--- a/ai-platform/snippets/predict-text-prompt.js
+++ b/ai-platform/snippets/predict-text-prompt.js
@@ -18,6 +18,7 @@
 
 async function main(project, location = 'us-central1') {
   // [START aiplatform_sdk_ideation]
+  // [START generativeaionvertexai_sdk_ideation]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -76,6 +77,7 @@ async function main(project, location = 'us-central1') {
 
   callPredict();
   // [END aiplatform_sdk_ideation]
+  // [END generativeaionvertexai_sdk_ideation]
 }
 
 process.on('unhandledRejection', err => {

--- a/ai-platform/snippets/tuning.js
+++ b/ai-platform/snippets/tuning.js
@@ -26,6 +26,7 @@ async function main(
   trainSteps = 300
 ) {
   // [START aiplatform_model_tuning]
+  // [START generativeaionvertexai_model_tuning]
   /**
    * TODO(developer): Uncomment these variables before running the sample.\
    * (Not necessary if passing values as arguments)
@@ -97,6 +98,7 @@ async function main(
 
   await tuneLLM();
   // [END aiplatform_model_tuning]
+  // [END generativeaionvertexai_model_tuning]
 }
 
 exports.tuneModel = main;

--- a/generative-ai/snippets/function-calling/functionCallingStreamContent.js
+++ b/generative-ai/snippets/function-calling/functionCallingStreamContent.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // [START aiplatform_gemini_function_calling_content]
+// [START generativeaionvertexai_gemini_function_calling_content]
 const {
   VertexAI,
   FunctionDeclarationSchemaType,
@@ -89,6 +90,7 @@ async function functionCallingStreamContent(
   }
 }
 // [END aiplatform_gemini_function_calling_content]
+// [END generativeaionvertexai_gemini_function_calling_content]
 
 functionCallingStreamContent(...process.argv.slice(2)).catch(err => {
   console.error(err.message);

--- a/generative-ai/snippets/streamChat.js
+++ b/generative-ai/snippets/streamChat.js
@@ -14,6 +14,7 @@
 
 // [START generativeaionvertexai_gemini_multiturn_chat_stream]
 // [START aiplatform_gemini_multiturn_chat]
+// [START generativeaionvertexai_gemini_multiturn_chat]
 const {VertexAI} = require('@google-cloud/vertexai');
 
 /**
@@ -43,6 +44,7 @@ async function createStreamChat(
   }
 }
 // [END aiplatform_gemini_multiturn_chat]
+// [END generativeaionvertexai_gemini_multiturn_chat]
 // [END generativeaionvertexai_gemini_multiturn_chat_stream]
 
 createStreamChat(...process.argv.slice(2)).catch(err => {

--- a/generative-ai/snippets/test/grounding/groundingPublicDataBasic.test.js
+++ b/generative-ai/snippets/test/grounding/groundingPublicDataBasic.test.js
@@ -36,6 +36,6 @@ describe('Google search grounding', async () => {
     const output = execSync(
       `node ./grounding/groundingPublicDataBasic.js ${projectId} ${location} ${model}`
     );
-    assert(output.match(/webSearchQueries.*Why is the sky blue?/));
+    assert(output.match(/GroundingMetadata.*Why is the sky blue?/));
   });
 });


### PR DESCRIPTION
No code changes.

Adding `generativeaionvertexai_` region tags to replace old `aiplatform_`

In near future GenAI code samples, will only use `generativeaionvertexai_` region tag prefix.

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
