### PR TITLE
docs: update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,12 @@ tests, ideally reducing dependencies on third party libraries.
 
 For tests, using the standard
 library [assert](https://nodejs.org/docs/latest-v18.x/api/assert.html) is
-preferred.
+preferred. The library provides a strict and a legacy mode; please use the
+strict mode as shown below:
+
+```js
+const assert = require('node:assert/strict');
+```
 
 If you want to use a third party package, help us to understand if you have
 requirements not fulfilled by core libraries in the description of your pull

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,18 +54,13 @@ Contributors are encouraged to use vanilla Node.js as much as pragmatically
 possible to standardize writing, reviewing, and maintaining samples and their
 tests, ideally reducing dependencies on third party libraries.
 
-For tests, using the standard
-library [assert](https://nodejs.org/docs/latest-v18.x/api/assert.html) is
-preferred. The library provides a strict and a legacy mode; please use the
+For tests, we recommend using the standard
+library [assert](https://nodejs.org/docs/latest-v18.x/api/assert.html). The library provides a strict and a legacy mode; please use the
 strict mode as shown below:
 
 ```js
 const assert = require('node:assert/strict');
 ```
-
-If you want to use a third party package, help us to understand if you have
-requirements not fulfilled by core libraries in the description of your pull
-request.
 
 ### CI testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,22 @@ All samples must have tests. We use `mocha` as testing framework. The
 executes the `mocha` tests via `npm test`
 ([example](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/batch/package.json#L13)).
 
+### Third party libraries
+
+Contributors are encouraged to use vanilla Node.js as much as pragmatically
+possible to standardize writing, reviewing, and maintaining samples and their
+tests, ideally reducing dependencies on third party libraries.
+
+For tests, using the standard
+library [assert](https://nodejs.org/docs/latest-v18.x/api/assert.html) is
+preferred.
+
+If you want to use a third party package, help us to understand if you have
+requirements not fulfilled by core libraries in the description of your pull
+request.
+
+### CI testing
+
 For new samples, a GitHub Actions workflow should be created to run your tests
 on the CI system:
 


### PR DESCRIPTION
Update CONTRIBUTING.md to favor using standard Node.js libraries over third party packages, if possible. This helps reduce dependencies and improves standardizing, reviewing, and maintaining samples and their tests.

Please merge for me.