### PR TITLE
fix: Getting embeddings using text-embedding-005.

### DIFF
--- a/ai-platform/snippets/embedding-model-tuning.js
+++ b/ai-platform/snippets/embedding-model-tuning.js
@@ -23,7 +23,7 @@ async function main(
   project,
   outputDir,
   pipelineJobDisplayName = 'embedding-customization-pipeline-sample',
-  baseModelVersionId = 'text-embedding-004',
+  baseModelVersionId = 'text-embedding-005',
   taskType = 'DEFAULT',
   corpusPath = 'gs://cloud-samples-data/ai-platform/embedding/goog-10k-2024/r11/corpus.jsonl',
   queriesPath = 'gs://cloud-samples-data/ai-platform/embedding/goog-10k-2024/r11/queries.jsonl',
@@ -62,7 +62,7 @@ async function main(
   };
   const pipelineJob = {
     templateUri:
-      'https://us-kfp.pkg.dev/ml-pipeline/llm-text-embedding/tune-text-embedding-model/v1.1.3',
+      'https://us-kfp.pkg.dev/ml-pipeline/llm-text-embedding/tune-text-embedding-model/v1.1.4',
     displayName: pipelineJobDisplayName,
     runtimeConfig,
   };

--- a/ai-platform/snippets/predict-text-embeddings-preview.js
+++ b/ai-platform/snippets/predict-text-embeddings-preview.js
@@ -21,7 +21,7 @@ async function main() {
 
   // TODO(developer): Update the following for your own use case.
   const project = 'long-door-651';
-  const model = 'text-embedding-preview-0815';
+  const model = 'text-embedding-005';
   const location = 'us-central1';
   // Calculate the embedding for code blocks. Using 'RETRIEVAL_DOCUMENT' for corpus.
   // Specify the task type as 'CODE_RETRIEVAL_QUERY' for query, e.g. 'Retrieve a function that adds two numbers'.

--- a/ai-platform/snippets/predict-text-embeddings.js
+++ b/ai-platform/snippets/predict-text-embeddings.js
@@ -20,7 +20,7 @@
 // [START generativeaionvertexai_sdk_embedding]
 async function main(
   project,
-  model = 'text-embedding-004',
+  model = 'text-embedding-005',
   texts = 'banana bread?;banana muffins?',
   task = 'QUESTION_ANSWERING',
   dimensionality = 0,


### PR DESCRIPTION
## Description

Fixes: b/366507572: Getting embeddings using text-embedding-005

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved