### PR TITLE
fix: pass service account directly to run step

### DIFF
--- a/.github/workflows/custard-run-dev.yaml
+++ b/.github/workflows/custard-run-dev.yaml
@@ -70,7 +70,7 @@ jobs:
     continue-on-error: true
     env:
       GOOGLE_SAMPLES_PROJECT: long-door-651
-      GOOGLE_SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
+      SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
     steps:
       - name: Check queued
         uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@9ee708234e240605d96e78f652c333ed6aa95a23 # v0.3.2
@@ -88,7 +88,7 @@ jobs:
         with:
           project_id: ${{ env.GOOGLE_SAMPLES_PROJECT }}
           workload_identity_provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-          service_account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s # 10 minutes
           token_format: id_token
           id_token_audience: https://action.test/ # service must have this custom audience

--- a/.github/workflows/custard-run-dev.yaml
+++ b/.github/workflows/custard-run-dev.yaml
@@ -109,6 +109,9 @@ jobs:
         run: |
           timeout ${{ fromJson(needs.affected.outputs.ci-setups)[matrix.path].timeout-minutes }}m \
             make test dir=${{ matrix.path }}
+        env:
+          # TODO: remove this when the self-contained runner lands.
+          SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
       - name: Check success
         uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@9ee708234e240605d96e78f652c333ed6aa95a23 # v0.3.2
         with:

--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -114,7 +114,7 @@ jobs:
     continue-on-error: true
     env:
       GOOGLE_SAMPLES_PROJECT: long-door-651
-      GOOGLE_SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
+      SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
     steps:
       - name: Check queued
         uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/create-check@9ee708234e240605d96e78f652c333ed6aa95a23 # v0.3.2
@@ -132,7 +132,7 @@ jobs:
         with:
           project_id: ${{ env.GOOGLE_SAMPLES_PROJECT }}
           workload_identity_provider: projects/1046198160504/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-          service_account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s # 10 minutes
           token_format: id_token
           id_token_audience: https://action.test/ # service must have this custom audience

--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -153,6 +153,9 @@ jobs:
         run: |
           timeout ${{ fromJson(needs.affected.outputs.ci-setups)[matrix.path].timeout-minutes }}m \
             make test dir=${{ matrix.path }}
+        env:
+          # TODO: remove this when the self-contained runner lands.
+          SERVICE_ACCOUNT: kokoro-system-test@long-door-651.iam.gserviceaccount.com
       - name: Check success
         uses: GoogleCloudPlatform/cloud-samples-tools/actions/steps/update-check@9ee708234e240605d96e78f652c333ed6aa95a23 # v0.3.2
         with:


### PR DESCRIPTION
## Description

It turns out that [`setup-custard`](https://github.com/GoogleCloudPlatform/cloud-samples-tools/blob/v0.3.2/actions/steps/setup-custard/action.yaml) overrides and clears up the SERVICE_ACCOUNT variable.
Even though the input is referenced, it's not defined and can't be passed.

This will no longer be an issue when https://github.com/GoogleCloudPlatform/cloud-samples-tools/pull/49 merges, and it will handle the environment variables as expected.

Once that merges, we can get rid of the `setup-custard` action altogether.
Instead of going through the whole cycle of fixing that action and releasing a new version, we pass the SERVICE_ACCOUNT directly to the step running the tests as a workaround.
This can go away once we use the TS runner.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
