### PR TITLE
ci: include custard name in job names

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CI (experimental)
+name: custard CI (dev)
 on:
   push:
     branches:

--- a/.github/workflows/ci-prod.yaml
+++ b/.github/workflows/ci-prod.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CI
+name: custard CI
 on:
   push:
     branches:


### PR DESCRIPTION
For discoverability, since these workflows create a variable number of jobs. And to help folks find docs by searching on the name.
