### PR TITLE
feat(parametermanager): add global and regional samples for kms_key field

### DIFF
--- a/parametermanager/createParamWithKmsKey.js
+++ b/parametermanager/createParamWithKmsKey.js
@@ -1,0 +1,64 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a global parameter with kms_key using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create. This ID must be unique within the project.
+ * @param {string} kmsKey - The ID of the KMS key to be used for encryption.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  kmsKey = 'projects/my-project/locations/global/keyRings/my-key-ring/cryptoKeys/my-encryption-key'
+) {
+  // [START parametermanager_create_param_with_kms_key]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const kmsKey = 'YOUR_KMS_KEY'
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function createParamWithKmsKey() {
+    const parent = client.locationPath(projectId, 'global');
+    const request = {
+      parent: parent,
+      parameterId: parameterId,
+      parameter: {
+        kmsKey: kmsKey,
+      },
+    };
+
+    const [parameter] = await client.createParameter(request);
+    console.log(
+      `Created parameter ${parameter.name} with kms_key ${parameter.kmsKey}`
+    );
+  }
+
+  await createParamWithKmsKey();
+  // [END parametermanager_create_param_with_kms_key]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parametermanager/package.json
+++ b/parametermanager/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "nodejs-parameter-manager-samples",
+    "private": true,
+    "license": "Apache-2.0",
+    "files": [
+      "*.js"
+    ],
+    "author": "Google LLC",
+    "repository": "googleapis/nodejs-parameter-manager",
+    "engines": {
+      "node": ">=20"
+    },
+    "scripts": {
+      "test": "c8 mocha --recursive test/ --timeout=800000"
+    },
+    "directories": {
+      "test": "test"
+    },
+    "dependencies": {
+      "@google-cloud/parametermanager": "^0.3.0"
+    },
+    "devDependencies": {
+      "@google-cloud/kms": "^4.0.0",
+      "c8": "^10.1.3",
+      "chai": "^4.5.0",
+      "mocha": "^11.1.0",
+      "uuid": "^11.0.5"
+    }
+  }

