### PR TITLE
fix: owlbot error output bug

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -51,7 +51,7 @@ def walk_through_owlbot_dirs(dir: Path, search_for_changed_files: bool) -> list[
             output.check_returncode()
         except subprocess.CalledProcessError as error:
             if error.returncode == 128:
-                logger.info(f"Error: ${e.output}; skipping fetching main")
+                logger.info(f"Error: ${error.output}; skipping fetching main")
             else:
                 raise error
     for path_object in dir.glob("**/package.json"):


### PR DESCRIPTION
## Description

Fixes error output due to `e` not being defined.

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/c8d80c8f-2ac3-4741-bb0a-712fd41f768a">

Please merge this PR for me once approved.
