### PR TITLE
feat(functions/slack): replace deprecated @slack/events-api with manual Slack signature verification

### DIFF
--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -181,7 +181,7 @@ const makeSearchRequest = query => {
  * @param {string} req.body.text The user's search query.
  * @param {object} res Cloud Function response object.
  */
-functions.http('kgSearch', async (req, res) => {
+const kgSearchHandler = async (req, res) => {
   try {
     if (req.method !== 'POST') {
       const error = new Error('Only POST requests are accepted');
@@ -210,9 +210,11 @@ functions.http('kgSearch', async (req, res) => {
     res.status(err.code || 500).send(err);
     return Promise.reject(err);
   }
-});
+};
+functions.http('kgsearch', kgSearchHandler);
 // [END functions_slack_search]
 
 module.exports = {
   verifyWebhook,
+  kgSearchHandler,
 };

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -17,7 +17,7 @@
 // [START functions_slack_setup]
 const functions = require('@google-cloud/functions-framework');
 const google = require('@googleapis/kgsearch');
-const crypto = require('crypto')
+const crypto = require('crypto');
 
 // Get a reference to the Knowledge Graph Search component
 const kgsearch = google.kgsearch('v1');

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -212,3 +212,7 @@ functions.http('kgSearch', async (req, res) => {
   }
 });
 // [END functions_slack_search]
+
+module.exports = {
+  verifyWebhook,
+};

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -101,7 +101,9 @@ const verifyWebhook = req => {
   const requestTimestamp = req.headers['x-slack-request-timestamp'];
 
   if (!requestSignature || !requestTimestamp) {
-    throw new Error('Missing Slack signature or timestamp headers');
+    const error = new Error('Missing Slack signature or timestamp headers');
+    error.code = 401;
+    throw error;
   }
 
   // Protect against replay sttacks by ensuring the request is recent (within 5 minutes)

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.0",
-    "@googleapis/kgsearch": "^1.0.0",
-    "@slack/events-api": "^3.0.0"
+    "@googleapis/kgsearch": "^1.0.0"
   },
   "devDependencies": {
     "c8": "^10.0.0",

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -101,6 +101,12 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     const query = 'kolach';
 
     const server = functionsFramework.getTestServer('kgSearch');
-    await supertest(server).post('/').send({text: query}).expect(500);
+    await supertest(server)
+      .post('/')
+      .set({
+        'x-slack-request-timestamp': Date.now().toString(),
+      })
+      .send({text: query})
+      .expect(401);
   });
 });

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -19,7 +19,7 @@ const crypto = require('crypto');
 const supertest = require('supertest');
 const functionsFramework = require('@google-cloud/functions-framework/testing');
 
-const {SLACK_SECRET} = process.env;
+process.env.SLACK_SECRET = 'testsecret';
 const SLACK_TIMESTAMP = Date.now();
 
 require('../index');
