### PR TITLE
feat(cloudrun): Add service-to-service authentication sample

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-n": "^14.0.0",
     "eslint-plugin-prettier": "^5.0.0-alpha.1",
     "gts": "5.3.0",
+    "http-status-codes": "^2.3.0",
     "mocha": "^10.2.0",
     "nunjucks": "^3.2.4",
     "prettier": "^3.0.3",

--- a/run/service-auth/index.js
+++ b/run/service-auth/index.js
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const express = require('express');
+const {receiveRequestAndParseAuthHeader} = require('./receive');
+
+const app = express();
+
+app.get('/', async (req, res) => {
+  try {
+    const response = await receiveRequestAndParseAuthHeader(req);
+
+    const status = response.includes('Hello') ? 200 : 401;
+    res.status(status).send(response);
+  } catch (e) {
+    res.status(401).send(`Error verifying ID token: ${e.message}`);
+  }
+});
+
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});
+
+module.exports = app;

--- a/run/service-auth/package.json
+++ b/run/service-auth/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "service-auth",
+    "description": "Node.js samples for authenticated service-to-service communication",
+    "version": "0.0.1",
+    "private": true,
+    "license": "Apache-2.0",
+    "author": "Google LLC",
+    "engines": {
+        "node": "20.x"
+    },
+    "scripts": {
+        "start": "node index.js",
+        "deploy": "gcloud run deploy service-auth --source .",
+        "unit-test": "c8 mocha -p -j 2 test/ --timeout=10000 --exit",
+        "test": "npm run unit-test"
+    },
+    "dependencies": {
+        "express": "^4.17.1",
+        "google-auth-library": "^9.0.0"
+    },
+    "devDependencies": {
+        "c8": "^10.0.0",
+        "chai": "^4.5.0",
+        "mocha": "^10.0.0",
+        "sinon": "^18.0.0"
+    }
+}

--- a/run/service-auth/package.json
+++ b/run/service-auth/package.json
@@ -19,9 +19,11 @@
         "google-auth-library": "^9.0.0"
     },
     "devDependencies": {
+        "axios": "^1.8.4",
         "c8": "^10.0.0",
         "chai": "^4.5.0",
         "mocha": "^10.0.0",
-        "sinon": "^18.0.0"
+        "sinon": "^18.0.0",
+        "uuid": "^11.1.0"
     }
 }

--- a/run/service-auth/receive.js
+++ b/run/service-auth/receive.js
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(req) {
+  // [START auth_validate_and_decode_bearer_token_on_express]
+  // [START cloudrun_service_to_service_receive]
+  const {OAuth2Client} = require('google-auth-library');
+
+  const client = new OAuth2Client();
+
+  // Inner function that parses and verifies the token.
+  async function receiveRequestAndParseAuthHeader(request) {
+    const authHeader = request.headers.authorization;
+    if (authHeader) {
+      // Split the auth type and token value from the Authorization header.
+      const [type, token] = authHeader.split(' ');
+
+      if (type.toLowerCase() === 'bearer') {
+        // More info on verifyIdToken:
+        // https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/verifyIdToken-iap.js
+        try {
+          const ticket = await client.verifyIdToken({
+            idToken: token,
+            audience: process.env.CLIENT_ID,
+          });
+          const payload = ticket.getPayload();
+          console.log(`Hello, ${payload.email}!\n`);
+          return;
+        } catch (err) {
+          console.log(`Invalid token: ${err.message}\n`);
+          return;
+        }
+      } else {
+        console.log(`Unhandled header format(${type}).\n`);
+        return;
+      }
+    }
+
+    console.log('Hello, anonymous user.\n');
+  }
+
+  await receiveRequestAndParseAuthHeader(req);
+}
+// [END cloudrun_service_to_service_receive]
+// [END auth_validate_and_decode_bearer_token_on_express]
+
+module.exports = {main};

