### PR TITLE
fix: (data_catalog) migrate region tag

### DIFF
--- a/datacatalog/cloud-client/createEntryGroup.js
+++ b/datacatalog/cloud-client/createEntryGroup.js
@@ -25,7 +25,7 @@ const main = async (
   projectId = process.env.GOOGLE_CLOUD_PROJECT,
   entryGroupId
 ) => {
-  // [START data_catalog_create_entry_group_tag]
+  // [START data_catalog_create_entry_group]
   // [START datacatalog_create_entry_group_tag]
   // -------------------------------
   // Import required modules.
@@ -60,7 +60,7 @@ const main = async (
 
   console.log(response);
   // [END datacatalog_create_entry_group_tag]
-  // [END data_catalog_create_entry_group_tag]
+  // [END data_catalog_create_entry_group]
 };
 
 // node createEntryGroup.js <projectId> <entryGroupId>

--- a/datacatalog/cloud-client/createEntryGroup.js
+++ b/datacatalog/cloud-client/createEntryGroup.js
@@ -25,11 +25,12 @@ const main = async (
   projectId = process.env.GOOGLE_CLOUD_PROJECT,
   entryGroupId
 ) => {
+  // [START data_catalog_create_entry_group_tag]
   // [START datacatalog_create_entry_group_tag]
   // -------------------------------
   // Import required modules.
   // -------------------------------
-  const {DataCatalogClient} = require('@google-cloud/datacatalog').v1;
+  const { DataCatalogClient } = require('@google-cloud/datacatalog').v1;
   const datacatalog = new DataCatalogClient();
 
   // Currently, Data Catalog stores metadata in the
@@ -59,6 +60,7 @@ const main = async (
 
   console.log(response);
   // [END datacatalog_create_entry_group_tag]
+  // [END data_catalog_create_entry_group_tag]
 };
 
 // node createEntryGroup.js <projectId> <entryGroupId>

--- a/datacatalog/cloud-client/createEntryGroup.js
+++ b/datacatalog/cloud-client/createEntryGroup.js
@@ -30,7 +30,7 @@ const main = async (
   // -------------------------------
   // Import required modules.
   // -------------------------------
-  const { DataCatalogClient } = require('@google-cloud/datacatalog').v1;
+  const {DataCatalogClient} = require('@google-cloud/datacatalog').v1;
   const datacatalog = new DataCatalogClient();
 
   // Currently, Data Catalog stores metadata in the


### PR DESCRIPTION
## Description
Migrate region "datacatalog_create_entry_group_tag" to "data_catalog_create_entry_group_tag"

Fixes [b/389693076](https://b/389693076)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