--- a/parametermanager/regional_samples/createRegionalParamWithKmsKey.js
+++ b/parametermanager/regional_samples/createRegionalParamWithKmsKey.js
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Creates a regional parameter with kms_key using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be created.
+ * @param {string} locationId - The ID of the region where parameter is to be created.
+ * @param {string} parameterId - The ID of the parameter to create. This ID must be unique within the project.
+ * @param {string} kmsKey - The ID of the KMS key to be used for encryption.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  kmsKey = 'projects/my-project/locations/us-central1/keyRings/my-key-ring/cryptoKeys/my-encryption-key'
+) {
+  // [START parametermanager_create_regional_param_with_kms_key]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'YOUR_LOCATION_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const kmsKey = 'YOUR_KMS_KEY'
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function createRegionalParamWithKmsKey() {
+    const parent = client.locationPath(projectId, locationId);
+    const request = {
+      parent: parent,
+      parameterId: parameterId,
+      parameter: {
+        kmsKey: kmsKey,
+      },
+    };
+
+    const [parameter] = await client.createParameter(request);
+    console.log(
+      `Created regional parameter ${parameter.name} with kms_key ${parameter.kmsKey}`
+    );
+  }
+
+  await createRegionalParamWithKmsKey();
+  // [END parametermanager_create_regional_param_with_kms_key]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parametermanager/regional_samples/removeRegionalParamKmsKey.js
+++ b/parametermanager/regional_samples/removeRegionalParamKmsKey.js
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Removes a kms_key for regional parameter  using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be updated.
+ * @param {string} locationId - The ID of the region where parameter is to be updated.
+ * @param {string} parameterId - The ID of the parameter to update. This ID must be unique within the project.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter'
+) {
+  // [START parametermanager_remove_regional_param_kms_key]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'YOUR_LOCATION_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function removeRegionalParamKmsKey() {
+    const name = client.parameterPath(projectId, locationId, parameterId);
+    const request = {
+      parameter: {
+        name: name,
+      },
+      updateMask: {
+        paths: ['kms_key'],
+      },
+    };
+
+    const [parameter] = await client.updateParameter(request);
+    console.log(`Removed kms_key for regional parameter ${parameter.name}`);
+  }
+
+  await removeRegionalParamKmsKey();
+  // [END parametermanager_remove_regional_param_kms_key]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parametermanager/regional_samples/updateRegionalParamKmsKey.js
+++ b/parametermanager/regional_samples/updateRegionalParamKmsKey.js
@@ -1,0 +1,74 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Updates a regional parameter with kms_key using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be updated.
+ * @param {string} locationId - The ID of the region where parameter is to be updated.
+ * @param {string} parameterId - The ID of the parameter to update. This ID must be unique within the project.
+ * @param {string} kmsKey - The ID of the KMS key to be used for encryption.
+ */
+async function main(
+  projectId = 'my-project',
+  locationId = 'us-central1',
+  parameterId = 'my-parameter',
+  kmsKey = 'projects/my-project/locations/us-central1/keyRings/my-key-ring/cryptoKeys/my-encryption-key'
+) {
+  // [START parametermanager_update_regional_param_kms_key]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const locationId = 'YOUR_LOCATION_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const kmsKey = 'YOUR_KMS_KEY'
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Adding the endpoint to call the regional parameter manager server
+  const options = {
+    apiEndpoint: `parametermanager.${locationId}.rep.googleapis.com`,
+  };
+
+  // Instantiates a client with regional endpoint
+  const client = new ParameterManagerClient(options);
+
+  async function updateRegionalParamKmsKey() {
+    const name = client.parameterPath(projectId, locationId, parameterId);
+    const request = {
+      parameter: {
+        name: name,
+        kmsKey: kmsKey,
+      },
+      updateMask: {
+        paths: ['kms_key'],
+      },
+    };
+
+    const [parameter] = await client.updateParameter(request);
+    console.log(
+      `Updated regional parameter ${parameter.name} with kms_key ${parameter.kmsKey}`
+    );
+  }
+
+  await updateRegionalParamKmsKey();
+  // [END parametermanager_update_regional_param_kms_key]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parametermanager/removeParamKmsKey.js
+++ b/parametermanager/removeParamKmsKey.js
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Removes a kms_key for global parameter using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be updated.
+ * @param {string} parameterId - The ID of the parameter to update. This ID must be unique within the project.
+ */
+async function main(projectId = 'my-project', parameterId = 'my-parameter') {
+  // [START parametermanager_remove_param_kms_key]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function removeParamKmsKey() {
+    const name = client.parameterPath(projectId, 'global', parameterId);
+    const request = {
+      parameter: {
+        name: name,
+      },
+      updateMask: {
+        paths: ['kms_key'],
+      },
+    };
+
+    const [parameter] = await client.updateParameter(request);
+    console.log(`Removed kms_key for parameter ${parameter.name}`);
+  }
+
+  await removeParamKmsKey();
+  // [END parametermanager_remove_param_kms_key]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/parametermanager/test/.eslintrc.yaml
+++ b/parametermanager/test/.eslintrc.yaml
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+env:
+  mocha: true

--- a/parametermanager/test/parametermanager.test.js
+++ b/parametermanager/test/parametermanager.test.js
@@ -1,0 +1,288 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert} = require('chai');
+const cp = require('child_process');
+const {v4: uuidv4} = require('uuid');
+
+const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+const client = new ParameterManagerClient();
+
+let projectId;
+const locationId = process.env.GCLOUD_LOCATION || 'us-central1';
+const options = {};
+options.apiEndpoint = `parametermanager.${locationId}.rep.googleapis.com`;
+
+const regionalClient = new ParameterManagerClient(options);
+
+const {KeyManagementServiceClient} = require('@google-cloud/kms');
+const kmsClient = new KeyManagementServiceClient();
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+const parameterId = `test-parameter-${uuidv4()}`;
+const regionalParameterId = `test-regional-${uuidv4()}`;
+
+const keyRingId = 'node-test-kms-key';
+const keyId = `test-parameter-${uuidv4()}`;
+const keyId1 = `test-parameter-${uuidv4()}`;
+
+let parameter;
+let regionalParameter;
+
+const keyRing = `projects/${projectId}/locations/global/keyRings/${keyRingId}`;
+const kmsKey = `projects/${projectId}/locations/global/keyRings/${keyRingId}/cryptoKeys/${keyId}`;
+const kmsKey1 = `projects/${projectId}/locations/global/keyRings/${keyRingId}/cryptoKeys/${keyId1}`;
+
+const regionalKeyRing = `projects/${projectId}/locations/${locationId}/keyRings/${keyRingId}`;
+const regionalKmsKey = `projects/${projectId}/locations/${locationId}/keyRings/${keyRingId}/cryptoKeys/${keyId}`;
+const regionalKmsKey1 = `projects/${projectId}/locations/${locationId}/keyRings/${keyRingId}/cryptoKeys/${keyId1}`;
+
+describe('Parameter Manager samples', () => {
+  const parametersToDelete = [];
+  const regionalParametersToDelete = [];
+
+  before(async () => {
+    projectId = await client.getProjectId();
+
+    // Create a test global parameter
+    [parameter] = await client.createParameter({
+      parent: `projects/${projectId}/locations/global`,
+      parameterId: parameterId,
+      parameter: {
+        format: 'JSON',
+      },
+    });
+    parametersToDelete.push(parameter);
+
+    // Create a test regional parameter
+    [regionalParameter] = await regionalClient.createParameter({
+      parent: `projects/${projectId}/locations/${locationId}`,
+      parameterId: regionalParameterId,
+      parameter: {
+        format: 'JSON',
+      },
+    });
+    regionalParametersToDelete.push(regionalParameter);
+
+    try {
+      await client.getKeyRing({name: keyRing});
+    } catch (error) {
+      if (error.code === 5) {
+        await kmsClient.createKeyRing({
+          parent: kmsClient.locationPath(projectId, 'global'),
+          keyRingId: keyRingId,
+        });
+      }
+    }
+
+    try {
+      await client.getKeyRing({name: regionalKeyRing});
+    } catch (error) {
+      if (error.code === 5) {
+        await kmsClient.createKeyRing({
+          parent: kmsClient.locationPath(projectId, locationId),
+          keyRingId: keyRingId,
+        });
+      }
+    }
+
+    try {
+      await client.getCryptoKey({name: kmsKey});
+    } catch (error) {
+      if (error.code === 5) {
+        await kmsClient.createCryptoKey({
+          parent: kmsClient.keyRingPath(projectId, 'global', keyRingId),
+          cryptoKeyId: keyId,
+          cryptoKey: {
+            purpose: 'ASYMMETRIC_DECRYPT',
+            versionTemplate: {
+              algorithm: 'RSA_DECRYPT_OAEP_2048_SHA256',
+            },
+          },
+        });
+      }
+    }
+
+    try {
+      await client.getCryptoKey({name: regionalKmsKey});
+    } catch (error) {
+      if (error.code === 5) {
+        await kmsClient.createCryptoKey({
+          parent: kmsClient.keyRingPath(projectId, locationId, keyRingId),
+          cryptoKeyId: keyId,
+          cryptoKey: {
+            purpose: 'ASYMMETRIC_DECRYPT',
+            versionTemplate: {
+              algorithm: 'RSA_DECRYPT_OAEP_2048_SHA256',
+            },
+          },
+        });
+      }
+    }
+
+    try {
+      await client.getCryptoKey({name: kmsKey1});
+    } catch (error) {
+      if (error.code === 5) {
+        await kmsClient.createCryptoKey({
+          parent: kmsClient.keyRingPath(projectId, 'global', keyRingId),
+          cryptoKeyId: keyId1,
+          cryptoKey: {
+            purpose: 'ASYMMETRIC_DECRYPT',
+            versionTemplate: {
+              algorithm: 'RSA_DECRYPT_OAEP_2048_SHA256',
+            },
+          },
+        });
+      }
+    }
+
+    try {
+      await client.getCryptoKey({name: regionalKmsKey1});
+    } catch (error) {
+      if (error.code === 5) {
+        await kmsClient.createCryptoKey({
+          parent: kmsClient.keyRingPath(projectId, kmsKey1, keyRingId),
+          cryptoKeyId: keyId1,
+          cryptoKey: {
+            purpose: 'ASYMMETRIC_DECRYPT',
+            versionTemplate: {
+              algorithm: 'RSA_DECRYPT_OAEP_2048_SHA256',
+            },
+          },
+        });
+      }
+    }
+  });
+
+  after(async () => {
+    // Clean up
+    parametersToDelete.forEach(async parameterName => {
+      await client.deleteParameter({name: parameterName});
+    });
+
+    regionalParametersToDelete.forEach(async regionalParameterName => {
+      await regionalClient.deleteParameter({name: regionalParameterName});
+    });
+
+    try {
+      await kmsClient.destroyCryptoKeyVersion({
+        name: `${kmsKey}/cryptoKeyVersions/1`,
+      });
+    } catch (error) {
+      if (error.code === 5) {
+        console.info(`Already destroyed: ${error.message}`);
+      }
+    }
+
+    try {
+      await kmsClient.destroyCryptoKeyVersion({
+        name: `${kmsKey1}/cryptoKeyVersions/1`,
+      });
+    } catch (error) {
+      if (error.code === 5) {
+        console.error(`Already destroyed: ${error.message}`);
+      }
+    }
+
+    try {
+      await kmsClient.destroyCryptoKeyVersion({
+        name: `${regionalKmsKey}/cryptoKeyVersions/1`,
+      });
+    } catch (error) {
+      if (error.code === 5) {
+        console.error(`Already destroyed: ${error.message}`);
+      }
+    }
+
+    try {
+      await kmsClient.destroyCryptoKeyVersion({
+        name: `${regionalKmsKey1}/cryptoKeyVersions/1`,
+      });
+    } catch (error) {
+      if (error.code === 5) {
+        console.error(`Already destroyed: ${error.message}`);
+      }
+    }
+  });
+
+  it('should create a parameter with kms_key', async () => {
+    const output = execSync(
+      `node createParamWithKmsKey.js ${projectId} ${parameterId}-1 ${kmsKey}`
+    );
+    parametersToDelete.push(`${parameterId}-1`);
+    assert.include(
+      output,
+      `Created parameter projects/${projectId}/locations/global/parameters/${parameterId}-1 with kms_key ${kmsKey}`
+    );
+  });
+
+  it('should create a regional parameter with kms_key', async () => {
+    const output = execSync(
+      `node regional_samples/createRegionalParamWithKmsKey.js ${projectId} ${locationId} ${regionalParameterId}-1 ${regionalKmsKey}`
+    );
+    regionalParametersToDelete.push(`${regionalParameterId}-1`);
+    assert.include(
+      output,
+      `Created regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}-1 with kms_key ${regionalKmsKey}`
+    );
+  });
+
+  it('should update a parameter with kms_key', async () => {
+    const output = execSync(
+      `node updateParamKmsKey.js ${projectId} ${parameterId} ${kmsKey}`
+    );
+    parametersToDelete.push(`${parameterId}`);
+    assert.include(
+      output,
+      `Updated parameter projects/${projectId}/locations/global/parameters/${parameterId} with kms_key ${kmsKey}`
+    );
+  });
+
+  it('should update a regional parameter with kms_key', async () => {
+    const output = execSync(
+      `node regional_samples/updateRegionalParamKmsKey.js ${projectId} ${locationId} ${regionalParameterId} ${regionalKmsKey}`
+    );
+    regionalParametersToDelete.push(`${regionalParameterId}`);
+    assert.include(
+      output,
+      `Updated regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId} with kms_key ${regionalKmsKey}`
+    );
+  });
+
+  it('should remove a kms_key for parameter', async () => {
+    const output = execSync(
+      `node removeParamKmsKey.js ${projectId} ${parameterId} ${kmsKey}`
+    );
+    parametersToDelete.push(`${parameterId}`);
+    assert.include(
+      output,
+      `Removed kms_key for parameter projects/${projectId}/locations/global/parameters/${parameterId}`
+    );
+  });
+
+  it('should remove a kms_key for regional parameter', async () => {
+    const output = execSync(
+      `node regional_samples/removeRegionalParamKmsKey.js ${projectId} ${locationId} ${regionalParameterId} ${regionalKmsKey}`
+    );
+    regionalParametersToDelete.push(`${regionalParameterId}`);
+    assert.include(
+      output,
+      `Removed kms_key for regional parameter projects/${projectId}/locations/${locationId}/parameters/${regionalParameterId}`
+    );
+  });
+});

