### PR TITLE
feat(parametermanager): Added global and regional samples for parameter manager

### DIFF
--- a/.github/workflows/parameter-manager.yaml
+++ b/.github/workflows/parameter-manager.yaml
@@ -1,0 +1,52 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: parameter-manager
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'parameter-manager/**'
+    - '.github/workflows/parameter-manager.yaml'
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
+    paths:
+    - 'parameter-manager/**'
+    - '.github/workflows/parameter-manager.yaml'
+  schedule:
+  - cron:  '0 0 * * 0'
+jobs:
+  test:
+    # Ref: https://github.com/google-github-actions/auth#usage
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    if: github.event.action != 'labeled' || github.event.label.name == 'actions:force-run'
+    uses: ./.github/workflows/test.yaml
+    with:
+      name: 'parameter-manager'
+      path: 'parameter-manager'
+  flakybot:
+    # Ref: https://github.com/google-github-actions/auth#usage
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    if: github.event_name == 'schedule' && always() # always() submits logs even if tests fail
+    uses: ./.github/workflows/flakybot.yaml
+    needs: [test]

--- a/.github/workflows/utils/workflows.json
+++ b/.github/workflows/utils/workflows.json
@@ -79,6 +79,7 @@
   "mediatranslation",
   "monitoring/prometheus",
   "monitoring/snippets",
+  "parameter-manager",  
   "retail",
   "run/filesystem",
   "scheduler",

--- a/parameter-manager/createParam.js
+++ b/parameter-manager/createParam.js
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a global parameter using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create. This ID must be unique within the project.
+ */
+async function main(projectId = 'my-project', parameterId = 'my-parameter') {
+  // [START parametermanager_create_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function createParam() {
+    const parent = client.locationPath(projectId, 'global');
+    const request = {
+      parent: parent,
+      parameterId: parameterId,
+    };
+
+    const [parameter] = await client.createParameter(request);
+    console.log(`Created parameter: ${parameter.name}`);
+  }
+
+  await createParam();
+  // [END parametermanager_create_param]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/createParamVersion.js
+++ b/parameter-manager/createParamVersion.js
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a parameter version globally for unstructured data.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created
+ * @param {string} parameterId - The ID of the parameter for which the version is to be created.
+ * @param {string} parameterVersionId - The ID of the parameter version to be created.
+ * @param {string} payload - The unformatted string payload to be stored in the new parameter version.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1',
+  payload = 'This is unstructured data'
+) {
+  // [START parametermanager_create_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const payload = 'This is unstructured data';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function createParamVersion() {
+    // Construct the parent resource name
+    const parent = client.parameterPath(projectId, 'global', parameterId);
+
+    // Construct the parameter version
+    const parameterVersion = {
+      payload: {
+        data: Buffer.from(payload, 'utf8'),
+      },
+    };
+
+    // Construct the request
+    const request = {
+      parent: parent,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: parameterVersion,
+    };
+
+    // Create the parameter version
+    const [response] = await client.createParameterVersion(request);
+    console.log(`Created parameter version: ${response.name}`);
+  }
+
+  await createParamVersion();
+  // [END parametermanager_create_param_version]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/createParamVersionWithSecret.js
+++ b/parameter-manager/createParamVersionWithSecret.js
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a new version of an existing parameter in the global location
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ * The payload is specified as a JSON string and includes a reference to a secret.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which the version is to be created.
+ * @param {string} parameterVersionId - The ID of the parameter version to be created.
+ * @param {string} secretId - The ID of the secret to be referenced.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1',
+  secretId = 'projects/my-project/secrets/application-secret/version/latest'
+) {
+  // [START parametermanager_create_param_version_with_secret]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const secretId = 'YOUR_SECRET_ID'; // For example projects/my-project/secrets/application-secret/version/latest
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function createParamVersionWithSecret() {
+    // Construct the parent resource name
+    const parent = client.parameterPath(projectId, 'global', parameterId);
+
+    // Construct the JSON data with secret references
+    const jsonData = {
+      db_user: 'test_user',
+      db_password: `__REF__(//secretmanager.googleapis.com/${secretId})`,
+    };
+
+    // Construct the parameter version
+    const parameterVersion = {
+      payload: {
+        data: Buffer.from(JSON.stringify(jsonData), 'utf8'),
+      },
+    };
+
+    // Construct the request
+    const request = {
+      parent: parent,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: parameterVersion,
+    };
+
+    // Create the parameter version
+    const [response] = await client.createParameterVersion(request);
+    console.log(
+      `Created parameter version with secret references: ${response.name}`
+    );
+  }
+
+  await createParamVersionWithSecret();
+  // [END parametermanager_create_param_version_with_secret]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/createStructuredParam.js
+++ b/parameter-manager/createStructuredParam.js
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {protos} = require('@google-cloud/parametermanager');
+
+/**
+ * Creates a parameter in the global location of the specified
+ * project with specified format using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create. This ID must be unique within the project.
+ * @param {string} formatType - The format type of the parameter (UNFORMATTED, YAML, JSON).
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-json-parameter',
+  formatType = protos.google.cloud.parametermanager.v1.ParameterFormat.JSON
+) {
+  // [START parametermanager_create_structured_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const {protos} = require('@google-cloud/parametermanager');
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const formatType = protos.google.cloud.parametermanager.v1.ParameterFormat.JSON;
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function createStructuredParam() {
+    const parent = client.locationPath(projectId, 'global');
+    const request = {
+      parent: parent,
+      parameterId: parameterId,
+      parameter: {
+        format: formatType,
+      },
+    };
+
+    const [parameter] = await client.createParameter(request);
+    console.log(
+      `Created parameter ${parameter.name} with format ${parameter.format}`
+    );
+  }
+
+  await createStructuredParam();
+  // [END parametermanager_create_structured_param]
+}
+
+// This sample demonstrates how to create a parameter for structured data of JSON type.
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/createStructuredParamVersion.js
+++ b/parameter-manager/createStructuredParamVersion.js
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a new version of an existing parameter in the global location
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ * The payload is specified as a JSON format.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create. This ID must be unique within the project.
+ * @param {string} parameterVersionId - The ID of the parameter version to be created.
+ * @param {Object} payload - The JSON payload data to be stored in the parameter version.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1',
+  payload = {username: 'test-user', host: 'localhost'}
+) {
+  // [START parametermanager_create_structured_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const jsonData = {username: "test-user", host: "localhost"};
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function createStructuredParamVersion() {
+    // Construct the parent resource name
+    const parent = client.parameterPath(projectId, 'global', parameterId);
+
+    // Construct the parameter version
+    const parameterVersion = {
+      payload: {
+        data: Buffer.from(JSON.stringify(payload), 'utf8'),
+      },
+    };
+
+    // Construct the request
+    const request = {
+      parent: parent,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: parameterVersion,
+    };
+
+    // Create the parameter version
+    const [response] = await client.createParameterVersion(request);
+    console.log(`Created parameter version: ${response.name}`);
+  }
+
+  await createStructuredParamVersion();
+  // [END parametermanager_create_structured_param_version]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/deleteParam.js
+++ b/parameter-manager/deleteParam.js
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Deletes a parameter from the global location of the specified project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter to delete.
+ */
+async function main(projectId = 'my-project', parameterId = 'my-parameter') {
+  // [START parametermanager_delete_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function deleteParam() {
+    // Construct the fully qualified parameter name
+    const name = client.parameterPath(projectId, 'global', parameterId);
+
+    // Delete the parameter
+    await client.deleteParameter({
+      name: name,
+    });
+
+    console.log(`Deleted parameter: ${name}`);
+  }
+
+  await deleteParam();
+  // [END parametermanager_delete_param]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/deleteParamVersion.js
+++ b/parameter-manager/deleteParamVersion.js
@@ -1,0 +1,67 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Deletes a specific version of an existing parameter in the global location
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version is to be deleted.
+ * @param {string} versionId - The version ID of the parameter to delete.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_delete_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function deleteParamVersion() {
+    // Construct the fully qualified parameter version name
+    const name = client.parameterVersionPath(
+      projectId,
+      'global',
+      parameterId,
+      versionId
+    );
+
+    // Delete the parameter version
+    await client.deleteParameterVersion({
+      name: name,
+    });
+
+    console.log(`Deleted parameter version: ${name}`);
+  }
+
+  await deleteParamVersion();
+  // [END parametermanager_delete_param_version]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/disableParamVersion.js
+++ b/parameter-manager/disableParamVersion.js
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Disables a specific version of a global parameter in Google Cloud Parameter Manager.
+ * This function demonstrates how to disable a global parameter version by setting
+ * its 'disabled' field to true using the Parameter Manager client library.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version is to be disabled.
+ * @param {string} versionId - The version ID of the parameter to be disabled.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_disable_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function disableParamVersion() {
+    // Construct the full resource name
+    const name = client.parameterVersionPath(
+      projectId,
+      'global',
+      parameterId,
+      versionId
+    );
+
+    // Construct the request
+    const request = {
+      parameterVersion: {
+        name: name,
+        disabled: true,
+      },
+      updateMask: {
+        paths: ['disabled'],
+      },
+    };
+
+    // Make the API call to update the parameter version
+    const [response] = await client.updateParameterVersion(request);
+
+    console.log(
+      `Disabled parameter version ${response.name} for parameter ${parameterId}`
+    );
+    return response;
+  }
+
+  await disableParamVersion();
+  // [END parametermanager_disable_param_version]
+}
+
+// The command-line arguments are passed as an array to main().
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/enableParamVersion.js
+++ b/parameter-manager/enableParamVersion.js
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Enables a specific version of a parameter in Google Cloud Parameter Manager.
+ * This function demonstrates how to enable a parameter version by setting
+ * its 'disabled' field to false using the Parameter Manager client library.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version is to be enabled.
+ * @param {string} versionId - The version ID of the parameter to be enabled.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_enable_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function enableParamVersion() {
+    // Construct the full resource name
+    const name = client.parameterVersionPath(
+      projectId,
+      'global',
+      parameterId,
+      versionId
+    );
+
+    // Construct the request
+    const request = {
+      parameterVersion: {
+        name: name,
+        disabled: false,
+      },
+      updateMask: {
+        paths: ['disabled'],
+      },
+    };
+
+    // Make the API call to update the parameter version
+    const [response] = await client.updateParameterVersion(request);
+
+    console.log(
+      `Enabled parameter version ${response.name} for parameter ${parameterId}`
+    );
+    return response;
+  }
+
+  await enableParamVersion();
+  // [END parametermanager_enable_param_version]
+}
+
+// The command-line arguments are passed as an array to main().
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/getParam.js
+++ b/parameter-manager/getParam.js
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Retrieves a parameter from the global location of the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter to retrieve.
+ */
+async function main(projectId = 'my-project', parameterId = 'my-parameter') {
+  // [START parametermanager_get_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function getParam() {
+    // Construct the fully qualified parameter name
+    const name = client.parameterPath(projectId, 'global', parameterId);
+
+    // Get the parameter
+    const [parameter] = await client.getParameter({
+      name: name,
+    });
+
+    // Find more details for the Parameter object here:
+    // https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters#Parameter
+    console.log(
+      `Found parameter ${parameter.name} with format ${parameter.format}`
+    );
+  }
+
+  await getParam();
+  // [END parametermanager_get_param]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/getParamVersion.js
+++ b/parameter-manager/getParamVersion.js
@@ -1,0 +1,73 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Retrieves the details of a specific version of an existing parameter in the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which the version details are to be retrieved.
+ * @param {string} versionId - The version ID of the parameter to retrieve.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_get_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function getParamVersion() {
+    // Construct the fully qualified parameter version name
+    const name = client.parameterVersionPath(
+      projectId,
+      'global',
+      parameterId,
+      versionId
+    );
+
+    // Get the parameter version
+    const [parameterVersion] = await client.getParameterVersion({
+      name: name,
+    });
+    // Find more details for the Parameter Version object here:
+    // https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions#ParameterVersion
+    console.log(
+      `Found parameter version ${parameterVersion.name} with state ${parameterVersion.disabled ? 'disabled' : 'enabled'}`
+    );
+    if (!parameterVersion.disabled) {
+      console.log(`Payload: ${parameterVersion.payload?.data.toString('utf-8')}`);
+    }
+  }
+
+  await getParamVersion();
+  // [END parametermanager_get_param_version]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/getParamVersion.js
+++ b/parameter-manager/getParamVersion.js
@@ -60,7 +60,9 @@ async function main(
       `Found parameter version ${parameterVersion.name} with state ${parameterVersion.disabled ? 'disabled' : 'enabled'}`
     );
     if (!parameterVersion.disabled) {
-      console.log(`Payload: ${parameterVersion.payload?.data.toString('utf-8')}`);
+      console.log(
+        `Payload: ${parameterVersion.payload.data.toString('utf-8')}`
+      );
     }
   }
 

