### PR TITLE
fix: failing groundingPublicDataBasic.test.js

### DIFF
--- a/generative-ai/snippets/test/grounding/groundingPublicDataBasic.test.js
+++ b/generative-ai/snippets/test/grounding/groundingPublicDataBasic.test.js
@@ -36,6 +36,6 @@ describe('Google search grounding', async () => {
     const output = execSync(
       `node ./grounding/groundingPublicDataBasic.js ${projectId} ${location} ${model}`
     );
-    assert(output.match(/GroundingMetadata.*Why is the sky blue?/));
+    assert(output.match(/GroundingMetadata.*[Ww]hy is the sky blue?/));
   });
 });


### PR DESCRIPTION
Fixes a failing test in #3756, which was merged after [I commented on it](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3756#issuecomment-2248938542), but before I was able to submit a working fix.

The test is updated to match the actual output (`["why is the sky blue"]`).

Note: the submitted prompt is `{text: 'Why is the sky blue?'}`.