### PR TITLE
chore(ci): migrate datastore/functions to new ci

### DIFF
--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -113,6 +113,7 @@
     "datacatalog/quickstart",
     "datacatalog/snippets",
     "datalabeling",
+    "datastore/functions",
     "dialogflow",
     "discoveryengine",
     "document-warehouse",

--- a/datastore/functions/index.js
+++ b/datastore/functions/index.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const {Datastore} = require('@google-cloud/datastore');
+import { Datastore } from '@google-cloud/datastore';
 
 // Instantiates a client
 const datastore = new Datastore();
@@ -58,7 +58,7 @@ const getKeyFromRequestData = requestData => {
  * @param {object} req.body.value Value to save to Cloud Datastore, e.g. {"description":"Buy milk"}
  * @param {object} res Cloud Function response context.
  */
-exports.set = async (req, res) => {
+export async function set(req, res) {
   // The value contains a JSON document representing the entity we want to save
   if (!req.body.value) {
     const err = makeErrorObj('Value');
@@ -80,7 +80,7 @@ exports.set = async (req, res) => {
     console.error(new Error(err.message)); // Add to Stackdriver Error Reporting
     res.status(500).send(err.message);
   }
-};
+}
 
 /**
  * Retrieves a record.
@@ -94,7 +94,7 @@ exports.set = async (req, res) => {
  * @param {string} req.body.key Key at which to retrieve the data, e.g. "sampletask1".
  * @param {object} res Cloud Function response context.
  */
-exports.get = async (req, res) => {
+export async function get(req, res) {
   try {
     const key = await getKeyFromRequestData(req.body);
     const [entity] = await datastore.get(key);
@@ -110,7 +110,7 @@ exports.get = async (req, res) => {
     console.error(new Error(err.message)); // Add to Stackdriver Error Reporting
     res.status(500).send(err.message);
   }
-};
+}
 
 /**
  * Deletes a record.
@@ -124,7 +124,7 @@ exports.get = async (req, res) => {
  * @param {string} req.body.key Key at which to delete data, e.g. "sampletask1".
  * @param {object} res Cloud Function response context.
  */
-exports.del = async (req, res) => {
+export async function del(req, res) {
   // Deletes the entity
   // The delete operation will not fail for a non-existent entity, it just
   // doesn't delete anything
@@ -136,4 +136,4 @@ exports.del = async (req, res) => {
     console.error(new Error(err.message)); // Add to Stackdriver Error Reporting
     res.status(500).send(err.message);
   }
-};
+}

--- a/datastore/functions/package.json
+++ b/datastore/functions/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
+  "type": "module",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/datastore/functions/test/index.test.js
+++ b/datastore/functions/test/index.test.js
@@ -14,22 +14,22 @@
 
 'use strict';
 
-const assert = require('assert');
-const execPromise = require('child-process-promise').exec;
-const path = require('path');
-const uuid = require('uuid');
-const sinon = require('sinon');
-const fetch = require('node-fetch');
-const waitPort = require('wait-port');
-const {Datastore} = require('@google-cloud/datastore');
+import { ok, strictEqual, deepStrictEqual } from 'assert';
+import { exec as execPromise } from 'child-process-promise';
+import { join } from 'path';
+import { v4 } from 'uuid';
+import { stub } from 'sinon';
+import fetch from 'node-fetch';
+import waitPort from 'wait-port';
+import { Datastore } from '@google-cloud/datastore';
 
 const datastore = new Datastore();
-const program = require('../');
+import { set, get, del } from '../';
 
 const FF_TIMEOUT = 3000;
-const cwd = path.join(__dirname, '..');
+const cwd = join(__dirname, '..');
 const NAME = 'sampletask1';
-const KIND = `Task-${uuid.v4()}`;
+const KIND = `Task-${v4()}`;
 const VALUE = {
   description: 'Buy milk',
 };
@@ -72,14 +72,14 @@ describe('functions/datastore', () => {
         body: {},
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
 
-      await program.set(req, res);
+      await set(req, res);
 
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Value')));
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Value')));
     });
 
     it('set: Fails without a key', async () => {
@@ -89,12 +89,12 @@ describe('functions/datastore', () => {
         },
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
-      await program.set(req, res);
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Key')));
+      await set(req, res);
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Key')));
     });
 
     it('set: Fails without a kind', async () => {
@@ -105,14 +105,14 @@ describe('functions/datastore', () => {
         },
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
 
-      await program.set(req, res);
+      await set(req, res);
 
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Kind')));
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Kind')));
     });
 
     it('set: Saves an entity', async () => {
@@ -125,9 +125,9 @@ describe('functions/datastore', () => {
         }),
         headers: {'Content-Type': 'application/json'},
       });
-      assert.strictEqual(response.status, 200);
+      strictEqual(response.status, 200);
       const body = await response.text();
-      assert.ok(body.includes(`Entity ${KIND}/${NAME} saved`));
+      ok(body.includes(`Entity ${KIND}/${NAME} saved`));
     });
   });
 
@@ -159,9 +159,9 @@ describe('functions/datastore', () => {
         validateStatus: () => true,
       });
 
-      assert.strictEqual(response.status, 500);
+      strictEqual(response.status, 500);
       const body = await response.text();
-      assert.ok(
+      ok(
         new RegExp(
           /(Missing or insufficient permissions.)|(No entity found for key)/
         ).test(body)
@@ -177,9 +177,9 @@ describe('functions/datastore', () => {
         }),
         headers: {'Content-Type': 'application/json'},
       });
-      assert.strictEqual(response.status, 200);
+      strictEqual(response.status, 200);
       const body = await response.json();
-      assert.deepStrictEqual(body, {
+      deepStrictEqual(body, {
         description: 'Buy milk',
       });
     });
@@ -189,14 +189,14 @@ describe('functions/datastore', () => {
         body: {},
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
 
-      await program.get(req, res);
+      await get(req, res);
 
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Key')));
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Key')));
     });
 
     it('get: Fails without a kind', async () => {
@@ -206,14 +206,14 @@ describe('functions/datastore', () => {
         },
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
 
-      await program.get(req, res);
+      await get(req, res);
 
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Kind')));
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Kind')));
     });
   });
 
