### PR TITLE
fix: (data_catalog) migrate region tag

### DIFF
--- a/datacatalog/quickstart/createFilesetEntry.js
+++ b/datacatalog/quickstart/createFilesetEntry.js
@@ -26,7 +26,7 @@ const main = async (
   entryGroupId,
   entryId
 ) => {
-  // [START data_catalog_create_fileset_quickstart_tag]
+  // [START data_catalog_create_fileset_quickstart]
   // [START datacatalog_create_fileset_quickstart_tag]
   // -------------------------------
   // Import required modules.
@@ -126,7 +126,7 @@ const main = async (
   console.log(response);
 };
 // [END datacatalog_create_fileset_quickstart_tag]
-// [END data_catalog_create_fileset_quickstart_tag]
+// [END data_catalog_create_fileset_quickstart]
 
 // node createFilesetEntry.js <projectId> <entryGroupId> <entryId>
 main(...process.argv.slice(2));

--- a/datacatalog/quickstart/createFilesetEntry.js
+++ b/datacatalog/quickstart/createFilesetEntry.js
@@ -26,6 +26,7 @@ const main = async (
   entryGroupId,
   entryId
 ) => {
+  // [START data_catalog_create_fileset_quickstart_tag]
   // [START datacatalog_create_fileset_quickstart_tag]
   // -------------------------------
   // Import required modules.
@@ -125,6 +126,7 @@ const main = async (
   console.log(response);
 };
 // [END datacatalog_create_fileset_quickstart_tag]
+// [END data_catalog_create_fileset_quickstart_tag]
 
 // node createFilesetEntry.js <projectId> <entryGroupId> <entryId>
 main(...process.argv.slice(2));


### PR DESCRIPTION
## Description

Migrate region "datacatalog_create_fileset_quickstart_tag" to "data_catalog_create_fileset_quickstart_tag"

Fixes [b/389763067](https://b/389763067)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.
## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