--- a/run/service-auth/test/receive.test.js
+++ b/run/service-auth/test/receive.test.js
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {expect} = require('chai');
+const sinon = require('sinon');
+const {OAuth2Client} = require('google-auth-library');
+const {main} = require('../receive');
+
+describe('receiveRequestAndParseAuthHeader sample', () => {
+  let verifyStub, consoleStub;
+
+  beforeEach(() => {
+    verifyStub = sinon.stub(OAuth2Client.prototype, 'verifyIdToken');
+    consoleStub = sinon.stub(console, 'log');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should log greeting if token is valid', async () => {
+    const mockReq = {
+      headers: {
+        authorization: 'Bearer valid-token',
+      },
+    };
+
+    verifyStub.resolves({
+      getPayload: () => ({email: 'test@example.com'}),
+    });
+
+    await main(mockReq);
+    expect(consoleStub.calledWith('Hello, test@example.com!\n')).to.be.true;
+  });
+
+  it('should log error message if token is invalid', async () => {
+    const mockReq = {
+      headers: {
+        authorization: 'Bearer invalid-token',
+      },
+    };
+
+    verifyStub.rejects(new Error('invalid'));
+
+    await main(mockReq);
+    expect(consoleStub.calledWithMatch(/Invalid token: invalid/)).to.be.true;
+  });
+
+  it('should log anonymous message if no auth header', async () => {
+    const mockReq = {
+      headers: {},
+    };
+
+    await main(mockReq);
+    expect(consoleStub.calledWith('Hello, anonymous user.\n')).to.be.true;
+  });
+
+  it('should log unhandled format message if auth is not bearer', async () => {
+    const mockReq = {
+      headers: {
+        authorization: 'Basic something',
+      },
+    };
+
+    await main(mockReq);
+    expect(consoleStub.calledWith('Unhandled header format (Basic).\n')).to.be
+      .true;
+  });
+});

--- a/run/service-auth/test/receive.test.js
+++ b/run/service-auth/test/receive.test.js
@@ -19,6 +19,7 @@ const axios = require('axios');
 const {execSync} = require('child_process');
 const {v4: uuidv4} = require('uuid');
 
+const INVALID_TOKEN = 'invalid-token';
 const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
 const REGION = 'us-central1';
 
@@ -84,7 +85,7 @@ describe('receiveRequestAndParseAuthHeader sample (Cloud Run integration)', func
     try {
       await axios.get(serviceUrl, {
         headers: {
-          Authorization: 'Bearer invalid-token',
+          Authorization: `Bearer ${INVALID_TOKEN}`,
         },
       });
     } catch (err) {

--- a/run/service-auth/test/receive.test.js
+++ b/run/service-auth/test/receive.test.js
@@ -14,69 +14,60 @@
 
 'use strict';
 
-const {expect} = require('chai');
+const { expect } = require('chai');
 const sinon = require('sinon');
-const {OAuth2Client} = require('google-auth-library');
-const {main} = require('../receive');
+const { OAuth2Client } = require('google-auth-library');
+const { main } = require('../receive');
+
+const TEST_VALID_TOKEN = 'test-valid-token';
+const TEST_INVALID_TOKEN = 'test-invalid-token';
 
 describe('receiveRequestAndParseAuthHeader sample', () => {
-  let verifyStub, consoleStub;
+    let verifyStub, consoleStub;
 
-  beforeEach(() => {
-    verifyStub = sinon.stub(OAuth2Client.prototype, 'verifyIdToken');
-    consoleStub = sinon.stub(console, 'log');
-  });
-
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  it('should log greeting if token is valid', async () => {
-    const mockReq = {
-      headers: {
-        authorization: 'Bearer valid-token',
-      },
-    };
-
-    verifyStub.resolves({
-      getPayload: () => ({email: 'test@example.com'}),
+    beforeEach(() => {
+        verifyStub = sinon.stub(OAuth2Client.prototype, 'verifyIdToken');
+        consoleStub = sinon.stub(console, 'log');
     });
 
-    await main(mockReq);
-    expect(consoleStub.calledWith('Hello, test@example.com!\n')).to.be.true;
-  });
+    afterEach(() => {
+        sinon.restore();
+    });
 
-  it('should log error message if token is invalid', async () => {
-    const mockReq = {
-      headers: {
-        authorization: 'Bearer invalid-token',
-      },
-    };
+    it('should log greeting if token is valid', async () => {
+        const mockReq = {
+            headers: {
+                authorization: `Bearer ${TEST_VALID_TOKEN}`,
+            },
+        };
 
-    verifyStub.rejects(new Error('invalid'));
+        verifyStub.resolves({
+            getPayload: () => ({ email: 'test@example.com' }),
+        });
 
-    await main(mockReq);
-    expect(consoleStub.calledWithMatch(/Invalid token: invalid/)).to.be.true;
-  });
+        await main(mockReq);
+        expect(consoleStub.calledWith('Hello, test@example.com!\n')).to.be.true;
+    });
 
-  it('should log anonymous message if no auth header', async () => {
-    const mockReq = {
-      headers: {},
-    };
+    it('should log error message if token is invalid', async () => {
+        const mockReq = {
+            headers: {
+                authorization: `Bearer ${TEST_INVALID_TOKEN}`,
+            },
+        };
 
-    await main(mockReq);
-    expect(consoleStub.calledWith('Hello, anonymous user.\n')).to.be.true;
-  });
+        verifyStub.rejects(new Error('invalid'));
 
-  it('should log unhandled format message if auth is not bearer', async () => {
-    const mockReq = {
-      headers: {
-        authorization: 'Basic something',
-      },
-    };
+        await main(mockReq);
+        expect(consoleStub.calledWithMatch(/Invalid token: invalid/)).to.be.true;
+    });
 
-    await main(mockReq);
-    expect(consoleStub.calledWith('Unhandled header format (Basic).\n')).to.be
-      .true;
-  });
+    it('should log anonymous message if no auth header', async () => {
+        const mockReq = {
+            headers: {},
+        };
+
+        await main(mockReq);
+        expect(consoleStub.calledWith('Hello, anonymous user.\n')).to.be.true;
+    });
 });

--- a/run/service-auth/test/receive.test.js
+++ b/run/service-auth/test/receive.test.js
@@ -18,8 +18,9 @@ const {expect} = require('chai');
 const axios = require('axios');
 const {execSync} = require('child_process');
 const {v4: uuidv4} = require('uuid');
+const {StatusCodes} = require('http-status-codes');
 
-const INVALID_TOKEN = 'invalid-token';
+const TEST_INVALID_TOKEN = 'test-invalid-token';
 const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
 const REGION = 'us-central1';
 
@@ -71,25 +72,25 @@ describe('receiveRequestAndParseAuthHeader sample (Cloud Run integration)', func
       },
     });
 
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(StatusCodes.OK);
     expect(res.data).to.match(/^Hello, .@.\.\w+!\n$/);
   });
 
   it('should respond with anonymous if no token is provided', async () => {
     const res = await axios.get(serviceUrl);
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(StatusCodes.OK);
     expect(res.data).to.equal('Hello, anonymous user.\n');
   });
 
-  it('should respond with 401 if token is invalid', async () => {
+  it('should respond with unoauthorized if token is invalid', async () => {
     try {
       await axios.get(serviceUrl, {
         headers: {
-          Authorization: `Bearer ${INVALID_TOKEN}`,
+          Authorization: `Bearer ${TEST_INVALID_TOKEN}`,
         },
       });
     } catch (err) {
-      expect(err.response.status).to.equal(401);
+      expect(err.response.status).to.equal(StatusCodes.UNAUTHORIZED);
       expect(err.response.data).to.include('Invalid token');
     }
   });


### PR DESCRIPTION
## Description

Fixes b/409547854

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] Please **merge** this PR for me once it is approved