@@ -239,14 +239,14 @@ describe('functions/datastore', () => {
         body: {},
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
 
-      await program.del(req, res);
+      await del(req, res);
 
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Key')));
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Key')));
     });
 
     it('del: Fails without a kind', async () => {
@@ -256,14 +256,14 @@ describe('functions/datastore', () => {
         },
       };
       const res = {
-        status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        status: stub().returnsThis(),
+        send: stub(),
       };
 
-      await program.del(req, res);
+      await del(req, res);
 
-      assert.ok(res.status.calledWith(500));
-      assert.ok(res.send.calledWith(errorMsg('Kind')));
+      ok(res.status.calledWith(500));
+      ok(res.send.calledWith(errorMsg('Kind')));
     });
 
     it("del: Doesn't fail when entity does not exist", async () => {
@@ -275,9 +275,9 @@ describe('functions/datastore', () => {
         }),
         headers: {'Content-Type': 'application/json'},
       });
-      assert.strictEqual(response.status, 200);
+      strictEqual(response.status, 200);
       const body = await response.text();
-      assert.strictEqual(body, `Entity ${KIND}/nonexistent deleted.`);
+      strictEqual(body, `Entity ${KIND}/nonexistent deleted.`);
     });
 
     it('del: Deletes an entity', async () => {
@@ -289,13 +289,13 @@ describe('functions/datastore', () => {
         }),
         headers: {'Content-Type': 'application/json'},
       });
-      assert.strictEqual(response.status, 200);
+      strictEqual(response.status, 200);
       const body = await response.text();
-      assert.strictEqual(body, `Entity ${KIND}/${NAME} deleted.`);
+      strictEqual(body, `Entity ${KIND}/${NAME} deleted.`);
 
       const key = datastore.key([KIND, NAME]);
       const [entity] = await datastore.get(key);
-      assert.ok(!entity);
+      ok(!entity);
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
