### PR TITLE
feat: test-isolation package setup configs

### DIFF
--- a/.github/cloud-samples-tools/pkg/config/utils.go
+++ b/.github/cloud-samples-tools/pkg/config/utils.go
@@ -26,7 +26,7 @@ import (
 var multiLineCommentsRegex = regexp.MustCompile(`(?s)\s*/\*.*?\*/`)
 var singleLineCommentsRegex = regexp.MustCompile(`\s*//.*\s*`)
 
-func ReadJsonc[a any](path string) (*a, error) {
+func ReadJsonc[a any](path string, defaults *a) (*a, error) {
 	// Read the JSONC file.
 	sourceJsonc, err := os.ReadFile(path)
 	if err != nil {
@@ -38,6 +38,9 @@ func ReadJsonc[a any](path string) (*a, error) {
 	sourceJson = singleLineCommentsRegex.ReplaceAll(sourceJson, []byte{})
 
 	var value a
+	if defaults != nil {
+		value = *defaults
+	}
 	err = json.Unmarshal(sourceJson, &value)
 	if err != nil {
 		return nil, err

--- a/.github/cloud-samples-tools/pkg/config/utils.go
+++ b/.github/cloud-samples-tools/pkg/config/utils.go
@@ -17,9 +17,33 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
+	"regexp"
 )
+
+var multiLineCommentsRegex = regexp.MustCompile(`(?s)\s*/\*.*?\*/`)
+var singleLineCommentsRegex = regexp.MustCompile(`\s*//.*\s*`)
+
+func ReadJsonc[a any](path string) (*a, error) {
+	// Read the JSONC file.
+	sourceJsonc, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Strip the comments and load the JSON.
+	sourceJson := multiLineCommentsRegex.ReplaceAll(sourceJsonc, []byte{})
+	sourceJson = singleLineCommentsRegex.ReplaceAll(sourceJson, []byte{})
+
+	var value a
+	err = json.Unmarshal(sourceJson, &value)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
 
 // fileExists returns true if the file exists.
 func fileExists(path string) bool {

--- a/.github/cloud-samples-tools/pkg/config/utils.go
+++ b/.github/cloud-samples-tools/pkg/config/utils.go
@@ -26,26 +26,17 @@ import (
 var multiLineCommentsRegex = regexp.MustCompile(`(?s)\s*/\*.*?\*/`)
 var singleLineCommentsRegex = regexp.MustCompile(`\s*//.*\s*`)
 
-func ReadJsonc[a any](path string, defaults *a) (*a, error) {
+func ReadJsonc[a any](path string, ref *a) error {
 	// Read the JSONC file.
 	sourceJsonc, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Strip the comments and load the JSON.
 	sourceJson := multiLineCommentsRegex.ReplaceAll(sourceJsonc, []byte{})
 	sourceJson = singleLineCommentsRegex.ReplaceAll(sourceJson, []byte{})
-
-	var value a
-	if defaults != nil {
-		value = *defaults
-	}
-	err = json.Unmarshal(sourceJson, &value)
-	if err != nil {
-		return nil, err
-	}
-	return &value, nil
+	return json.Unmarshal(sourceJson, ref)
 }
 
 // fileExists returns true if the file exists.

--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -16,6 +16,7 @@
 
 {
   "package-file": [ "package.json" ],
+  "setup-file": "setup.json",
   "ignore": [
     ".eslintignore",
     ".eslintrc.json",

--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -16,7 +16,13 @@
 
 {
   "package-file": [ "package.json" ],
-  "setup-file": "setup.json",
+  "setup": {
+    "filename": "setup.json",
+    "defaults": {
+      "nodejs_version": 20,
+      "secrets": null
+    }
+  },
   "ignore": [
     ".eslintignore",
     ".eslintrc.json",

--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -54,7 +54,6 @@
     "functions/firebase", // parent directory
     "functions/helloworld", // parent directory
     "functions/http", // parent directory
-    "functions/http/uploadFile", // parent directory
     "functions/log", // parent directory
     "functions/pubsub", // parent directory
     "memorystore/redis", // parent directory

--- a/.github/config/nodejs-prod.jsonc
+++ b/.github/config/nodejs-prod.jsonc
@@ -16,6 +16,7 @@
 
 {
   "package-file": [ "package.json" ],
+  "setup-file": "setup.json",
   "ignore": [
     ".eslintignore",
     ".eslintrc.json",

--- a/.github/config/nodejs-prod.jsonc
+++ b/.github/config/nodejs-prod.jsonc
@@ -52,7 +52,6 @@
     "functions/firebase", // parent directory
     "functions/helloworld", // parent directory
     "functions/http", // parent directory
-    "functions/http/uploadFile", // parent directory
     "functions/log", // parent directory
     "functions/pubsub", // parent directory
     "memorystore/redis", // parent directory
@@ -78,6 +77,7 @@
     "eventarc/audit-storage", // (untested) Environment Variable 'SERVICE_NAME' not found
     "eventarc/pubsub", // (untested) Environment Variable 'SERVICE_NAME' not found
     "functions/billing", // Error: Request failed with status code 500
+    "functions/http/uploadFile", // npm error Missing script: "test"
     "functions/imagemagick", // Error: A bucket name is needed to use Cloud Storage
     "functions/ocr/app", // Error: Bucket not provided. Make sure you have a "bucket" property in your request
     "functions/slack", // TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be of type ... Received undefined

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -70,9 +70,12 @@ jobs:
           workload_identity_provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
           service_account: kokoro-system-test@long-door-651.iam.gserviceaccount.com
           access_token_lifetime: 600s # 10 minutes
-      - name: Test ${{ matrix.package }}
-        run: |
-          npm install
-          bash .github/scripts/nodejs-test.sh ${{ matrix.package }}
+      - if: matrix.package.secrets
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: ${{ join(matrix.package.secrets) }}
+          export_to_environment: true
+      - name: Test ${{ matrix.package.path }}
+        run: make test dir=${{ matrix.package.path }}
         env:
           GOOGLE_SAMPLES_PROJECT: long-door-651

--- a/generative-ai/snippets/setup.json
+++ b/generative-ai/snippets/setup.json
@@ -1,4 +1,5 @@
 {
+  "nodejs_version": 18,
   "secrets": [
     "CAIP_PROJECT_ID:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id",
     "LOCATION:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-location",

--- a/generative-ai/snippets/setup.json
+++ b/generative-ai/snippets/setup.json
@@ -1,0 +1,7 @@
+{
+  "secrets": [
+    "CAIP_PROJECT_ID:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id",
+    "LOCATION:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-location",
+    "DATASTORE_ID:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-datastore-id"
+  ]
+}


### PR DESCRIPTION
## Description

Supports package setup configuration files. These allow packages to provide per-package configurations like secrets, environment variables, and the runtime version.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
