### PR TITLE
feat: add Live Stream API channel clip samples and tests

### DIFF
--- a/media/livestream/createChannel.js
+++ b/media/livestream/createChannel.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/media/livestream/createChannel.js
+++ b/media/livestream/createChannel.js
@@ -93,10 +93,17 @@ function main(projectId, location, channelId, inputId, outputUri) {
           {
             fileName: 'manifest.m3u8',
             type: 'HLS',
+            key: 'manifest_hls',
             muxStreams: ['mux_video', 'mux_audio'],
             maxSegmentCount: 5,
           },
         ],
+        // Optional, but required for VOD clips
+        retentionConfig: {
+          retentionWindowDuration: {
+            seconds: 86400,
+          },
+        },
       },
     };
 

--- a/media/livestream/createChannel.js
+++ b/media/livestream/createChannel.js
@@ -1,10 +1,11 @@
 /**
- * Copyright 2022, Google, Inc.
+ * Copyright 2024 Google LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/media/livestream/createChannelClip.js
+++ b/media/livestream/createChannelClip.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function main(projectId, location, channelId, clipId, outputUri) {
+  // [START livestream_create_channel_clip]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // projectId = 'my-project-id';
+  // location = 'us-central1';
+  // channelId = 'my-channel';
+  // clipId = 'my-channel-clip';
+  // outputUri = 'gs://my-bucket/my-output-folder';
+
+  // Imports the Livestream library
+  const {LivestreamServiceClient} = require('@google-cloud/livestream').v1;
+
+  // Instantiates a client
+  const livestreamServiceClient = new LivestreamServiceClient();
+
+  async function createChannelClip() {
+    // Create a 20 second clip starting 40 seconds ago
+    const recent = new Date();
+    recent.setSeconds(recent.getSeconds() - 20);
+    const earlier = new Date();
+    earlier.setSeconds(earlier.getSeconds() - 40);
+
+    // Construct request
+    const request = {
+      parent: livestreamServiceClient.channelPath(
+        projectId,
+        location,
+        channelId
+      ),
+      clipId: clipId,
+      clip: {
+        outputUri: outputUri,
+        slices: [
+          {
+            timeSlice: {
+              markinTime: {
+                seconds: Math.floor(earlier.getTime() / 1000),
+                nanos: earlier.getMilliseconds() * 1000000,
+              },
+              markoutTime: {
+                seconds: Math.floor(recent.getTime() / 1000),
+                nanos: recent.getMilliseconds() * 1000000,
+              },
+            },
+          },
+        ],
+        clipManifests: [
+          {
+            manifestKey: 'manifest_hls',
+          },
+        ],
+      },
+    };
+
+    // Run request
+    const [operation] = await livestreamServiceClient.createClip(request);
+    const response = await operation.promise();
+    const [clip] = response;
+    console.log(`Channel clip: ${clip.name}`);
+  }
+
+  createChannelClip();
+  // [END livestream_create_channel_clip]
+}
+
+// node createChannelClip.js <projectId> <location> <channelId> <clipId> <outputUri>
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/media/livestream/createInput.js
+++ b/media/livestream/createInput.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/media/livestream/createInput.js
+++ b/media/livestream/createInput.js
@@ -1,10 +1,11 @@
 /**
- * Copyright 2022, Google, Inc.
+ * Copyright 2024 Google LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/media/livestream/deleteChannelClip.js
+++ b/media/livestream/deleteChannelClip.js
@@ -1,10 +1,11 @@
 /**
- * Copyright 2022, Google, Inc.
+ * Copyright 2024 Google LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,14 +16,15 @@
 
 'use strict';
 
-function main(projectId, location, inputId) {
-  // [START livestream_create_input]
+function main(projectId, location, channelId, clipId) {
+  // [START livestream_delete_channel_clip]
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // projectId = 'my-project-id';
   // location = 'us-central1';
-  // inputId = 'my-input';
+  // channelId = 'my-channel';
+  // clipId = 'my-channel-clip';
 
   // Imports the Livestream library
   const {LivestreamServiceClient} = require('@google-cloud/livestream').v1;
@@ -30,29 +32,28 @@ function main(projectId, location, inputId) {
   // Instantiates a client
   const livestreamServiceClient = new LivestreamServiceClient();
 
-  async function createInput() {
+  async function deleteChannelClip() {
     // Construct request
     const request = {
-      parent: livestreamServiceClient.locationPath(projectId, location),
-      inputId: inputId,
-      input: {
-        type: 'RTMP_PUSH',
-      },
+      name: livestreamServiceClient.clipPath(
+        projectId,
+        location,
+        channelId,
+        clipId
+      ),
     };
 
     // Run request
-    const [operation] = await livestreamServiceClient.createInput(request);
-    const response = await operation.promise();
-    const [input] = response;
-    console.log(`Input: ${input.name}`);
-    console.log(`Uri: ${input.uri}`);
+    const [operation] = await livestreamServiceClient.deleteClip(request);
+    await operation.promise();
+    console.log('Deleted channel clip');
   }
 
-  createInput();
-  // [END livestream_create_input]
+  deleteChannelClip();
+  // [END livestream_delete_channel_clip]
 }
 
-// node createInput.js <projectId> <location> <inputId>
+// node deleteChannelClip.js <projectId> <location> <channelId> <clipId>
 process.on('unhandledRejection', err => {
   console.error(err.message);
   process.exitCode = 1;

--- a/media/livestream/getChannelClip.js
+++ b/media/livestream/getChannelClip.js
@@ -1,10 +1,11 @@
 /**
- * Copyright 2022, Google, Inc.
+ * Copyright 2024 Google LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,14 +16,15 @@
 
 'use strict';
 
-function main(projectId, location, inputId) {
-  // [START livestream_create_input]
+function main(projectId, location, channelId, clipId) {
+  // [START livestream_get_channel_clip]
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // projectId = 'my-project-id';
   // location = 'us-central1';
-  // inputId = 'my-input';
+  // channelId = 'my-channel';
+  // clipId = 'my-channel-clip';
 
   // Imports the Livestream library
   const {LivestreamServiceClient} = require('@google-cloud/livestream').v1;
@@ -30,29 +32,25 @@ function main(projectId, location, inputId) {
   // Instantiates a client
   const livestreamServiceClient = new LivestreamServiceClient();
 
-  async function createInput() {
+  async function getChannelClip() {
     // Construct request
     const request = {
-      parent: livestreamServiceClient.locationPath(projectId, location),
-      inputId: inputId,
-      input: {
-        type: 'RTMP_PUSH',
-      },
+      name: livestreamServiceClient.clipPath(
+        projectId,
+        location,
+        channelId,
+        clipId
+      ),
     };
-
-    // Run request
-    const [operation] = await livestreamServiceClient.createInput(request);
-    const response = await operation.promise();
-    const [input] = response;
-    console.log(`Input: ${input.name}`);
-    console.log(`Uri: ${input.uri}`);
+    const [clip] = await livestreamServiceClient.getClip(request);
+    console.log(`Channel clip: ${clip.name}`);
   }
 
-  createInput();
-  // [END livestream_create_input]
+  getChannelClip();
+  // [END livestream_get_channel_clip]
 }
 
-// node createInput.js <projectId> <location> <inputId>
+// node getChannelClip.js <projectId> <location> <channelId> <clipId>
 process.on('unhandledRejection', err => {
   console.error(err.message);
   process.exitCode = 1;

--- a/media/livestream/listChannelClips.js
+++ b/media/livestream/listChannelClips.js
@@ -1,10 +1,11 @@
 /**
- * Copyright 2022, Google, Inc.
+ * Copyright 2024 Google LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,14 +16,14 @@
 
 'use strict';
 
-function main(projectId, location, inputId) {
-  // [START livestream_create_input]
+function main(projectId, location, channelId) {
+  // [START livestream_list_channel_clips]
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // projectId = 'my-project-id';
   // location = 'us-central1';
-  // inputId = 'my-input';
+  // channelId = 'my-channel';
 
   // Imports the Livestream library
   const {LivestreamServiceClient} = require('@google-cloud/livestream').v1;
@@ -30,29 +31,25 @@ function main(projectId, location, inputId) {
   // Instantiates a client
   const livestreamServiceClient = new LivestreamServiceClient();
 
-  async function createInput() {
-    // Construct request
-    const request = {
-      parent: livestreamServiceClient.locationPath(projectId, location),
-      inputId: inputId,
-      input: {
-        type: 'RTMP_PUSH',
-      },
-    };
-
-    // Run request
-    const [operation] = await livestreamServiceClient.createInput(request);
-    const response = await operation.promise();
-    const [input] = response;
-    console.log(`Input: ${input.name}`);
-    console.log(`Uri: ${input.uri}`);
+  async function listChannelClips() {
+    const iterable = await livestreamServiceClient.listClipsAsync({
+      parent: livestreamServiceClient.channelPath(
+        projectId,
+        location,
+        channelId
+      ),
+    });
+    console.info('Channel clips:');
+    for await (const response of iterable) {
+      console.log(response.name);
+    }
   }
 
-  createInput();
-  // [END livestream_create_input]
+  listChannelClips();
+  // [END livestream_list_channel_clips]
 }
 
-// node createInput.js <projectId> <location> <inputId>
+// node listChannelClips.js <projectId> <location> <channelId>
 process.on('unhandledRejection', err => {
   console.error(err.message);
   process.exitCode = 1;

--- a/media/livestream/package.json
+++ b/media/livestream/package.json
@@ -13,9 +13,10 @@
     "test": "c8 mocha -p -j 2 --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/livestream": "^1.0.0"
+    "@google-cloud/livestream": "^1.4.0"
   },
   "devDependencies": {
+    "@google-cloud/storage": "^7.0.0",
     "c8": "^10.0.0",
     "chai": "^4.5.0",
     "mocha": "^10.1.0",


### PR DESCRIPTION
## Description

Fixes b:341726237

Important: FFmpeg (https://www.ffmpeg.org/) must be installed in the test environment.

`sudo apt install ffmpeg`

These samples follow the existing format of the Live Stream API samples.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [X] Please **merge** this PR for me once it is approved
