### PR TITLE
feat(tpu): Updating TPU samples to use TPUv5e

### DIFF
--- a/tpu/createStartupScriptVM.js
+++ b/tpu/createStartupScriptVM.js
@@ -50,11 +50,11 @@ async function main(tpuClient) {
   // The accelerator type that specifies the version and size of the Cloud TPU you want to create.
   // For more information about supported accelerator types for each TPU version,
   // see https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#versions.
-  const tpuType = 'v2-8';
+  const tpuType = 'v5litepod-4';
 
   // Software version that specifies the version of the TPU runtime to install. For more information,
   // see https://cloud.google.com/tpu/docs/runtimes
-  const tpuSoftwareVersion = 'tpu-vm-tf-2.17.0-pod-pjrt';
+  const tpuSoftwareVersion = 'v2-tpuv5-litepod';
 
   async function callCreateTpuVMStartupScript() {
     // Create a node

--- a/tpu/createTopologyVM.js
+++ b/tpu/createTopologyVM.js
@@ -51,7 +51,7 @@ async function main(tpuClient) {
 
   // Software version that specifies the version of the TPU runtime to install. For more information,
   // see https://cloud.google.com/tpu/docs/runtimes
-  const tpuSoftwareVersion = 'tpu-vm-tf-2.17.0-pod-pjrt';
+  const tpuSoftwareVersion = 'v2-tpuv5-litepod';
 
   // The version of the Cloud TPU you want to create.
   // Available options: TYPE_UNSPECIFIED = 0, V2 = 2, V3 = 4, V4 = 7

--- a/tpu/createVM.js
+++ b/tpu/createVM.js
@@ -49,11 +49,11 @@ async function main(tpuClient) {
   // The accelerator type that specifies the version and size of the Cloud TPU you want to create.
   // For more information about supported accelerator types for each TPU version,
   // see https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#versions.
-  const tpuType = 'v2-8';
+  const tpuType = 'v5litepod-4';
 
   // Software version that specifies the version of the TPU runtime to install. For more information,
   // see https://cloud.google.com/tpu/docs/runtimes
-  const tpuSoftwareVersion = 'tpu-vm-tf-2.14.1';
+  const tpuSoftwareVersion = 'v2-tpuv5-litepod';
 
   async function callCreateTpuVM() {
     // Create a node

--- a/tpu/queuedResources/createQueuedResource.js
+++ b/tpu/queuedResources/createQueuedResource.js
@@ -49,7 +49,7 @@ async function main(tpuClient) {
   // The zone in which to create the node.
   // For more information about supported TPU types for specific zones,
   // see https://cloud.google.com/tpu/docs/regions-zones
-  const zone = `${region}-f`;
+  const zone = `${region}-a`;
 
   // The accelerator type that specifies the version and size of the node you want to create.
   // For more information about supported accelerator types for each TPU version,

--- a/tpu/queuedResources/createQueuedResource.js
+++ b/tpu/queuedResources/createQueuedResource.js
@@ -54,11 +54,11 @@ async function main(tpuClient) {
   // The accelerator type that specifies the version and size of the node you want to create.
   // For more information about supported accelerator types for each TPU version,
   // see https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#versions.
-  const tpuType = 'v2-8';
+  const tpuType = 'v5litepod-4';
 
   // Software version that specifies the version of the node runtime to install. For more information,
   // see https://cloud.google.com/tpu/docs/runtimes
-  const tpuSoftwareVersion = 'tpu-vm-tf-2.14.1';
+  const tpuSoftwareVersion = 'v2-tpuv5-litepod';
 
   async function callCreateQueuedResource() {
     // Create a node

--- a/tpu/queuedResources/deleteQueuedResource.js
+++ b/tpu/queuedResources/deleteQueuedResource.js
@@ -36,7 +36,7 @@ async function main(tpuClient) {
   const queuedResourceName = 'queued-resource-1';
 
   // The zone of your queued resource.
-  const zone = 'us-central1-f';
+  const zone = 'us-central1-a';
 
   async function callDeleteTpuVM(nodeName) {
     const request = {

--- a/tpu/queuedResources/forceDeleteQueuedResource.js
+++ b/tpu/queuedResources/forceDeleteQueuedResource.js
@@ -36,7 +36,7 @@ async function main(tpuClient) {
   const queuedResourceName = 'queued-resource-1';
 
   // The zone of your queued resource.
-  const zone = 'us-central1-f';
+  const zone = 'us-central1-a';
 
   async function callForceDeleteQueuedResource() {
     const request = {

--- a/tpu/queuedResources/getQueuedResource.js
+++ b/tpu/queuedResources/getQueuedResource.js
@@ -36,7 +36,7 @@ async function main(tpuClient) {
   const queuedResourceName = 'queued-resource-1';
 
   // The zone of your queued resource.
-  const zone = 'us-central1-f';
+  const zone = 'us-central1-a';
 
   async function callGetQueuedResource() {
     const request = {

--- a/tpu/queuedResources/getQueuedResourcesList.js
+++ b/tpu/queuedResources/getQueuedResourcesList.js
@@ -33,7 +33,7 @@ async function main(tpuClient) {
   const projectId = await tpuClient.getProjectId();
 
   // The zone from which the Queued Resources are retrived.
-  const zone = 'us-central1-f';
+  const zone = 'us-central1-a';
 
   async function callGetQueuedResourcesList() {
     const request = {

--- a/tpu/test/forceDeleteQueuedResource.test.js
+++ b/tpu/test/forceDeleteQueuedResource.test.js
@@ -23,7 +23,7 @@ const forceDeleteQueuedResource = require('../queuedResources/forceDeleteQueuedR
 
 describe('TPU queued resource force deletion', async () => {
   const queuedResourceName = 'queued-resource-1';
-  const zone = 'us-central1-f';
+  const zone = 'us-central1-a';
   const projectId = 'project_id';
   let tpuClientMock;
 

--- a/tpu/test/queuedResource.test.js
+++ b/tpu/test/queuedResource.test.js
@@ -27,7 +27,7 @@ const deleteQueuedResource = require('../queuedResources/deleteQueuedResource.js
 describe('TPU queued resource', () => {
   const queuedResourceName = 'queued-resource-1';
   const nodeName = 'node-name-1';
-  const zone = 'us-central1-f';
+  const zone = 'us-central1-a';
   const projectId = 'project_id';
   let tpuClientMock;
 


### PR DESCRIPTION
## Description

Fixes b/396449050

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
