### PR TITLE
chore: update custard to v0.2.5

### DIFF
--- a/.github/workflows/custard-ci-dev.yaml
+++ b/.github/workflows/custard-ci-dev.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: GoogleCloudPlatform/cloud-samples-tools
-          ref: v0.2.1
+          ref: v0.2.5
           path: cloud-samples-tools
       - name: Create `bin` directory for cloud-samples-tools binaries
         run: mkdir bin

--- a/.github/workflows/custard-ci.yaml
+++ b/.github/workflows/custard-ci.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: GoogleCloudPlatform/cloud-samples-tools
-          ref: v0.2.1
+          ref: v0.2.5
           path: cloud-samples-tools
       - name: Create `bin` directory for cloud-samples-tools binaries
         run: mkdir bin

--- a/.github/workflows/custard-run-dev.yaml
+++ b/.github/workflows/custard-run-dev.yaml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   affected:
-    uses: GoogleCloudPlatform/cloud-samples-tools/.github/workflows/affected.yaml@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+    uses: GoogleCloudPlatform/cloud-samples-tools/.github/workflows/affected.yaml@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
     permissions:
       statuses: write
     with:
@@ -73,7 +73,7 @@ jobs:
       GOOGLE_SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
     steps:
       - name: Check queued
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         id: queued
         with:
           sha: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
@@ -81,7 +81,7 @@ jobs:
           job-name: ${{ github.job }} (${{ matrix.path }})
           if: ${{ !!github.event.workflow_run }}
       - name: Setup Custard
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/setup-custard@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/setup-custard@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           path: ${{ matrix.path }}
           ci-setup: ${{ toJson(fromJson(needs.affected.outputs.ci-setups)[matrix.path]) }}
@@ -89,7 +89,7 @@ jobs:
           workload-identity-provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
           service-account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
       - name: Check in_progress
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         id: in_progress
         with:
           check: ${{ steps.queued.outputs.check }}
@@ -99,12 +99,12 @@ jobs:
           timeout ${{ fromJson(needs.affected.outputs.ci-setups)[matrix.path].timeout-minutes }}m \
             make test dir=${{ matrix.path }}
       - name: Check success
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           check: ${{ steps.in_progress.outputs.check }}
           status: success
       - name: Check failure
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         if: failure()
         with:
           check: ${{ steps.in_progress.outputs.check }}
@@ -118,7 +118,7 @@ jobs:
       statuses: write
     steps:
       - name: Check success
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           check: ${{ needs.affected.outputs.check }}
           status: success

--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -50,7 +50,7 @@ on:
 
 jobs:
   affected:
-    uses: GoogleCloudPlatform/cloud-samples-tools/.github/workflows/affected.yaml@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+    uses: GoogleCloudPlatform/cloud-samples-tools/.github/workflows/affected.yaml@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
     permissions:
       statuses: write
     with:
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check in_progress
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         id: in_progress
         with:
           sha: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
@@ -83,17 +83,17 @@ jobs:
           node-version: 20
       - run: npm install
       - name: npx gtx lint (${{ needs.affected.outputs.num-paths }} packages)
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/map-run@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/map-run@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           command: npx gts lint
           paths: ${{ needs.affected.outputs.paths }}
       - name: Check success
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           check: ${{ steps.in_progress.outputs.check }}
           status: success
       - name: Check failure
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         if: failure()
         with:
           check: ${{ steps.in_progress.outputs.check }}
@@ -117,7 +117,7 @@ jobs:
       GOOGLE_SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
     steps:
       - name: Check queued
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         id: queued
         with:
           sha: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
@@ -125,7 +125,7 @@ jobs:
           job-name: ${{ github.job }} (${{ matrix.path }})
           if: ${{ !!github.event.workflow_run }}
       - name: Setup Custard
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/setup-custard@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/setup-custard@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           path: ${{ matrix.path }}
           ci-setup: ${{ toJson(fromJson(needs.affected.outputs.ci-setups)[matrix.path]) }}
@@ -133,7 +133,7 @@ jobs:
           workload-identity-provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
           service-account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
       - name: Check in_progress
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         id: in_progress
         with:
           check: ${{ steps.queued.outputs.check }}
@@ -143,12 +143,12 @@ jobs:
           timeout ${{ fromJson(needs.affected.outputs.ci-setups)[matrix.path].timeout-minutes }}m \
             make test dir=${{ matrix.path }}
       - name: Check success
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           check: ${{ steps.in_progress.outputs.check }}
           status: success
       - name: Check failure
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         if: failure()
         with:
           check: ${{ steps.in_progress.outputs.check }}
@@ -162,7 +162,7 @@ jobs:
       statuses: write
     steps:
       - name: Check success
-        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@967334777b636ec212c32bf60e69b6635971b593 # v0.2.3
+        uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@34b34881006f34d210c4af9d0f7ba9b2d681621d # v0.2.5
         with:
           check: ${{ needs.affected.outputs.check }}
           status: success


### PR DESCRIPTION
## Description

Addresses issues in #4067

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