--- a/parametermanager/updateParamKmsKey.js
+++ b/parametermanager/updateParamKmsKey.js
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Updates a global parameter with kms_key using the Parameter Manager SDK.
+ *
+ * @param {string} projectId - The Google Cloud project ID where the parameter is to be updated.
+ * @param {string} parameterId - The ID of the parameter to update. This ID must be unique within the project.
+ * @param {string} kmsKey - The ID of the KMS key to be used for encryption.
+ */
+async function main(
+  projectId = 'my-project',
+  parameterId = 'my-parameter',
+  kmsKey = 'projects/my-project/locations/global/keyRings/my-key-ring/cryptoKeys/my-encryption-key'
+) {
+  // [START parametermanager_update_param_kms_key]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'YOUR_PROJECT_ID';
+  // const parameterId = 'YOUR_PARAMETER_ID';
+  // const kmsKey = 'YOUR_KMS_KEY'
+
+  // Imports the Parameter Manager library
+  const {ParameterManagerClient} = require('@google-cloud/parametermanager');
+
+  // Instantiates a client
+  const client = new ParameterManagerClient();
+
+  async function updateParamKmsKey() {
+    const name = client.parameterPath(projectId, 'global', parameterId);
+    const request = {
+      parameter: {
+        name: name,
+        kmsKey: kmsKey,
+      },
+      updateMask: {
+        paths: ['kms_key'],
+      },
+    };
+
+    const [parameter] = await client.updateParameter(request);
+    console.log(
+      `Updated parameter ${parameter.name} with kms_key ${parameter.kmsKey}`
+    );
+  }
+
+  await updateParamKmsKey();
+  // [END parametermanager_update_param_kms_key]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);


### PR DESCRIPTION
## Description
Created samples for the **KMS key** field in the global and regional parameter manager.

**Added Sample List:**

1. create_regional_param_with_kms_key
2. remove_regional_param_kms_key
3. update_regional_param_kms_key
4. create_param_with_kms_key
5. remove_param_kms_key
6. update_param_kms_key

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] These samples need a new **API enabled** in testing projects to pass (let us know which ones) - This requires [Parameter manager API](https://cloud.google.com/secret-manager/parameter-manager/docs/prepare-environment) to be enabled
- [X] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones) - This requires GCLOUD_LOCATION to be set otherwise it will use `us-central1`
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [X] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [X] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [X] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
