### PR TITLE
chore(security-center): update workflow security center path (include v2)

### DIFF
--- a/.github/workflows/security-center-snippets.yaml
+++ b/.github/workflows/security-center-snippets.yaml
@@ -18,8 +18,7 @@ on:
     branches:
     - main
     paths:
-    - 'security-center/snippets/v1/**'
-    - 'security-center/snippets/package.json'
+    - 'security-center/snippets/**'
     - '.github/workflows/security-center-snippets.yaml'
   pull_request:
     types:


### PR DESCRIPTION
The original intention was that Security Center v1 and v2 directories could be independently tested. This was later changed so that the pull request workflow would get triggered for changes in either directory. This pull requests updates the path for merges to main to be consistent with that decision for PRs.

Ideally, this should be merged before #3835.