--- a/parameter-manager/listParamVersions.js
+++ b/parameter-manager/listParamVersions.js
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ *
+ * Lists all versions of an existing parameter in the global location
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where parameter is located.
+ * @param {string} parameterId - The parameter ID for which versions are to be listed.
+ */
+async function main(projectId = 'my-project', parameterId = 'my-parameter') {
+  // [START parametermanager_list_param_versions]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function listParamVersions() {
+    // Construct the parent string for listing parameter versions globally
+    const parent = client.parameterPath(projectId, 'global', parameterId);
+
+    const request = {
+      parent: parent,
+    };
+
+    // Use listParameterVersionsAsync to handle pagination automatically
+    const iterable = await client.listParameterVersionsAsync(request);
+
+    console.log(`Parameter versions for ${parameterId}:`);
+    for await (const version of iterable) {
+      console.log(
+        `Found parameter version ${version.name} with state ${version.disabled ? 'disabled' : 'enabled'}`
+      );
+    }
+  }
+
+  await listParamVersions();
+  // [END parametermanager_list_param_versions]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/listParamVersions.js
+++ b/parameter-manager/listParamVersions.js
@@ -47,7 +47,6 @@ async function main(projectId = 'my-project', parameterId = 'my-parameter') {
     // Use listParameterVersionsAsync to handle pagination automatically
     const iterable = await client.listParameterVersionsAsync(request);
 
-    console.log(`Parameter versions for ${parameterId}:`);
     for await (const version of iterable) {
       console.log(
         `Found parameter version ${version.name} with state ${version.disabled ? 'disabled' : 'enabled'}`

--- a/parameter-manager/listParams.js
+++ b/parameter-manager/listParams.js
@@ -44,7 +44,6 @@ async function main(projectId = 'my-project') {
     // Use listParametersAsync to handle pagination automatically
     const iterable = await client.listParametersAsync(request);
 
-    console.log('Parameters:');
     for await (const parameter of iterable) {
       console.log(
         `Found parameter ${parameter.name} with format ${parameter.format}`

--- a/parameter-manager/listParams.js
+++ b/parameter-manager/listParams.js
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Lists all parameters in the global location for the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameters are located.
+ */
+async function main(projectId = 'my-project') {
+  // [START parametermanager_list_params]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function listParams() {
+    // Construct the parent string for listing parameters globally
+    const parent = client.locationPath(projectId, 'global');
+
+    const request = {
+      parent: parent,
+    };
+
+    // Use listParametersAsync to handle pagination automatically
+    const iterable = await client.listParametersAsync(request);
+
+    console.log('Parameters:');
+    for await (const parameter of iterable) {
+      console.log(
+        `Found parameter ${parameter.name} with format ${parameter.format}`
+      );
+    }
+  }
+
+  await listParams();
+  // [END parametermanager_list_params]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/package.json
+++ b/parameter-manager/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "nodejs-parameter-manager-samples",
+  "private": true,
+  "license": "Apache-2.0",
+  "files": [
+    "*.js"
+  ],
+  "author": "Google LLC",
+  "repository": "googleapis/nodejs-parameter-manager",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "c8 mocha --recursive test/ --timeout=800000"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "@google-cloud/parametermanager": "^0.1.0"
+  },
+  "devDependencies": {
+    "@google-cloud/secret-manager": "^5.6.0",
+    "c8": "^10.1.3",
+    "chai": "^4.5.0",
+    "mocha": "^11.1.0",
+    "uuid": "^11.0.5"
+  }
+}

--- a/parameter-manager/quickstart.js
+++ b/parameter-manager/quickstart.js
@@ -38,9 +38,9 @@ async function main(
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
-  // const projectId = 'YOUR_PROJECT_ID';
-  // const parameterId = 'YOUR_PARAMETER_ID';
-  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const projectId = 'my-project';
+  // const parameterId = 'my-parameter';
+  // const parameterVersionId = 'v1';
 
   // Imports the Google Cloud Parameter Manager library
   const {

--- a/parameter-manager/quickstart.js
+++ b/parameter-manager/quickstart.js
@@ -1,0 +1,97 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * This is a quickstart sample for the Google Cloud Parameter Manager.
+ * It demonstrates how to create a parameter, create a parameter version,
+ * view the parameter version, and render its payload.
+ */
+
+'use strict';
+
+/**
+ * Quickstart example for using Google Cloud Parameter Manager to
+ * create a global parameter, add a version with a JSON payload,
+ * and fetch the parameter version details.
+ *
+ * @param {string} projectId - The Google Cloud project ID where parameter is created.
+ * @param {string} parameterId - The ID of the new parameter.
+ * @param {string} parameterVersionId - The ID of the parameter version.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1'
+) {
+  // [START parametermanager_quickstart]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+
+  // Imports the Google Cloud Parameter Manager library
+  const {
+    ParameterManagerClient,
+    protos,
+  } = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function quickstart() {
+    const parent = client.locationPath(projectId, 'global');
+    const parameterRequest = {
+      parent: parent,
+      parameterId: parameterId,
+      parameter: {
+        format: protos.google.cloud.parametermanager.v1.ParameterFormat.JSON,
+      },
+    };
+
+    // Create a new parameter
+    const [parameter] = await client.createParameter(parameterRequest);
+    console.log(
+      `Created parameter ${parameter.name} with format ${parameter.format}`
+    );
+
+    const payload = {username: 'test-user', host: 'localhost'};
+    // Create a new parameter version
+    const [parameterVersion] = await client.createParameterVersion({
+      parent: parameter.name,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: {
+        payload: {
+          data: Buffer.from(JSON.stringify(payload), 'utf8'),
+        },
+      },
+    });
+    console.log(`Created parameter version: ${parameterVersion.name}`);
+
+    // Get the parameter version
+    const [response] = await client.getParameterVersion({
+      name: parameterVersion.name,
+    });
+    console.log(`Retrieved parameter version: ${response.name}`);
+    console.log('Payload:', response.payload.data.toString('utf8'));
+  }
+
+  await quickstart();
+  // [END parametermanager_quickstart]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/createRegionalParam.js
+++ b/parameter-manager/regional_samples/createRegionalParam.js
@@ -1,0 +1,67 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a new version of an existing parameter in the specified region
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ * The payload is specified as a JSON string and includes a reference to a secret.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} locationId - The ID of the region where parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create. This ID must be unique within the project location.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-regional-parameter'
+) {
+  // [START parametermanager_create_regional_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'YOUR_LOCATION_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function createRegionalParam() {
+    const parent = client.locationPath(projectId, locationId);
+    const request = {
+      parent: parent,
+      parameterId: parameterId,
+    };
+
+    const [parameter] = await client.createParameter(request);
+    console.log(`Created regional parameter: ${parameter.name}`);
+  }
+
+  await createRegionalParam();
+  // [END parametermanager_create_regional_param]
+}
+
+// This sample demonstrates how to create a regional parameter with unstructured data.
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/createRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/createRegionalParamVersion.js
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a new version of an existing parameter in the specified region
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ * The payload is specified as an unformatted string.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which the version is to be created.
+ * @param {string} parameterVersionId - The ID of the parameter version to be created.
+ * @param {string} payload - The unformatted string payload to be stored in the parameter version.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1',
+  payload = 'This is unstructured data'
+) {
+  // [START parametermanager_create_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'us-central1';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const payload = 'This is unstructured data';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function createRegionalParamVersion() {
+    // Construct the parent resource name
+    const parent = client.parameterPath(projectId, locationId, parameterId);
+
+    // Construct the parameter version
+    const parameterVersion = {
+      payload: {
+        data: Buffer.from(payload, 'utf8'),
+      },
+    };
+
+    // Construct the request
+    const request = {
+      parent: parent,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: parameterVersion,
+    };
+
+    // Create the parameter version
+    const [response] = await client.createParameterVersion(request);
+    console.log(`Created regional parameter version: ${response.name}`);
+  }
+
+  await createRegionalParamVersion();
+  // [END parametermanager_create_regional_param_version]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/createRegionalParamVersionWithSecret.js
+++ b/parameter-manager/regional_samples/createRegionalParamVersionWithSecret.js
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a new version of an existing parameter in the specified region
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ * The payload is specified as a JSON string and includes a reference to a secret.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which the version is to be created.
+ * @param {string} parameterVersionId - The ID of the parameter version to be created.
+ * @param {string} secretId - The ID of the secret to be referenced.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1',
+  secretId = 'projects/my-project/secrets/application-secret/version/latest'
+) {
+  // [START parametermanager_create_regional_param_version_with_secret]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'us-central1';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const secretId = 'YOUR_SECRET_ID'; // For example projects/my-project/secrets/application-secret/version/latest
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function createRegionalParamVersionWithSecret() {
+    // Construct the parent resource name
+    const parent = client.parameterPath(projectId, locationId, parameterId);
+
+    // Construct the payload JSON data with secret references
+    const payloadData = {
+      db_user: 'test_user',
+      db_password: `__REF__("//secretmanager.googleapis.com/${secretId}")`,
+    };
+
+    // Construct the parameter version
+    const parameterVersion = {
+      payload: {
+        data: Buffer.from(JSON.stringify(payloadData), 'utf8'),
+      },
+    };
+
+    // Construct the request
+    const request = {
+      parent: parent,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: parameterVersion,
+    };
+
+    // Create the regional parameter version
+    const [response] = await client.createParameterVersion(request);
+    console.log(
+      `Created regional parameter version with secret: ${response.name}`
+    );
+  }
+
+  await createRegionalParamVersionWithSecret();
+  // [END parametermanager_create_regional_param_version_with_secret]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/createStructuredRegionalParam.js
+++ b/parameter-manager/regional_samples/createStructuredRegionalParam.js
@@ -1,0 +1,77 @@
+// Copyright 2025  Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {protos} = require('@google-cloud/parametermanager');
+
+/**
+ * Creates a parameter in the specified region of the specified project using the Google Cloud Parameter Manager SDK.
+ * The parameter is created with the specified format type.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} locationId - The ID of the region where parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create.
+ * @param {string} formatType - The format type of the parameter (UNFORMATTED, YAML, JSON).
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-json-parameter',
+  formatType = protos.google.cloud.parametermanager.v1.ParameterFormat.JSON
+) {
+  // [START parametermanager_create_structured_regional_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const {protos} = require('@google-cloud/parametermanager');
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'YOUR_LOCATION_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const formatType = protos.google.cloud.parametermanager.v1.ParameterFormat.JSON;
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function createStructuredRegionalParam() {
+    const parent = client.locationPath(projectId, locationId);
+    const request = {
+      parent: parent,
+      parameterId: parameterId,
+      parameter: {
+        format: formatType,
+      },
+    };
+
+    const [parameter] = await client.createParameter(request);
+    console.log(
+      `Created regional parameter ${parameter.name} with format ${parameter.format}`
+    );
+  }
+
+  await createStructuredRegionalParam();
+  // [END parametermanager_create_structured_regional_param]
+}
+
+// This sample demonstrates how to create a regional parameter with structured (JSON) data.
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/createStructuredRegionalParam.js
+++ b/parameter-manager/regional_samples/createStructuredRegionalParam.js
@@ -1,4 +1,4 @@
-// Copyright 2025  Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parameter-manager/regional_samples/createStructuredRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/createStructuredRegionalParamVersion.js
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a new version of an existing parameter in the specified region of the
+ * specified project using the Google Cloud Parameter Manager SDK.
+ * The payload is specified as a JSON format.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which the version is to be created.
+ * @param {string} parameterVersionId - The ID of the parameter version to be created.
+ * @param {Object} payload - The JSON data payload to be stored in the parameter version.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1',
+  payload = {username: 'test-user', host: 'localhost'}
+) {
+  // [START parametermanager_create_structured_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'us-central1';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const payload = {username: "test-user", host: "localhost"};
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function createStructuredRegionalParamVersion() {
+    // Construct the parent resource name
+    const parent = client.parameterPath(projectId, locationId, parameterId);
+
+    // Construct the parameter version
+    const parameterVersion = {
+      payload: {
+        data: Buffer.from(JSON.stringify(payload), 'utf8'),
+      },
+    };
+
+    // Construct the request
+    const request = {
+      parent: parent,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: parameterVersion,
+    };
+
+    // Create the regional parameter version
+    const [response] = await client.createParameterVersion(request);
+    console.log(`Created regional parameter version: ${response.name}`);
+  }
+
+  await createStructuredRegionalParamVersion();
+  // [END parametermanager_create_structured_regional_param_version]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/deleteRegionalParam.js
+++ b/parameter-manager/regional_samples/deleteRegionalParam.js
@@ -1,0 +1,67 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Deletes a parameter from the specified region of the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter to delete.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter'
+) {
+  // [START parametermanager_delete_regional_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function deleteRegionalParam() {
+    // Construct the fully qualified parameter name
+    const name = client.parameterPath(projectId, locationId, parameterId);
+
+    // Delete the parameter
+    await client.deleteParameter({
+      name: name,
+    });
+
+    console.log(`Deleted regional parameter: ${name}`);
+  }
+
+  await deleteRegionalParam();
+  // [END parametermanager_delete_regional_param]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/deleteRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/deleteRegionalParamVersion.js
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Deletes a specific version of an existing parameter in the specified region
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version is to be deleted.
+ * @param {string} versionId - The version ID of the parameter to delete.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_delete_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function deleteRegionalParamVersion() {
+    // Construct the fully qualified parameter version name
+    const name = client.parameterVersionPath(
+      projectId,
+      locationId,
+      parameterId,
+      versionId
+    );
+
+    // Delete the parameter version
+    await client.deleteParameterVersion({
+      name: name,
+    });
+
+    console.log(`Deleted regional parameter version: ${name}`);
+  }
+
+  await deleteRegionalParamVersion();
+  // [END parametermanager_delete_regional_param_version]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/disableRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/disableRegionalParamVersion.js
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Disables a specific version of an existing parameter in the specified region
+ * of the specified project using the Google Cloud Parameter Manager SDK.
+ *
+ * This function demonstrates how to disable a global parameter version by setting
+ * its 'disabled' field to true using the Parameter Manager client library.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version is to be disabled.
+ * @param {string} versionId - The version ID of the parameter to be disabled.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_disable_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function disableRegionalParamVersion() {
+    // Construct the full resource name
+    const name = client.parameterVersionPath(
+      projectId,
+      locationId,
+      parameterId,
+      versionId
+    );
+
+    // Construct the request
+    const request = {
+      parameterVersion: {
+        name: name,
+        disabled: true,
+      },
+      updateMask: {
+        paths: ['disabled'],
+      },
+    };
+
+    // Make the API call to update the parameter version
+    const [response] = await client.updateParameterVersion(request);
+
+    console.log(
+      `Disabled regional parameter version ${response.name} for parameter ${parameterId}`
+    );
+    return response;
+  }
+
+  await disableRegionalParamVersion();
+  // [END parametermanager_disable_regional_param_version]
+}
+
+// The command-line arguments are passed as an array to main().
+main(...process.argv.slice(2)).catch(console.error);

--- a/parameter-manager/regional_samples/enableRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/enableRegionalParamVersion.js
@@ -1,0 +1,87 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Enables a specific version of a regional parameter in Google Cloud Parameter Manager.
+ * This function demonstrates how to enable a regional parameter version by setting
+ * its 'disabled' field to false using the Parameter Manager client library.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version is to be enabled.
+ * @param {string} versionId - The version ID of the parameter to be enabled.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_enable_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function enableRegionalParamVersion() {
+    // Construct the full resource name
+    const name = client.parameterVersionPath(
+      projectId,
+      locationId,
+      parameterId,
+      versionId
+    );
+
+    // Construct the request
+    const request = {
+      parameterVersion: {
+        name: name,
+        disabled: false,
+      },
+      updateMask: {
+        paths: ['disabled'],
+      },
+    };
+
+    // Make the API call to update the parameter version
+    const [response] = await client.updateParameterVersion(request);
+
+    console.log(
+      `Enabled regional parameter version ${response.name} for parameter ${parameterId}`
+    );
+    return response;
+  }
+
+  await enableRegionalParamVersion();
+  // [END parametermanager_enable_regional_param_version]
+}
+
+// The command-line arguments are passed as an array to main().
+main(...process.argv.slice(2)).catch(console.error);

--- a/parameter-manager/regional_samples/getRegionalParam.js
+++ b/parameter-manager/regional_samples/getRegionalParam.js
@@ -1,0 +1,71 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Retrieves a parameter from the specified region of the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter to retrieve.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter'
+) {
+  // [START parametermanager_get_regional_param]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function getRegionalParam() {
+    // Construct the fully qualified parameter name
+    const name = client.parameterPath(projectId, locationId, parameterId);
+
+    // Get the parameter
+    const [parameter] = await client.getParameter({
+      name: name,
+    });
+
+    // Find more details for the Parameter object here:
+    // https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters#Parameter
+    console.log(
+      `Found regional parameter ${parameter.name} with format ${parameter.format}`
+    );
+  }
+
+  await getRegionalParam();
+  // [END parametermanager_get_regional_param]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/getRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/getRegionalParamVersion.js
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Retrieves the details of a specific version of an existing parameter in the specified region of the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version details are to be retrieved.
+ * @param {string} versionId - The version ID of the parameter to retrieve.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  versionId = 'v1'
+) {
+  // [START parametermanager_get_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+  // const versionId = 'v1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function getRegionalParamVersion() {
+    // Construct the fully qualified parameter version name
+    const name = client.parameterVersionPath(
+      projectId,
+      locationId,
+      parameterId,
+      versionId
+    );
+
+    // Get the parameter version
+    const [parameterVersion] = await client.getParameterVersion({
+      name: name,
+    });
+
+    // Find more details for the Parameter Version object here:
+    // https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions#ParameterVersion
+    console.log(
+      `Found regional parameter version ${parameterVersion.name} with state ${parameterVersion.disabled ? 'disabled' : 'enabled'}`
+    );
+    if (!parameterVersion.disabled) {
+      console.log(
+        `Payload: ${parameterVersion.payload.data.toString('utf-8')}`
+      );
+    }
+  }
+
+  await getRegionalParamVersion();
+  // [END parametermanager_get_regional_param_version]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/listRegionalParamVersions.js
+++ b/parameter-manager/regional_samples/listRegionalParamVersions.js
@@ -1,0 +1,73 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * List all versions of an existing parameter in the specific region for the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where the parameter is located.
+ * @param {string} parameterId - The parameter ID for which versions are to be listed.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter'
+) {
+  // [START parametermanager_list_regional_param_versions]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function listRegionalParamVersions() {
+    // Construct the parent string for listing parameter versions in a specific region
+    const parent = client.parameterPath(projectId, locationId, parameterId);
+
+    const request = {
+      parent: parent,
+    };
+
+    // Use listParameterVersionsAsync to handle pagination automatically
+    const iterable = await client.listParameterVersionsAsync(request);
+
+    console.log(`Parameter versions for ${parameterId} in ${locationId}:`);
+    for await (const version of iterable) {
+      console.log(
+        `Found regional parameter version ${version.name} with state ${version.disabled ? 'disabled' : 'enabled'} `
+      );
+    }
+  }
+
+  await listRegionalParamVersions();
+  // [END parametermanager_list_regional_param_versions]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/listRegionalParamVersions.js
+++ b/parameter-manager/regional_samples/listRegionalParamVersions.js
@@ -57,7 +57,6 @@ async function main(
     // Use listParameterVersionsAsync to handle pagination automatically
     const iterable = await client.listParameterVersionsAsync(request);
 
-    console.log(`Parameter versions for ${parameterId} in ${locationId}:`);
     for await (const version of iterable) {
       console.log(
         `Found regional parameter version ${version.name} with state ${version.disabled ? 'disabled' : 'enabled'} `

--- a/parameter-manager/regional_samples/listRegionalParams.js
+++ b/parameter-manager/regional_samples/listRegionalParams.js
@@ -51,7 +51,6 @@ async function main(projectId = 'my-project', locationId = 'us-central1') {
     // Use listParametersAsync to handle pagination automatically
     const iterable = await client.listParametersAsync(request);
 
-    console.log(`Parameters in ${locationId}:`);
     for await (const parameter of iterable) {
       console.log(
         `Found regional parameter ${parameter.name} with format ${parameter.format}`

--- a/parameter-manager/regional_samples/listRegionalParams.js
+++ b/parameter-manager/regional_samples/listRegionalParams.js
@@ -1,0 +1,67 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Lists all parameters in the specified region for the specified
+ * project using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameters are located.
+ * @param {string} locationId - The ID of the region where parameters are located.
+ */
+async function main(projectId = 'my-project', locationId = 'us-central1') {
+  // [START parametermanager_list_regional_params]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function listRegionalParams() {
+    // Construct the parent string for listing parameters in a specific region
+    const parent = client.locationPath(projectId, locationId);
+
+    const request = {
+      parent: parent,
+    };
+
+    // Use listParametersAsync to handle pagination automatically
+    const iterable = await client.listParametersAsync(request);
+
+    console.log(`Parameters in ${locationId}:`);
+    for await (const parameter of iterable) {
+      console.log(
+        `Found regional parameter ${parameter.name} with format ${parameter.format}`
+      );
+    }
+  }
+
+  await listRegionalParams();
+  // [END parametermanager_list_regional_params]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/regionalQuickstart.js
+++ b/parameter-manager/regional_samples/regionalQuickstart.js
@@ -1,0 +1,99 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Quickstart example for using Google Cloud Parameter Manager to
+ * create a regional parameter, add a version with a JSON payload,
+ * fetch the parameter version details and render its payload.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} locationId - The ID of the region where parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create.
+ * @param {string} parameterVersionId - The ID of the parameter version to create.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1'
+) {
+  // [START parametermanager_regional_quickstart]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'YOUR_LOCATION_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+
+  // Imports the Google Cloud Parameter Manager library
+  const {
+    ParameterManagerClient,
+    protos,
+  } = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function regionalQuickstart() {
+    const parent = client.locationPath(projectId, locationId);
+    const parameterRequest = {
+      parent: parent,
+      parameterId: parameterId,
+      parameter: {
+        format: protos.google.cloud.parametermanager.v1.ParameterFormat.JSON,
+      },
+    };
+
+    // Create a new parameter
+    const [parameter] = await client.createParameter(parameterRequest);
+    console.log(
+      `Created regional parameter ${parameter.name} with format ${parameter.format}`
+    );
+
+    const payload = {username: 'test-user', host: 'localhost'};
+    // Create a new parameter version
+    const [parameterVersion] = await client.createParameterVersion({
+      parent: parameter.name,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: {
+        payload: {
+          data: Buffer.from(JSON.stringify(payload), 'utf8'),
+        },
+      },
+    });
+    console.log(`Created regional parameter version: ${parameterVersion.name}`);
+
+    // Get the parameter version
+    const [response] = await client.getParameterVersion({
+      name: parameterVersion.name,
+    });
+    console.log(`Retrieved regional parameter version: ${response.name}`);
+    console.log('Payload:', response.payload.data.toString('utf8'));
+  }
+
+  await regionalQuickstart();
+  // [END parametermanager_regional_quickstart]
+}
+
+// The command-line arguments are passed as an array to main()
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/regional_samples/regionalQuickstart.js
+++ b/parameter-manager/regional_samples/regionalQuickstart.js
@@ -34,10 +34,10 @@ async function main(
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
-  // const projectId = 'YOUR_PROJECT_ID';
-  // const locationId = 'YOUR_LOCATION_ID';
-  // const parameterId = 'YOUR_PARAMETER_ID';
-  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+  // const projectId = 'my-project';
+  // const locationId = 'us-central1';
+  // const parameterId = 'my-parameter';
+  // const parameterVersionId = 'v1';
 
   // Imports the Google Cloud Parameter Manager library
   const {

--- a/parameter-manager/regional_samples/renderRegionalParamVersion.js
+++ b/parameter-manager/regional_samples/renderRegionalParamVersion.js
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Retrieves and renders the details of a specific version of an
+ * existing parameter in the specified region of the specified project
+ * using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} locationId - The ID of the region where parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version details are to be rendered.
+ * @param {string} parameterVersionId - The ID of the parameter version to be rendered.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1'
+) {
+  // [START parametermanager_render_regional_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'us-central1';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function renderRegionalParamVersion() {
+    // Construct the parameter version name
+    const name = client.parameterVersionPath(
+      projectId,
+      locationId,
+      parameterId,
+      parameterVersionId
+    );
+
+    // Construct the request
+    const request = {
+      name: name,
+    };
+
+    // Render the parameter version
+    const [response] = await client.renderParameterVersion(request);
+
+    console.log(
+      `Rendered regional parameter version: ${response.parameterVersion}`
+    );
+
+    // If the parameter contains secret references, they will be resolved
+    // and the actual secret values will be included in the rendered output.
+    // Be cautious with logging or displaying this information.
+    console.log(
+      'Rendered payload: ',
+      response.renderedPayload.toString('utf-8')
+    );
+  }
+
+  await renderRegionalParamVersion();
+  // [END parametermanager_render_regional_param_version]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/renderParamVersion.js
+++ b/parameter-manager/renderParamVersion.js
@@ -1,0 +1,78 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Retrieves and renders the details of a specific version of an
+ * existing parameter in the global location of the specified project
+ * using the Google Cloud Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is located.
+ * @param {string} parameterId - The ID of the parameter for which version details are to be rendered.
+ * @param {string} parameterVersionId - The ID of the parameter version to be rendered.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  parameterVersionId = 'v1'
+) {
+  // [START parametermanager_render_param_version]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const parameterVersionId = 'YOUR_PARAMETER_VERSION_ID';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function renderParamVersion() {
+    // Construct the parameter version name
+    const name = client.parameterVersionPath(
+      projectId,
+      'global',
+      parameterId,
+      parameterVersionId
+    );
+
+    // Construct the request
+    const request = {
+      name: name,
+    };
+
+    // Render the parameter version
+    const [response] = await client.renderParameterVersion(request);
+    console.log(`Rendered parameter version: ${response.parameterVersion}`);
+
+    // If the parameter contains secret references, they will be resolved
+    // and the actual secret values will be included in the rendered output.
+    // Be cautious with logging or displaying this information.
+    console.log(
+      'Rendered payload: ',
+      response.renderedPayload.toString('utf-8')
+    );
+  }
+
+  await renderParamVersion();
+  // [END parametermanager_render_param_version]
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parameter-manager/test/.eslintrc.yml
+++ b/parameter-manager/test/.eslintrc.yml
@@ -1,0 +1,3 @@
+---
+env:
+  mocha: true

--- a/parameter-manager/test/.eslintrc.yml
+++ b/parameter-manager/test/.eslintrc.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 env:
   mocha: true

--- a/parameter-manager/test/parametermanager.test.js
+++ b/parameter-manager/test/parametermanager.test.js
@@ -1,0 +1,596 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert} = require('chai');
+const cp = require('child_process');
+const {v4: uuidv4} = require('uuid');
+
+const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+const client = new ParameterManagerClient();
+
+const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+const secretClient = new SecretManagerServiceClient();
+
+const projectId = process.env.GCLOUD_PROJECT;
+const locationId = process.env.GCLOUD_LOCATION || 'us-central1';
+const options = {};
+options.apiEndpoint = `parametermanager.${locationId}.rep.googleapis.com`;
+
+const regionalClient = new ParameterManagerClient(options);
+
+const secretOptions = {};
+secretOptions.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+
+const regionalSecretClient = new SecretManagerServiceClient(secretOptions);
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+const secretId = `test-secret-${uuidv4()}`;
+const parameterId = `test-parameter-${uuidv4()}`;
+const regionalParameterId = `test-regional-${uuidv4()}`;
+const parameterVersionId = 'v1';
+
+let parameter;
+let regionalParameter;
+let parameterVersion;
+let regionalParameterVersion;
+let secret;
+let secretVersion;
+let regionalSecret;
+let regionalSecretVersion;
+
+describe('Parameter Manager samples', () => {
+  const parametersToDelete = [];
+  const regionalParametersToDelete = [];
+
+  before(async () => {
+    // Create a secret
+    [secret] = await secretClient.createSecret({
+      parent: `projects/${projectId}`,
+      secretId: secretId,
+      secret: {
+        replication: {
+          automatic: {},
+        },
+      },
+    });
+
+    // Create a regional secret
+    [regionalSecret] = await regionalSecretClient.createSecret({
+      parent: `projects/${projectId}/locations/${locationId}`,
+      secretId: secretId,
+    });
+
+    // Create a secret version
+    [secretVersion] = await secretClient.addSecretVersion({
+      parent: secret.name,
+      payload: {
+        data: Buffer.from('my super secret data', 'utf-8'),
+      },
+    });
+
+    // Create a regional secret version
+    [regionalSecretVersion] = await regionalSecretClient.addSecretVersion({
+      parent: regionalSecret.name,
+      payload: {
+        data: Buffer.from('my super secret data', 'utf-8'),
+      },
+    });
+
+    // Create a test global parameter
+    [parameter] = await client.createParameter({
+      parent: `projects/${projectId}/locations/global`,
+      parameterId: parameterId,
+      parameter: {
+        format: 'JSON',
+      },
+    });
+
+    // Create a test regional parameter
+    [regionalParameter] = await regionalClient.createParameter({
+      parent: `projects/${projectId}/locations/${locationId}`,
+      parameterId: regionalParameterId,
+      parameter: {
+        format: 'JSON',
+      },
+    });
+
+    // Create a version for the global parameter
+    [parameterVersion] = await client.createParameterVersion({
+      parent: parameter.name,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: {
+        payload: {
+          data: Buffer.from(JSON.stringify({key: 'global_value'}), 'utf-8'),
+        },
+      },
+    });
+
+    // Create a version for the regional parameter
+    [regionalParameterVersion] = await regionalClient.createParameterVersion({
+      parent: regionalParameter.name,
+      parameterVersionId: parameterVersionId,
+      parameterVersion: {
+        payload: {
+          data: Buffer.from(JSON.stringify({key: 'regional_value'}), 'utf-8'),
+        },
+      },
+    });
+  });
+
+  after(async () => {
+    // Clean up
+    parametersToDelete.forEach(async parameterName => {
+      await client.deleteParameterVersion({
+        name: `${parameterName}/versions/v1`,
+      });
+      await client.deleteParameter({name: parameterName});
+    });
+    regionalParametersToDelete.forEach(async regionalParameterName => {
+      await regionalClient.deleteParameterVersion({
+        name: `${regionalParameterName}/versions/v1`,
+      });
+      await regionalClient.deleteParameter({name: regionalParameterName});
+    });
+    await secretClient.deleteSecret({
+      name: secret.name,
+    });
+    await regionalSecretClient.deleteSecret({
+      name: regionalSecret.name,
+    });
+  });
+
+  it('should runs the quickstart', async () => {
+    const output = execSync(
+      `node quickstart.js ${projectId} ${parameterId}-quickstart ${parameterVersionId}`
+    );
+    parametersToDelete.push(`${parameterId}-quickstart`);
+    assert.include(
+      output,
+      `Created parameter projects/${projectId}/locations/global/parameters/${parameterId}-quickstart with format JSON`
+    );
+    assert.include(
+      output,
+      `Created parameter version: projects/${projectId}/locations/global/parameters/${parameterId}-quickstart/versions/v1`
+    );
+    assert.include(
+      output,
+      `Retrieved parameter version: projects/${projectId}/locations/global/parameters/${parameterId}-quickstart/versions/v1`
+    );
+    assert.include(
+      output,
+      'Payload: {"username":"test-user","host":"localhost"}'
+    );
+  });
+
+  it('should runs the regional quickstart', async () => {
+    const output = execSync(
+      `node regional_samples/regionalQuickstart.js ${projectId} ${locationId} ${regionalParameterId}-quickstart ${parameterVersionId}`
+    );
+    regionalParametersToDelete.push(`${regionalParameterId}-quickstart`);
+    assert.include(
+      output,
+      `Created regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-quickstart with format JSON`
+    );
+    assert.include(
+      output,
+      `Created regional parameter version: projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-quickstart/versions/v1`
+    );
+    assert.include(
+      output,
+      `Retrieved regional parameter version: projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-quickstart/versions/v1`
+    );
+    assert.include(
+      output,
+      'Payload: {"username":"test-user","host":"localhost"}'
+    );
+  });
+
+  it('should create parameter version with secret references', async () => {
+    const output = execSync(
+      `node createParamVersionWithSecret.js ${projectId} ${parameterId} ${parameterVersionId}2 ${secretVersion.name}`
+    );
+    assert.include(
+      output,
+      `Created parameter version with secret references: projects/${projectId}/locations/global/parameters/${parameterId}/versions/${parameterVersionId}2`
+    );
+  });
+
+  it('should create regional parameter version with secret references', async () => {
+    const output = execSync(
+      `node regional_samples/createRegionalParamVersionWithSecret.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}2 ${regionalSecretVersion.name}`
+    );
+    assert.include(
+      output,
+      `Created regional parameter version with secret: projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}/versions/${parameterVersionId}2`
+    );
+  });
+
+  it('should create a structured parameter', async () => {
+    const output = execSync(
+      `node createStructuredParam.js ${projectId} ${parameterId}-2`
+    );
+    parametersToDelete.push(`${parameterId}-2`);
+    assert.include(
+      output,
+      `Created parameter projects/${projectId}/locations/global/parameters/${parameterId}-2 with format JSON`
+    );
+  });
+
+  it('should create a regional structured parameter', async () => {
+    const output = execSync(
+      `node regional_samples/createStructuredRegionalParam.js ${projectId} ${locationId} ${regionalParameterId}-2`
+    );
+    regionalParametersToDelete.push(`${regionalParameterId}-2`);
+    assert.include(
+      output,
+      `Created regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-2 with format JSON`
+    );
+  });
+
+  it('should create a unstructured parameter', async () => {
+    const output = execSync(
+      `node createParam.js ${projectId} ${parameterId}-3`
+    );
+    parametersToDelete.push(`${parameterId}-3`);
+    assert.include(
+      output,
+      `Created parameter: projects/${projectId}/locations/global/parameters/${parameterId}-3`
+    );
+  });
+
+  it('should create a regional unstructured parameter', async () => {
+    const output = execSync(
+      `node regional_samples/createRegionalParam.js ${projectId} ${locationId} ${regionalParameterId}-3`
+    );
+    regionalParametersToDelete.push(`${regionalParameterId}-3`);
+    assert.include(
+      output,
+      `Created regional parameter: projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-3`
+    );
+  });
+
+  it('should create a structured parameter version', async () => {
+    const output = execSync(
+      `node createStructuredParamVersion.js ${projectId} ${parameterId}-2 ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Created parameter version: projects/${projectId}/locations/global/parameters/${parameterId}-2/versions/${parameterVersionId}`
+    );
+  });
+
+  it('should create a regional structured parameter version', async () => {
+    const output = execSync(
+      `node regional_samples/createStructuredRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId}-2 ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Created regional parameter version: projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-2/versions/${parameterVersionId}`
+    );
+  });
+
+  it('should create a unstructured parameter version', async () => {
+    const output = execSync(
+      `node createParamVersion.js ${projectId} ${parameterId}-3 ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Created parameter version: projects/${projectId}/locations/global/parameters/${parameterId}-3/versions/${parameterVersionId}`
+    );
+  });
+
+  it('should create a regional unstructured parameter version', async () => {
+    const output = execSync(
+      `node regional_samples/createRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId}-3 ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Created regional parameter version: projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-3/versions/${parameterVersionId}`
+    );
+  });
+
+  it('should list parameters', async () => {
+    const output = execSync(`node listParams.js ${projectId}`);
+    assert.include(output, 'Parameters:');
+    assert.include(
+      output,
+      `Found parameter ${parameter.name} with format ${parameter.format}`
+    );
+    assert.include(
+      output,
+      `Found parameter projects/${projectId}/locations/global/parameters/${parameterId}-2 with format JSON`
+    );
+    assert.include(
+      output,
+      `Found parameter projects/${projectId}/locations/global/parameters/${parameterId}-3 with format UNFORMATTED`
+    );
+  });
+
+  it('should list regional parameters', async () => {
+    const output = execSync(
+      `node regional_samples/listRegionalParams.js ${projectId} ${locationId}`
+    );
+    assert.include(output, `Parameters in ${locationId}:`);
+    assert.include(
+      output,
+      `Found regional parameter ${regionalParameter.name} with format ${regionalParameter.format}`
+    );
+    assert.include(
+      output,
+      `Found regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-2 with format JSON`
+    );
+    assert.include(
+      output,
+      `Found regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-3 with format UNFORMATTED`
+    );
+  });
+
+  it('should get a parameter', async () => {
+    const output = execSync(`node getParam.js ${projectId} ${parameterId}`);
+    assert.include(
+      output,
+      `Found parameter ${parameter.name} with format ${parameter.format}`
+    );
+  });
+
+  it('should get a regional parameter', async () => {
+    const output = execSync(
+      `node regional_samples/getRegionalParam.js ${projectId} ${locationId} ${regionalParameterId}`
+    );
+    assert.include(
+      output,
+      `Found regional parameter ${regionalParameter.name} with format ${regionalParameter.format}`
+    );
+  });
+
+  it('should disable a parameter version', async () => {
+    const output = execSync(
+      `node disableParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Disabled parameter version ${parameterVersion.name} for parameter ${parameterId}`
+    );
+  });
+
+  it('should disable a regional parameter version', async () => {
+    const output = execSync(
+      `node regional_samples/disableRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Disabled regional parameter version ${regionalParameterVersion.name} for parameter ${regionalParameterId}`
+    );
+  });
+
+  it('should list parameter versions', async () => {
+    const output = execSync(
+      `node listParamVersions.js ${projectId} ${parameterId}`
+    );
+    assert.include(output, `Parameter versions for ${parameterId}:`);
+    assert.include(
+      output,
+      `Found parameter version ${parameterVersion.name} with state disabled`
+    );
+    assert.include(
+      output,
+      `Found parameter version ${parameterVersion.name}2 with state enabled`
+    );
+  });
+
+  it('should list regional parameter versions', async () => {
+    const output = execSync(
+      `node regional_samples/listRegionalParamVersions.js ${projectId} ${locationId} ${regionalParameterId}`
+    );
+    assert.include(
+      output,
+      `Parameter versions for ${regionalParameterId} in ${locationId}:`
+    );
+    assert.include(
+      output,
+      `Found regional parameter version ${regionalParameterVersion.name} with state disabled`
+    );
+    assert.include(
+      output,
+      `Found regional parameter version ${regionalParameterVersion.name}2 with state enabled`
+    );
+  });
+
+  it('should get a parameter version', async () => {
+    let output = execSync(
+      `node getParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Found parameter version ${parameterVersion.name} with state disabled`
+    );
+
+    output = execSync(
+      `node getParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}2`
+    );
+    assert.include(
+      output,
+      `Found parameter version ${parameterVersion.name}2 with state enabled`
+    );
+    assert.include(
+      output,
+      'Payload: {"db_user":"test_user","db_password":"__REF__(//secretmanager.googleapis.com/projects/385768059301/secrets/test-secret-91cd9792-5f13-47c5-85ba-6622682f0035/versions/1)"}'
+    );
+  });
+
+  it('should get a regional parameter version', async () => {
+    let output = execSync(
+      `node regional_samples/getRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Found regional parameter version ${regionalParameterVersion.name} with state disabled`
+    );
+
+    output = execSync(
+      `node regional_samples/getRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}2`
+    );
+    assert.include(
+      output,
+      `Found regional parameter version ${regionalParameterVersion.name}2 with state enabled`
+    );
+    assert.include(
+      output,
+      'Payload: {"db_user":"test_user","db_password":"__REF__("//secretmanager.googleapis.com/projects/385768059301/locations/us-central1/secrets/test-secret-91cd9792-5f13-47c5-85ba-6622682f0035/versions/1")"}'
+    );
+  });
+
+  it('should enable a parameter version', async () => {
+    const output = execSync(
+      `node enableParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Enabled parameter version ${parameterVersion.name} for parameter ${parameterId}`
+    );
+  });
+
+  it('should enable a regional parameter version', async () => {
+    const output = execSync(
+      `node regional_samples/enableRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Enabled regional parameter version ${regionalParameterVersion.name} for parameter ${regionalParameterId}`
+    );
+  });
+
+  it('should render parameter version', async () => {
+    // Get the current IAM policy.
+    const [policy] = await secretClient.getIamPolicy({
+      resource: secret.name,
+    });
+
+    // Add the user with accessor permissions to the bindings list.
+    policy.bindings.push({
+      role: 'roles/secretmanager.secretAccessor',
+      members: [parameter.policyMember.iamPolicyUidPrincipal],
+    });
+
+    // Save the updated IAM policy.
+    await secretClient.setIamPolicy({
+      resource: secret.name,
+      policy: policy,
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 120000));
+
+    const output = execSync(
+      `node renderParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}2`
+    );
+    assert.include(output, 'Rendered parameter version:');
+    assert.include(
+      output,
+      `/parameters/${parameterId}/versions/${parameterVersionId}2`
+    );
+    assert.include(output, 'Rendered payload:');
+    assert.include(
+      output,
+      '{"db_user":"test_user","db_password":"my super secret data"}'
+    );
+  });
+
+  it('should render regional parameter version', async () => {
+    // Get the current IAM policy.
+    const [policy] = await regionalSecretClient.getIamPolicy({
+      resource: regionalSecret.name,
+    });
+
+    // Add the user with accessor permissions to the bindings list.
+    policy.bindings.push({
+      role: 'roles/secretmanager.secretAccessor',
+      members: [regionalParameter.policyMember.iamPolicyUidPrincipal],
+    });
+
+    // Save the updated IAM policy.
+    await regionalSecretClient.setIamPolicy({
+      resource: regionalSecret.name,
+      policy: policy,
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 120000));
+
+    const output = execSync(
+      `node regional_samples/renderRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}2`
+    );
+    assert.include(output, 'Rendered regional parameter version:');
+    assert.include(
+      output,
+      `/parameters/${regionalParameterId}/versions/${parameterVersionId}2`
+    );
+    assert.include(output, 'Rendered payload:');
+    assert.include(
+      output,
+      '{"db_user":"test_user","db_password":"my super secret data"}'
+    );
+  });
+
+  it('should delete a parameter version', async () => {
+    let output = execSync(
+      `node deleteParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Deleted parameter version: ${parameterVersion.name}`
+    );
+    output = execSync(
+      `node deleteParamVersion.js ${projectId} ${parameterId} ${parameterVersionId}2`
+    );
+    assert.include(
+      output,
+      `Deleted parameter version: ${parameterVersion.name}2`
+    );
+  });
+
+  it('should delete a regional parameter version', async () => {
+    let output = execSync(
+      `node regional_samples/deleteRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}`
+    );
+    assert.include(
+      output,
+      `Deleted regional parameter version: ${regionalParameterVersion.name}`
+    );
+
+    output = execSync(
+      `node regional_samples/deleteRegionalParamVersion.js ${projectId} ${locationId} ${regionalParameterId} ${parameterVersionId}2`
+    );
+    assert.include(
+      output,
+      `Deleted regional parameter version: ${regionalParameterVersion.name}2`
+    );
+  });
+
+  it('should delete a parameter', async () => {
+    const output = execSync(`node deleteParam.js ${projectId} ${parameterId}`);
+    assert.include(output, `Deleted parameter: ${parameter.name}`);
+  });
+
+  it('should delete a regional parameter', async () => {
+    const output = execSync(
+      `node regional_samples/deleteRegionalParam.js ${projectId} ${locationId} ${regionalParameterId}`
+    );
+    assert.include(
+      output,
+      `Deleted regional parameter: ${regionalParameter.name}`
+    );
+  });
+});

--- a/parameter-manager/test/parametermanager.test.js
+++ b/parameter-manager/test/parametermanager.test.js
@@ -305,7 +305,6 @@ describe('Parameter Manager samples', () => {
 
   it('should list parameters', async () => {
     const output = execSync(`node listParams.js ${projectId}`);
-    assert.include(output, 'Parameters:');
     assert.include(
       output,
       `Found parameter ${parameter.name} with format ${parameter.format}`
@@ -324,7 +323,6 @@ describe('Parameter Manager samples', () => {
     const output = execSync(
       `node regional_samples/listRegionalParams.js ${projectId} ${locationId}`
     );
-    assert.include(output, `Parameters in ${locationId}:`);
     assert.include(
       output,
       `Found regional parameter ${regionalParameter.name} with format ${regionalParameter.format}`
@@ -381,7 +379,6 @@ describe('Parameter Manager samples', () => {
     const output = execSync(
       `node listParamVersions.js ${projectId} ${parameterId}`
     );
-    assert.include(output, `Parameter versions for ${parameterId}:`);
     assert.include(
       output,
       `Found parameter version ${parameterVersion.name} with state disabled`
@@ -395,10 +392,6 @@ describe('Parameter Manager samples', () => {
   it('should list regional parameter versions', async () => {
     const output = execSync(
       `node regional_samples/listRegionalParamVersions.js ${projectId} ${locationId} ${regionalParameterId}`
-    );
-    assert.include(
-      output,
-      `Parameter versions for ${regionalParameterId} in ${locationId}:`
     );
     assert.include(
       output,
@@ -428,7 +421,7 @@ describe('Parameter Manager samples', () => {
     );
     assert.include(
       output,
-      'Payload: {"db_user":"test_user","db_password":"__REF__(//secretmanager.googleapis.com/projects/385768059301/secrets/test-secret-91cd9792-5f13-47c5-85ba-6622682f0035/versions/1)"}'
+      `Payload: {"db_user":"test_user","db_password":"__REF__(//secretmanager.googleapis.com/${secretVersion.name})"}`
     );
   });
 
@@ -450,7 +443,7 @@ describe('Parameter Manager samples', () => {
     );
     assert.include(
       output,
-      'Payload: {"db_user":"test_user","db_password":"__REF__("//secretmanager.googleapis.com/projects/385768059301/locations/us-central1/secrets/test-secret-91cd9792-5f13-47c5-85ba-6622682f0035/versions/1")"}'
+      `Payload: {"db_user":"test_user","db_password":"__REF__(\\"//secretmanager.googleapis.com/${regionalSecretVersion.name}\\")"}`
     );
   });
 

--- a/parameter-manager/test/parametermanager.test.js
+++ b/parameter-manager/test/parametermanager.test.js
@@ -24,7 +24,7 @@ const client = new ParameterManagerClient();
 const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
 const secretClient = new SecretManagerServiceClient();
 
-const projectId = process.env.GCLOUD_PROJECT;
+let projectId;
 const locationId = process.env.GCLOUD_LOCATION || 'us-central1';
 const options = {};
 options.apiEndpoint = `parametermanager.${locationId}.rep.googleapis.com`;
@@ -57,6 +57,8 @@ describe('Parameter Manager samples', () => {
   const regionalParametersToDelete = [];
 
   before(async () => {
+    projectId = await client.getProjectId();
+
     // Create a secret
     [secret] = await secretClient.createSecret({
       parent: `projects/${projectId}`,


### PR DESCRIPTION
## Description

Created samples for Global and Regional Parameter Manager API

Samples (Global, Regional)
quickstart
[parameter-structured-data](https://cloud.google.com/secret-manager/parameter-manager/docs/create-parameter#parameter-structured-data)
[parameter-unstructured-data](https://cloud.google.com/secret-manager/parameter-manager/docs/create-parameter#parameter-unstructured-data)
[add-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/add-parameter-version#add-parameter-version) (structured, unstructured)
[create-parameter-secret-reference](https://cloud.google.com/secret-manager/parameter-manager/docs/reference-secrets-in-parameter#create-parameter-secret-reference)
[list-all-parameters](https://cloud.google.com/secret-manager/parameter-manager/docs/list-parameter#list-all-parameters)
[view-parameter-details](https://cloud.google.com/secret-manager/parameter-manager/docs/view-parameter-details#view-parameter-details)
[delete-parameter](https://cloud.google.com/secret-manager/parameter-manager/docs/delete-parameters#list-all-parameters)
[list-all-parameters-versions](https://cloud.google.com/secret-manager/parameter-manager/docs/list-parameter-versions#list-all-parameters-versions)
[view-parameter-version-details](https://cloud.google.com/secret-manager/parameter-manager/docs/view-parameter-version-details#view-parameter-version-details)
[render-secret-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/render-parameter-version#render-secret-parameter-version)
[disable-parameters-version](https://cloud.google.com/secret-manager/parameter-manager/docs/disable-parameter-versions#disable-parameters-version)
[enable-disabled-parameters-version](https://cloud.google.com/secret-manager/parameter-manager/docs/enable-disabled-versions#enable-disabled-parameters-version)
[delete-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/delete-parameter-version#list-all-parameters)

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] These samples need a new **API enabled** in testing projects to pass (let us know which ones) - This requires [Parameter manager API](https://cloud.google.com/secret-manager/parameter-manager/docs/prepare-environment) to be enabled
- [X] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones) -  This requires `GCLOUD_LOCATION` to be set otherwise it will use `us-central1`
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [X] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
