### PR TITLE
chore(datacatalog): skip tests for deprecated Data Catalog

### DIFF
--- a/datacatalog/cloud-client/system-test/createEntryGroup.test.js
+++ b/datacatalog/cloud-client/system-test/createEntryGroup.test.js
@@ -33,7 +33,7 @@ before(async () => {
   projectId = await client.getProjectId();
 });
 
-describe('createEntryGroup', () => {
+describe.skip('createEntryGroup', () => {
   it('should create a entry group', done => {
     const expectedName = `projects/${projectId}/locations/${location}/entryGroups/${entryGroupId}`;
     exec(

--- a/datacatalog/cloud-client/system-test/createFilesetEntry.test.js
+++ b/datacatalog/cloud-client/system-test/createFilesetEntry.test.js
@@ -34,7 +34,7 @@ before(async () => {
   projectId = await client.getProjectId();
 });
 
-describe('createFilesetEntry', () => {
+describe.skip('createFilesetEntry', () => {
   before(done => {
     // Must create entryGroup before creating entry
     exec(`node createEntryGroup.js ${projectId} ${entryGroupId}`, {cwd}, done);

--- a/datacatalog/cloud-client/system-test/lookupEntry.test.js
+++ b/datacatalog/cloud-client/system-test/lookupEntry.test.js
@@ -19,7 +19,7 @@ const assert = require('assert');
 const cwd = path.join(__dirname, '..');
 const {exec} = require('child_process');
 
-describe('lookupEntry lookup', () => {
+describe.skip('lookupEntry lookup', () => {
   it('should lookup a dataset entry', done => {
     const projectId = 'bigquery-public-data';
     const datasetId = 'new_york_taxi_trips';

--- a/datacatalog/quickstart/system-test/createFilesetEntry.test.js
+++ b/datacatalog/quickstart/system-test/createFilesetEntry.test.js
@@ -34,7 +34,7 @@ before(async () => {
   projectId = await client.getProjectId();
 });
 
-describe('createFilesetEntry', () => {
+describe.skip('createFilesetEntry', () => {
   it('should create a fileset entry', done => {
     const expectedLinkedResource = `//datacatalog.googleapis.com/projects/${projectId}/locations/${location}/entryGroups/${entryGroupId}/entries/${entryId}`;
     exec(

--- a/datacatalog/quickstart/system-test/deleteFilesetEntry.test.js
+++ b/datacatalog/quickstart/system-test/deleteFilesetEntry.test.js
@@ -34,7 +34,7 @@ before(async () => {
   projectId = await client.getProjectId();
 });
 
-describe('deleteFilesetEntry', () => {
+describe.skip('deleteFilesetEntry', () => {
   before(done => {
     // Must create an entry to be deleted.
     exec(

--- a/datacatalog/snippets/test/quickstart.test.js
+++ b/datacatalog/snippets/test/quickstart.test.js
@@ -28,7 +28,7 @@ const GCLOUD_TESTS_PREFIX = 'nodejs_data_catalog_samples';
 const generateUuid = () =>
   `${GCLOUD_TESTS_PREFIX}_${uuid.v4()}`.replace(/-/gi, '_');
 
-describe('Quickstart', async () => {
+describe.skip('Quickstart', async () => {
   const projectId = process.env.GCLOUD_PROJECT;
   let datasetId;
   let tableId;

--- a/datacatalog/snippets/test/samples.test.js
+++ b/datacatalog/snippets/test/samples.test.js
@@ -34,7 +34,7 @@ const projectId = process.env.GCLOUD_PROJECT;
 const location = 'us-central1';
 let taxonomyName;
 
-describe('Samples', async () => {
+describe.skip('Samples', async () => {
   before(async () => {
     // Delete stale resources from samples tests.
     await deleteEntryGroups();


### PR DESCRIPTION
## Description

Fixes b/394006908

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
