### PR TITLE
fix(ci): don't run all tests on exclusions change

### DIFF
--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -24,6 +24,7 @@
     "secrets": { }
   },
   "ignore": [
+    ".github/config/", // prevent changes to exclusions from running all tests
     ".eslintignore",
     ".eslintrc.json",
     ".github/.OwlBot.lock.yaml",

--- a/.github/config/nodejs-prod.jsonc
+++ b/.github/config/nodejs-prod.jsonc
@@ -24,6 +24,7 @@
     "secrets": { }
   },
   "ignore": [
+    ".github/config/", // prevent changes to exclusions from running all tests
     ".eslintignore",
     ".eslintrc.json",
     ".github/.OwlBot.lock.yaml",


### PR DESCRIPTION
Ignore ".github/config/" so changes to the configs aren't considered global changes (which cause all packages to be tested)
