### PR TITLE
fix: testing-isolation trim spaces on diffs

### DIFF
--- a/.github/cloud-samples-tools/cmd/main.go
+++ b/.github/cloud-samples-tools/cmd/main.go
@@ -72,7 +72,7 @@ func affectedCmd(configFile string, diffsFile string) {
 	if err != nil {
 		log.Fatalln("❌ error getting the diffs: ", diffsFile, "\n", err)
 	}
-diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n") // Trim whitespace to remove extra newline from diff output.
+	diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n") // Trim whitespace to remove extra newline from diff output.
 
 	packages, err := config.Affected(diffs)
 	if err != nil {

--- a/.github/cloud-samples-tools/cmd/main.go
+++ b/.github/cloud-samples-tools/cmd/main.go
@@ -72,7 +72,7 @@ func affectedCmd(configFile string, diffsFile string) {
 	if err != nil {
 		log.Fatalln("❌ error getting the diffs: ", diffsFile, "\n", err)
 	}
-	diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n")
+diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n") // Trim whitespace to remove extra newline from diff output.
 
 	packages, err := config.Affected(diffs)
 	if err != nil {

--- a/.github/cloud-samples-tools/cmd/main.go
+++ b/.github/cloud-samples-tools/cmd/main.go
@@ -72,7 +72,7 @@ func affectedCmd(configFile string, diffsFile string) {
 	if err != nil {
 		log.Fatalln("❌ error getting the diffs: ", diffsFile, "\n", err)
 	}
-	diffs := strings.Split(string(diffsBytes), "\n")
+	diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n")
 
 	packages, err := config.Affected(diffs)
 	if err != nil {


### PR DESCRIPTION
## Description

The `git diff` tool appends an extra newline at the end. When the tool parses the diffs files, there's an extra "empty" diff, which is considered as a global change, so all the packages are marked as affected.

Trimming spaces before splitting the diffs into a list solves this.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
