### PR TITLE
chore(grpc): migrate from grpc to @grpc/grpc-js in getting-started-grpc example

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -13,9 +13,28 @@ $ node server.js -p 50051
 ```
 
 ### Run the client
+For running the client locally, you'll need either an API key or a JWT auth token:
+
+#### Using a JWT token (recommended for local development)
+You can generate a development-only JWT token using Google Cloud CLI:
+
 ```
-$ node client.js -h localhost:50051
+$ gcloud auth print-identity-token
 ```
+See [print-identity-token](https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token) for more info.
+
+Then run the client using this token:
+```
+$ node client.js -h localhost:50051 -j YOUR_JWT_TOKEN
+```
+
+#### Using an API key
+Alternatively, you can use an API key from your Google Cloud project:
+```
+$ node client.js -h localhost:50051 -k YOUR_API_KEY
+```
+
+You can create API keys in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
 
 ## Running on Google Cloud Platform
 ### Setup

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -21,7 +21,7 @@ You can generate a development-only JWT token using Google Cloud CLI:
 ```
 $ gcloud auth print-identity-token
 ```
-See [print-identity-token](https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token) for more info.
+See [get-id-token#generic-dev](https://cloud.google.com/docs/authentication/get-id-token#generic-dev) for more info.
 
 Then run the client using this token:
 ```

--- a/endpoints/getting-started-grpc/client.js
+++ b/endpoints/getting-started-grpc/client.js
@@ -23,12 +23,22 @@ const makeGrpcRequest = (JWT_AUTH_TOKEN, API_KEY, HOST, GREETEE) => {
   // const GREETEE = 'world';
 
   // Import required libraries
-  const grpc = require('grpc');
+  const grpc = require('@grpc/grpc-js');
+  const protoLoader = require('@grpc/proto-loader');
   const path = require('path');
 
   // Load protobuf spec for an example API
   const PROTO_PATH = path.join(__dirname, '/protos/helloworld.proto');
-  const protoObj = grpc.load(PROTO_PATH).helloworld;
+
+  const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  });
+
+  const protoObj = grpc.loadPackageDefinition(packageDefinition).helloworld;
 
   // Create a client for the protobuf spec
   const client = new protoObj.Greeter(HOST, grpc.credentials.createInsecure());

--- a/endpoints/getting-started-grpc/package.json
+++ b/endpoints/getting-started-grpc/package.json
@@ -17,7 +17,8 @@
     "test": "mocha --exit system-test/*.test.js --timeout=60000"
   },
   "dependencies": {
-    "grpc": "^1.18.0",
+    "@grpc/grpc-js": "^1.13.3",
+    "@grpc/proto-loader": "^0.7.15",
     "yargs": "^17.0.0"
   },
   "devDependencies": {
@@ -26,4 +27,3 @@
     "wait-port": "^1.0.4"
   }
 }
-

--- a/endpoints/getting-started-grpc/server.js
+++ b/endpoints/getting-started-grpc/server.js
@@ -42,7 +42,7 @@ const startServer = PORT => {
     `0.0.0.0:${PORT}`,
     grpc.ServerCredentials.createInsecure(),
     () => {
-      server.start();
+      console.log(`gRPC server started on port ${PORT}`);
     }
   );
 };

--- a/endpoints/getting-started-grpc/server.js
+++ b/endpoints/getting-started-grpc/server.js
@@ -17,8 +17,17 @@
 const path = require('path');
 const PROTO_PATH = path.join(__dirname, '/protos/helloworld.proto');
 
-const grpc = require('grpc');
-const helloProto = grpc.load(PROTO_PATH).helloworld;
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require('@grpc/proto-loader');
+
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+const helloProto = grpc.loadPackageDefinition(packageDefinition).helloworld;
 
 // Implement the SayHello RPC method.
 const sayHello = (call, callback) => {
@@ -28,9 +37,14 @@ const sayHello = (call, callback) => {
 // Start an RPC server to handle Greeter service requests
 const startServer = PORT => {
   const server = new grpc.Server();
-  server.addProtoService(helloProto.Greeter.service, {sayHello: sayHello});
-  server.bind(`0.0.0.0:${PORT}`, grpc.ServerCredentials.createInsecure());
-  server.start();
+  server.addService(helloProto.Greeter.service, {sayHello: sayHello});
+  server.bindAsync(
+    `0.0.0.0:${PORT}`,
+    grpc.ServerCredentials.createInsecure(),
+    () => {
+      server.start();
+    }
+  );
 };
 
 // The command-line program


### PR DESCRIPTION
## Description

Fixes b/410998134


## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] Please **merge** this PR for me once it is approved