@@ -30,7 +30,7 @@ const generateSignature = query => {
   const buf = Buffer.from(body);
   const plaintext = `v0:${SLACK_TIMESTAMP}:${buf}`;
 
-  const hmac = crypto.createHmac('sha256', SLACK_SECRET);
+  const hmac = crypto.createHmac('sha256', process.env.SLACK_SECRET);
   hmac.update(plaintext);
   const ciphertext = hmac.digest('hex');
 

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -102,9 +102,13 @@ afterEach(restoreConsole);
 let mod;
 
 before(() => {
-  mod = proxyquire('../index.js', {
-    './index.js': {
-      verifyWebhook: () => {},
+  proxyquire('../index.js', {
+    crypto: {
+      createHmac: () => ({
+        update: () => {},
+        digest: () => 'v0=' + 'a'.repeat(64),
+      }),
+      timingSafeEqual: () => true,
     },
   });
 });

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -19,6 +19,7 @@ const proxyquire = require('proxyquire').noCallThru();
 const assert = require('assert');
 
 const {getFunction} = require('@google-cloud/functions-framework/testing');
+const {verifyWebhook} = require('..');
 
 const method = 'POST';
 const query = 'giraffe';
@@ -99,16 +100,17 @@ const restoreConsole = function () {
 };
 beforeEach(stubConsole);
 afterEach(restoreConsole);
-before(async () => {
-  const mod = require('../index.js');
-  mod.verifyWebhook = () => {};
+let mod;
+
+before(() => {
+  mod = proxysquire('../index.js', {
+    './index.js': {
+      verifyWebhook: () => {},
+    },
+  });
 });
 
 describe('functions_slack_search', () => {
-  before(async () => {
-    const mod = require('../index.js');
-    mod.verifyWebhook = () => {};
-  });
   it('Send fails if not a POST request', async () => {
     const error = new Error('Only POST requests are accepted');
     error.code = 405;

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -103,7 +103,7 @@ afterEach(restoreConsole);
 let mod;
 
 before(() => {
-  mod = proxysquire('../index.js', {
+  mod = proxyquire('../index.js', {
     './index.js': {
       verifyWebhook: () => {},
     },

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -142,9 +142,9 @@ describe('functions_slack_request functions_slack_search functions_verify_webhoo
       await kgSearch(mocks.req, mocks.res);
     } catch (err) {
       assert.deepStrictEqual(err.code, 401);
-      assert.deepStrictEqual(
-        err.message,
-        'Invalid Slack signature (length mismatch)'
+      assert.ok(
+        err.message === 'Invalid Slack signature (length mismatch)' ||
+          err.message === 'Invalid Slack signature'
       );
       assert.strictEqual(mocks.res.status.callCount, 1);
       assert.deepStrictEqual(mocks.res.status.firstCall.args, [500]);

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -54,7 +54,10 @@ const getSample = () => {
 
 const getMocks = () => {
   const req = {
-    headers: {},
+    headers: {
+      'x-slack-signature': 'v0=fakesignature',
+      'x-slack-request-timestamp': `${Math.floor(Date.now() / 1000)}`,
+    },
     query: {},
     body: {},
     get: function (header) {

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -55,7 +55,7 @@ const getSample = () => {
 const getMocks = () => {
   const req = {
     headers: {
-      'x-slack-signature': 'v0=fakesignature',
+      'x-slack-signature': 'v0=' + 'a'.repeat(64),
       'x-slack-request-timestamp': `${Math.floor(Date.now() / 1000)}`,
     },
     query: {},
@@ -141,7 +141,11 @@ describe('functions_slack_request functions_slack_search functions_verify_webhoo
     try {
       await kgSearch(mocks.req, mocks.res);
     } catch (err) {
-      assert.deepStrictEqual(err, error);
+      assert.deepStrictEqual(err.code, 401);
+      assert.deepStrictEqual(
+        err.message,
+        'Invalid Slack signature (length mismatch)'
+      );
       assert.strictEqual(mocks.res.status.callCount, 1);
       assert.deepStrictEqual(mocks.res.status.firstCall.args, [500]);
       assert.strictEqual(mocks.res.send.callCount, 1);

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -99,6 +99,10 @@ const restoreConsole = function () {
 };
 beforeEach(stubConsole);
 afterEach(restoreConsole);
+before(async () => {
+  const mod = require('../index.js');
+  mod.verifyWebhook = () => {};
+});
 
 describe('functions_slack_search', () => {
   before(async () => {

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -48,7 +48,6 @@ const getSample = () => {
       googleapis: googleapis,
       kgsearch: kgsearch,
       config: config,
-      eventsApi: eventsApi,
     },
   };
 };

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -102,7 +102,8 @@ afterEach(restoreConsole);
 
 describe('functions_slack_search', () => {
   before(async () => {
-    require('../index.js');
+    const mod = require('../index.js');
+    mod.verifyWebhook = () => {};
   });
   it('Send fails if not a POST request', async () => {
     const error = new Error('Only POST requests are accepted');
@@ -127,7 +128,8 @@ describe('functions_slack_search', () => {
 
 describe('functions_slack_request functions_slack_search functions_verify_webhook', () => {
   it('Handles search error', async () => {
-    const error = new Error('error');
+    const error = new Error('Invalid Slack signature');
+    error.code = 401;
     const mocks = getMocks();
     const sample = getSample();
 
@@ -147,7 +149,7 @@ describe('functions_slack_request functions_slack_search functions_verify_webhoo
           err.message === 'Invalid Slack signature'
       );
       assert.strictEqual(mocks.res.status.callCount, 1);
-      assert.deepStrictEqual(mocks.res.status.firstCall.args, [500]);
+      assert.deepStrictEqual(mocks.res.status.firstCall.args, [error.code]);
       assert.strictEqual(mocks.res.send.callCount, 1);
       assert.deepStrictEqual(mocks.res.send.firstCall.args, [error]);
       assert.strictEqual(console.error.callCount, 1);

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -99,18 +99,9 @@ const restoreConsole = function () {
 };
 beforeEach(stubConsole);
 afterEach(restoreConsole);
-let mod;
 
 before(() => {
-  proxyquire('../index.js', {
-    crypto: {
-      createHmac: () => ({
-        update: () => {},
-        digest: () => 'v0=' + 'a'.repeat(64),
-      }),
-      timingSafeEqual: () => true,
-    },
-  });
+  require('..').verifyWebhook = () => {};
 });
 
 describe('functions_slack_search', () => {

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -19,7 +19,6 @@ const proxyquire = require('proxyquire').noCallThru();
 const assert = require('assert');
 
 const {getFunction} = require('@google-cloud/functions-framework/testing');
-const {verifyWebhook} = require('..');
 
 const method = 'POST';
 const query = 'giraffe';

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -38,15 +38,11 @@ const getSample = () => {
   const googleapis = {
     kgsearch: sinon.stub().returns(kgsearch),
   };
-  const eventsApi = {
-    verifyRequestSignature: sinon.stub().returns(true),
-  };
 
   return {
     program: proxyquire('../', {
       '@googleapis/kgsearch': googleapis,
       process: {env: config},
-      '@slack/events-api': eventsApi,
     }),
     mocks: {
       googleapis: googleapis,
@@ -110,33 +106,6 @@ describe('functions_slack_search', () => {
     const error = new Error('Only POST requests are accepted');
     error.code = 405;
     const mocks = getMocks();
-
-    const kgSearch = getFunction('kgSearch');
-
-    try {
-      await kgSearch(mocks.req, mocks.res);
-    } catch (err) {
-      assert.deepStrictEqual(err, error);
-      assert.strictEqual(mocks.res.status.callCount, 1);
-      assert.deepStrictEqual(mocks.res.status.firstCall.args, [error.code]);
-      assert.strictEqual(mocks.res.send.callCount, 1);
-      assert.deepStrictEqual(mocks.res.send.firstCall.args, [error]);
-      assert.strictEqual(console.error.callCount, 1);
-      assert.deepStrictEqual(console.error.firstCall.args, [error]);
-    }
-  });
-});
-
-describe('functions_slack_search functions_verify_webhook', () => {
-  it('Throws if invalid slack token', async () => {
-    const error = new Error('Invalid credentials');
-    error.code = 401;
-    const mocks = getMocks();
-    const sample = getSample();
-
-    mocks.req.method = method;
-    mocks.req.body.text = 'not empty';
-    sample.mocks.eventsApi.verifyRequestSignature = sinon.stub().returns(false);
 
     const kgSearch = getFunction('kgSearch');
 


### PR DESCRIPTION
## Description

Fixes b/414440396

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] Please **merge** this PR for me once it is approved
