### PR TITLE
fix: testing-isolation do not force run all if no packages were found

### DIFF
--- a/.github/cloud-samples-tools/pkg/config/config.go
+++ b/.github/cloud-samples-tools/pkg/config/config.go
@@ -177,10 +177,6 @@ func (c *Config) Changed(log io.Writer, diffs []string) []string {
 		changedUnique[pkg] = true
 	}
 
-	if len(changedUnique) == 0 {
-		return []string{"."}
-	}
-
 	changed := make([]string, 0, len(changedUnique))
 	for pkg := range changedUnique {
 		if slices.Contains(c.ExcludePackages, pkg) {

--- a/.github/cloud-samples-tools/pkg/config/config_test.go
+++ b/.github/cloud-samples-tools/pkg/config/config_test.go
@@ -169,6 +169,7 @@ func TestChanged(t *testing.T) {
 	config := c.Config{
 		PackageFile:     []string{"package.json"},
 		Match:           []string{"*"},
+		Ignore:          []string{"ignored.txt"},
 		ExcludePackages: []string{filepath.Join("testdata", "excluded")},
 	}
 
@@ -179,6 +180,10 @@ func TestChanged(t *testing.T) {
 		{ // Global change, everything is affected.
 			diffs:    []string{filepath.Join("testdata", "file.txt")},
 			expected: []string{"."},
+		},
+		{ // Ignored files should not trigger tests.
+			diffs:    []string{filepath.Join("testdata", "ignored.txt")},
+			expected: []string{},
 		},
 		{ // Single affected package.
 			diffs:    []string{filepath.Join("testdata", "my-package", "file.txt")},


### PR DESCRIPTION
## Description

Currently, if all diff files are in the ignore list, it's considered as a global change. This is not necessary since a non-ignored file will return the "." package, which will correctly trigger all tests. If no packages were found that's because files should be ignored and no tests should be run. Added a test case to cover this.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
