### PR TITLE
fix: testing-isolation excluded packages

### DIFF
--- a/.github/cloud-samples-tools/cmd/main.go
+++ b/.github/cloud-samples-tools/cmd/main.go
@@ -72,9 +72,11 @@ func affectedCmd(configFile string, diffsFile string) {
 	if err != nil {
 		log.Fatalln("❌ error getting the diffs: ", diffsFile, "\n", err)
 	}
-	diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n") // Trim whitespace to remove extra newline from diff output.
+	// Trim whitespace to remove extra newline from diff output.
+	diffs := strings.Split(strings.TrimSpace(string(diffsBytes)), "\n")
 
-	packages, err := config.Affected(diffs)
+	// Log to stderr since GitHub Actions expects the output on stdout.
+	packages, err := config.Affected(os.Stderr, diffs)
 	if err != nil {
 		log.Fatalln("❌ error finding the affected packages.\n", err)
 	}

--- a/.github/cloud-samples-tools/pkg/config/config.go
+++ b/.github/cloud-samples-tools/pkg/config/config.go
@@ -19,6 +19,8 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -154,8 +156,8 @@ func (c *Config) FindAllPackages(root string) ([]string, error) {
 // Affected returns the packages that have been affected from diffs.
 // If there are diffs on at leat one global file affecting all packages,
 // then this returns all packages matched by the config.
-func (c *Config) Affected(diffs []string) ([]string, error) {
-	changed := c.Changed(diffs)
+func (c *Config) Affected(log io.Writer, diffs []string) ([]string, error) {
+	changed := c.Changed(log, diffs)
 	if slices.Contains(changed, ".") {
 		return c.FindAllPackages(".")
 	}
@@ -165,16 +167,13 @@ func (c *Config) Affected(diffs []string) ([]string, error) {
 // Changed returns the packages that have changed.
 // It only returns packages that are matched by the config,
 // and are not excluded by the config.
-func (c *Config) Changed(diffs []string) []string {
+func (c *Config) Changed(log io.Writer, diffs []string) []string {
 	changedUnique := make(map[string]bool)
 	for _, diff := range diffs {
 		if !c.Matches(diff) {
 			continue
 		}
 		pkg := c.FindPackage(diff)
-		if slices.Contains(c.ExcludePackages, pkg) {
-			continue
-		}
 		changedUnique[pkg] = true
 	}
 
@@ -184,6 +183,10 @@ func (c *Config) Changed(diffs []string) []string {
 
 	changed := make([]string, 0, len(changedUnique))
 	for pkg := range changedUnique {
+		if slices.Contains(c.ExcludePackages, pkg) {
+			fmt.Fprintf(log, "ℹ️ Excluded package %q, skipping.\n", pkg)
+			continue
+		}
 		changed = append(changed, pkg)
 	}
 	return changed

--- a/.github/cloud-samples-tools/pkg/config/config_test.go
+++ b/.github/cloud-samples-tools/pkg/config/config_test.go
@@ -167,30 +167,35 @@ func TestFindPackage(t *testing.T) {
 
 func TestChanged(t *testing.T) {
 	config := c.Config{
-		PackageFile: []string{"package.json"},
-		Match:       []string{"*"},
+		PackageFile:     []string{"package.json"},
+		Match:           []string{"*"},
+		ExcludePackages: []string{filepath.Join("testdata", "excluded")},
 	}
 
 	tests := []struct {
 		diffs    []string
 		expected []string
 	}{
-		{
+		{ // Global change, everything is affected.
 			diffs:    []string{filepath.Join("testdata", "file.txt")},
 			expected: []string{"."},
 		},
-		{
+		{ // Single affected package.
 			diffs:    []string{filepath.Join("testdata", "my-package", "file.txt")},
 			expected: []string{filepath.Join("testdata", "my-package")},
 		},
-		{
+		{ // Single affected nested package.
 			diffs:    []string{filepath.Join("testdata", "my-package", "subpackage", "file.txt")},
 			expected: []string{filepath.Join("testdata", "my-package", "subpackage")},
+		},
+		{ // Excluded package.
+			diffs:    []string{filepath.Join("testdata", "excluded", "file.txt")},
+			expected: []string{},
 		},
 	}
 
 	for _, test := range tests {
-		got := config.Changed(test.diffs)
+		got := config.Changed(os.Stderr, test.diffs)
 		if !reflect.DeepEqual(test.expected, got) {
 			t.Fatal("expected equal\n", test.expected, got)
 		}


### PR DESCRIPTION
## Description

Excluded packages were filtered before checking for global changes. If a package was excluded, then it looked like no packages were found so it was marked as a global change, affecting all packages.

Moving the excluded filtering after checking if a package were found solves this. Also added additional logging, more comments, and a unit test covering this case.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
