### PR TITLE
chore(datacatalog): skip tests for deprecated Data Catalog

### DIFF
--- a/datacatalog/cloud-client/system-test/createEntryGroup.test.js
+++ b/datacatalog/cloud-client/system-test/createEntryGroup.test.js
@@ -34,7 +34,7 @@ before(async () => {
 });
 
 describe('createEntryGroup', () => {
-  it('should create a entry group', done => {
+  it.skip('should create a entry group', done => {
     const expectedName = `projects/${projectId}/locations/${location}/entryGroups/${entryGroupId}`;
     exec(
       `node createEntryGroup.js ${projectId} ${entryGroupId}`,

--- a/datacatalog/cloud-client/system-test/createFilesetEntry.test.js
+++ b/datacatalog/cloud-client/system-test/createFilesetEntry.test.js
@@ -40,7 +40,7 @@ describe('createFilesetEntry', () => {
     exec(`node createEntryGroup.js ${projectId} ${entryGroupId}`, {cwd}, done);
   });
 
-  it('should create a fileset entry', done => {
+  it.skip('should create a fileset entry', done => {
     const expectedLinkedResource = `//datacatalog.googleapis.com/projects/${projectId}/locations/${location}/entryGroups/${entryGroupId}/entries/${entryId}`;
     exec(
       `node createFilesetEntry.js ${projectId} ${entryGroupId} ${entryId}`,

--- a/datacatalog/cloud-client/system-test/lookupEntry.test.js
+++ b/datacatalog/cloud-client/system-test/lookupEntry.test.js
@@ -20,7 +20,7 @@ const cwd = path.join(__dirname, '..');
 const {exec} = require('child_process');
 
 describe('lookupEntry lookup', () => {
-  it('should lookup a dataset entry', done => {
+  it.skip('should lookup a dataset entry', done => {
     const projectId = 'bigquery-public-data';
     const datasetId = 'new_york_taxi_trips';
     const expectedLinkedResource = `//bigquery.googleapis.com/projects/${projectId}/datasets/${datasetId}`;

--- a/datacatalog/quickstart/system-test/createFilesetEntry.test.js
+++ b/datacatalog/quickstart/system-test/createFilesetEntry.test.js
@@ -35,7 +35,7 @@ before(async () => {
 });
 
 describe('createFilesetEntry', () => {
-  it('should create a fileset entry', done => {
+  it.skip('should create a fileset entry', done => {
     const expectedLinkedResource = `//datacatalog.googleapis.com/projects/${projectId}/locations/${location}/entryGroups/${entryGroupId}/entries/${entryId}`;
     exec(
       `node createFilesetEntry.js ${projectId} ${entryGroupId} ${entryId}`,

--- a/datacatalog/quickstart/system-test/deleteFilesetEntry.test.js
+++ b/datacatalog/quickstart/system-test/deleteFilesetEntry.test.js
@@ -44,7 +44,7 @@ describe('deleteFilesetEntry', () => {
     );
   });
 
-  it('should delete a fileset entry', done => {
+  it.skip('should delete a fileset entry', done => {
     exec(
       `node deleteFilesetEntry.js ${projectId} ${entryGroupId} ${entryId}`,
       {cwd},

--- a/datacatalog/snippets/test/quickstart.test.js
+++ b/datacatalog/snippets/test/quickstart.test.js
@@ -44,7 +44,7 @@ describe('Quickstart', async () => {
     await bigquery.dataset(datasetId).createTable(tableId);
   });
 
-  it('quickstart should attach tag to BigQuery table', async () => {
+  it.skip('quickstart should attach tag to BigQuery table', async () => {
     const output = execSync(
       `node quickstart ${projectId} ${datasetId} ${tableId}`
     );

--- a/datacatalog/snippets/test/samples.test.js
+++ b/datacatalog/snippets/test/samples.test.js
@@ -54,7 +54,7 @@ describe('Samples', async () => {
   });
 
   describe('policyTagManager', async () => {
-    it('should create a taxonomy', async () => {
+    it.skip('should create a taxonomy', async () => {
       const taxLocation = 'us';
       const displayName = generateUuid();
       const output = execSync(
@@ -63,14 +63,14 @@ describe('Samples', async () => {
       assert.include(output, 'Created taxonomy:');
     });
 
-    it('should get a taxonomy', async () => {
+    it.skip('should get a taxonomy', async () => {
       const output = execSync(
         `node policyTagManager/getTaxonomy ${taxonomyName}`
       );
       assert.include(output, `Retrieved taxonomy: ${taxonomyName}`);
     });
 
-    it('should list taxonomies', async () => {
+    it.skip('should list taxonomies', async () => {
       const taxLocation = 'us';
       const output = execSync(
         `node policyTagManager/listTaxonomies ${projectId} ${taxLocation}`
@@ -78,14 +78,14 @@ describe('Samples', async () => {
       assert.include(output, 'Taxonomies:');
     });
 
-    it('should delete a taxonomy', async () => {
+    it.skip('should delete a taxonomy', async () => {
       const output = execSync(
         `node policyTagManager/deleteTaxonomy ${taxonomyName}`
       );
       assert.include(output, 'Deleted taxonomy:');
     });
 
-    it('should create a policy tag', async () => {
+    it.skip('should create a policy tag', async () => {
       const tagLocation = 'us';
       const displayName = generateUuid();
       const parent = datacatalog.locationPath(projectId, tagLocation);
@@ -108,7 +108,7 @@ describe('Samples', async () => {
     });
   });
 
-  it('should create a custom entry', async () => {
+  it.skip('should create a custom entry', async () => {
     const entryGroupId = generateUuid();
     const entryId = generateUuid();
     const output = execSync(
@@ -120,7 +120,7 @@ describe('Samples', async () => {
     assert.include(output, 'Created tag:');
   });
 
-  it('should create a fileset', async () => {
+  it.skip('should create a fileset', async () => {
     const entryGroupId = generateUuid();
     const entryId = generateUuid();
     const output = execSync(
@@ -131,7 +131,7 @@ describe('Samples', async () => {
     assert.include(output, 'Type: FILESET');
   });
 
-  it('should grant tagTemplateUser role', async () => {
+  it.skip('should grant tagTemplateUser role', async () => {
     const resourceName = `${datacatalog.locationPath(
       projectId,
       location
@@ -146,7 +146,7 @@ describe('Samples', async () => {
     assert.include(output, memberId);
   });
 
-  it('should search data assets in project', async () => {
+  it.skip('should search data assets in project', async () => {
     const output = execSync(`node searchAssets ${projectId}`);
     assert.match(output, /Found [0-9]+ datasets in project/);
   });


### PR DESCRIPTION
## Description

Fixes b/394006908

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
