### PR TITLE
fix: (data_catalog) delete deprecated region tag in deleteFilesettEntry

### DIFF
--- a/datacatalog/quickstart/deleteFilesetEntry.js
+++ b/datacatalog/quickstart/deleteFilesetEntry.js
@@ -27,7 +27,6 @@ const main = async (
   entryId
 ) => {
   // [START data_catalog_delete_fileset_quickstart]
-  // [START datacatalog_delete_fileset_quickstart_tag]
   // -------------------------------
   // Import required modules.
   // -------------------------------
@@ -72,7 +71,6 @@ const main = async (
     console.log('Entry Group does not exist or is not empty.');
   }
 };
-// [END datacatalog_delete_fileset_quickstart_tag]
 // [END data_catalog_delete_fileset_quickstart]
 
 // node deleteFilesetEntry.js <projectId> <entryGroupId> <entryId>


### PR DESCRIPTION
## Description

Remove region "datacatalog_delete_fileset_quickstart_tag"

Fixes [b/389895440](http://b/389895440)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
