### PR TITLE
fix: rename service account env var

### DIFF
--- a/.github/workflows/custard-run-dev.yaml
+++ b/.github/workflows/custard-run-dev.yaml
@@ -70,7 +70,7 @@ jobs:
     continue-on-error: true
     env:
       GOOGLE_SAMPLES_PROJECT: long-door-651
-      GOOGLE_SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
+      SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
     steps:
       - name: Check queued
         uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@9ee708234e240605d96e78f652c333ed6aa95a23 # v0.3.2
@@ -88,7 +88,7 @@ jobs:
         with:
           project_id: ${{ env.GOOGLE_SAMPLES_PROJECT }}
           workload_identity_provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-          service_account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s # 10 minutes
           token_format: id_token
           id_token_audience: https://action.test/ # service must have this custom audience

--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -114,7 +114,7 @@ jobs:
     continue-on-error: true
     env:
       GOOGLE_SAMPLES_PROJECT: long-door-651
-      GOOGLE_SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
+      SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
     steps:
       - name: Check queued
         uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@9ee708234e240605d96e78f652c333ed6aa95a23 # v0.3.2
@@ -132,7 +132,7 @@ jobs:
         with:
           project_id: ${{ env.GOOGLE_SAMPLES_PROJECT }}
           workload_identity_provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-          service_account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s # 10 minutes
           token_format: id_token
           id_token_audience: https://action.test/ # service must have this custom audience


### PR DESCRIPTION
## Description

Cloud Run tests expect the service account variable be named `SERVICE_ACCOUNT`. The setup-custard action doesn't include an input to pass and re-export the variable, but that will go away with the self-contained runner. Renaming it to `SERVICE_ACCOUNT` is also what the self-contained runner expects.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
