### PR TITLE
fix: Use USER and ASSISTANT in functionCallingStreamContent.js

### DIFF
--- a/generative-ai/snippets/function-calling/functionCallingStreamContent.js
+++ b/generative-ai/snippets/function-calling/functionCallingStreamContent.js
@@ -70,7 +70,7 @@ async function functionCallingStreamContent(
     contents: [
       {role: 'user', parts: [{text: 'What is the weather in Boston?'}]},
       {
-        role: 'model',
+        role: 'ASSISTANT',
         parts: [
           {
             functionCall: {
@@ -80,7 +80,7 @@ async function functionCallingStreamContent(
           },
         ],
       },
-      {role: 'user', parts: functionResponseParts},
+      {role: 'USER', parts: functionResponseParts},
     ],
     tools: functionDeclarations,
   };


### PR DESCRIPTION
## Description

Please see b/376903836.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
