### PR TITLE
chore(ci): migrate ai-platform/snippets

### DIFF
--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -77,6 +77,7 @@
     "recaptcha_enterprise/demosite/app", // no tests exist
 
     // These tests are already passing in prod, so skip them in dev.
+    "ai-platform/snippets",
     "appengine/building-an-app/build",
     "appengine/building-an-app/update",
     "appengine/datastore",

--- a/.github/config/nodejs.jsonc
+++ b/.github/config/nodejs.jsonc
@@ -75,7 +75,6 @@
     "recaptcha_enterprise/demosite/app", // no tests exist
 
     // TODO: fix these
-    "ai-platform/snippets", // PERMISSION_DENIED: Permission denied: Consumer 'projects/undefined' has been suspended.
     "automl", // (untested) FAILED_PRECONDITION: Google Cloud AutoML Natural Language was retired on March 15, 2024. Please migrate to Vertex AI instead
     "cloud-sql/sqlserver/tedious", // (untested) TypeError: The "config.server" property is required and must be of type string.
     "compute", // GoogleError: The resource 'projects/long-door-651/zones/us-central1-a/disks/disk-from-pool-name' was not found

--- a/ai-platform/snippets/ci-setup.json
+++ b/ai-platform/snippets/ci-setup.json
@@ -1,4 +1,5 @@
 {
+  "timeout-minutes": 20,
   "secrets": {
     "CAIP_PROJECT_ID": "nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id"
   }

--- a/ai-platform/snippets/ci-setup.json
+++ b/ai-platform/snippets/ci-setup.json
@@ -1,0 +1,5 @@
+{
+  "secrets": {
+    "CAIP_PROJECT_ID": "nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id"
+  }
+}

--- a/ai-platform/snippets/expensive-test/create-data-labeling-job-image.test.js
+++ b/ai-platform/snippets/expensive-test/create-data-labeling-job-image.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/expensive-test/create-data-labeling-job-video.test.js
+++ b/ai-platform/snippets/expensive-test/create-data-labeling-job-video.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/expensive-test/create-data-labeling-job.test.js
+++ b/ai-platform/snippets/expensive-test/create-data-labeling-job.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/expensive-test/get-training-pipeline.test.js
+++ b/ai-platform/snippets/expensive-test/get-training-pipeline.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/expensive-test/import-data-text-entity-extraction.test.js
+++ b/ai-platform/snippets/expensive-test/import-data-text-entity-extraction.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/expensive-test/import-data-text-sentiment-analysis.test.js
+++ b/ai-platform/snippets/expensive-test/import-data-text-sentiment-analysis.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/expensive-test/import-data-video-object-tracking.test.js
+++ b/ai-platform/snippets/expensive-test/import-data-video-object-tracking.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/gemma2PredictGpu.js
+++ b/ai-platform/snippets/gemma2PredictGpu.js
@@ -65,7 +65,7 @@ async function gemma2PredictGpu(predictionServiceClient) {
   return text;
 }
 
-module.exports = gemma2PredictGpu;
+export default gemma2PredictGpu;
 
 // TODO(developer): Uncomment below lines before running the sample.
 // gemma2PredictGpu(...process.argv.slice(2)).catch(err => {

--- a/ai-platform/snippets/gemma2PredictTpu.js
+++ b/ai-platform/snippets/gemma2PredictTpu.js
@@ -68,7 +68,7 @@ async function gemma2PredictTpu(predictionServiceClient) {
   return text;
 }
 
-module.exports = gemma2PredictTpu;
+export default gemma2PredictTpu;
 
 // TODO(developer): Uncomment below lines before running the sample.
 // gemma2PredictTpu(...process.argv.slice(2)).catch(err => {

--- a/ai-platform/snippets/imagen-edit-image-inpainting-insert-mask.js
+++ b/ai-platform/snippets/imagen-edit-image-inpainting-insert-mask.js
@@ -44,8 +44,8 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function editImageInpaintingInsertMask() {
-    const fs = require('fs');
-    const util = require('util');
+    const fs = require('node:fs');
+    const util = require('node:util');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagegeneration@006`;
 

--- a/ai-platform/snippets/imagen-edit-image-inpainting-remove-mask.js
+++ b/ai-platform/snippets/imagen-edit-image-inpainting-remove-mask.js
@@ -44,8 +44,8 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function editImageInpaintingRemoveMask() {
-    const fs = require('fs');
-    const util = require('util');
+    const fs = require('node:fs');
+    const util = require('node:util');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagegeneration@006`;
 

--- a/ai-platform/snippets/imagen-edit-image-mask-free.js
+++ b/ai-platform/snippets/imagen-edit-image-mask-free.js
@@ -43,8 +43,8 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function editImageMaskFree() {
-    const fs = require('fs');
-    const util = require('util');
+    const fs = require('node:fs');
+    const util = require('node:util');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagegeneration@002`;
 

--- a/ai-platform/snippets/imagen-edit-image-outpainting-mask.js
+++ b/ai-platform/snippets/imagen-edit-image-outpainting-mask.js
@@ -44,8 +44,8 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function editImageOutpaintingMask() {
-    const fs = require('fs');
-    const util = require('util');
+    const fs = require('node:fs');
+    const util = require('node:util');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagegeneration@006`;
 

--- a/ai-platform/snippets/imagen-generate-image.js
+++ b/ai-platform/snippets/imagen-generate-image.js
@@ -42,8 +42,8 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function generateImage() {
-    const fs = require('fs');
-    const util = require('util');
+    const fs = require('node:fs');
+    const util = require('node:util');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagen-3.0-generate-001`;
 

--- a/ai-platform/snippets/imagen-get-short-form-image-captions.js
+++ b/ai-platform/snippets/imagen-get-short-form-image-captions.js
@@ -42,7 +42,7 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function getShortFormImageCaptions() {
-    const fs = require('fs');
+    const fs = require('node:fs');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagetext@001`;
 

--- a/ai-platform/snippets/imagen-get-short-form-image-responses.js
+++ b/ai-platform/snippets/imagen-get-short-form-image-responses.js
@@ -44,7 +44,7 @@ async function main() {
   const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
   async function getShortFormImageResponses() {
-    const fs = require('fs');
+    const fs = require('node:fs');
     // Configure the parent resource
     const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagetext@001`;
 

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -10,7 +10,7 @@
     "*.js"
   ],
   "scripts": {
-    "test": "c8 mocha -p -j 2 --timeout 2400000 test/*.js"
+    "test": "c8 mocha -p -j 2 --timeout 2400000 test/*.js --reporter list"
   },
   "dependencies": {
     "@google-cloud/aiplatform": "^3.0.0",

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -13,16 +13,16 @@
     "test": "c8 mocha -p -j 2 --timeout 2400000 test/*.js --reporter list"
   },
   "dependencies": {
-    "@google-cloud/aiplatform": "^3.0.0",
-    "@google-cloud/bigquery": "^7.0.0",
+    "@google-cloud/aiplatform": "^4.0.0",
+    "@google-cloud/bigquery": "^8.0.0",
     "@google-cloud/storage": "^7.0.0"
   },
   "devDependencies": {
     "c8": "^10.0.0",
-    "chai": "^4.5.0",
-    "mocha": "^10.0.0",
-    "uuid": "^10.0.0",
-    "sinon": "^18.0.0"
+    "chai": "^5.0.0",
+    "mocha": "^11.0.0",
+    "uuid": "^11.0.0",
+    "sinon": "^20.0.0"
   }
 }
 

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "type": "module",
   "engines": {
     "node": ">=16.0.0"
   },
@@ -25,4 +26,3 @@
     "sinon": "^20.0.0"
   }
 }
-

--- a/ai-platform/snippets/predict-custom-trained-model.js
+++ b/ai-platform/snippets/predict-custom-trained-model.js
@@ -27,8 +27,8 @@ async function main(filename, endpointId, project, location = 'us-central1') {
   // const endpointId = "YOUR_ENDPOINT_ID";
   // const project = 'YOUR_PROJECT_ID';
   // const location = 'YOUR_PROJECT_LOCATION';
-  const util = require('util');
-  const {readFile} = require('fs');
+  const util = require('node:util');
+  const {readFile} = require('node:fs');
   const readFileAsync = util.promisify(readFile);
 
   // Imports the Google Cloud Prediction Service Client library

--- a/ai-platform/snippets/predict-image-classification.js
+++ b/ai-platform/snippets/predict-image-classification.js
@@ -52,7 +52,7 @@ function main(filename, endpointId, project, location = 'us-central1') {
     });
     const parameters = parametersObj.toValue();
 
-    const fs = require('fs');
+    const fs = require('node:fs');
     const image = fs.readFileSync(filename, 'base64');
     const instanceObj = new instance.ImageClassificationPredictionInstance({
       content: image,

--- a/ai-platform/snippets/predict-image-from-image-and-text.js
+++ b/ai-platform/snippets/predict-image-from-image-and-text.js
@@ -54,7 +54,7 @@ async function main(
     // Configure the parent resource
     const endpoint = `projects/${project}/locations/${location}/publishers/${publisher}/models/${model}`;
 
-    const fs = require('fs');
+    const fs = require('node:fs');
     const imageFile = fs.readFileSync(baseImagePath);
 
     // Convert the image data to a Buffer and base64 encode it.
@@ -95,4 +95,4 @@ async function main(
   // [END generativeaionvertexai_sdk_text_image_embedding]
 }
 
-exports.predictImageFromImageAndText = main;
+export {main as predictImageFromImageAndText};

--- a/ai-platform/snippets/predict-image-object-detection.js
+++ b/ai-platform/snippets/predict-image-object-detection.js
@@ -52,7 +52,7 @@ async function main(filename, endpointId, project, location = 'us-central1') {
     });
     const parameters = parametersObj.toValue();
 
-    const fs = require('fs');
+    const fs = require('node:fs');
     const image = fs.readFileSync(filename, 'base64');
     const instanceObj = new instance.ImageObjectDetectionPredictionInstance({
       content: image,

--- a/ai-platform/snippets/test/batch-prediction-gemini.test.js
+++ b/ai-platform/snippets/test/batch-prediction-gemini.test.js
@@ -16,12 +16,12 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const cp = require('child_process');
-const {JobServiceClient} = require('@google-cloud/aiplatform');
+import { assert } from 'chai';
+import { after, describe, it } from 'mocha';
+import { execSync as _execSync } from 'child_process';
+import { JobServiceClient } from '@google-cloud/aiplatform';
 
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => _execSync(cmd, {encoding: 'utf-8'});
 
 describe('Batch predict with Gemini', async () => {
   const projectId = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/batch-prediction-gemini.test.js
+++ b/ai-platform/snippets/test/batch-prediction-gemini.test.js
@@ -18,7 +18,7 @@
 
 import { assert } from 'chai';
 import { after, describe, it } from 'mocha';
-import { execSync as _execSync } from 'child_process';
+import { execSync as _execSync } from 'node:child_process';
 import { JobServiceClient } from '@google-cloud/aiplatform';
 
 const execSync = cmd => _execSync(cmd, {encoding: 'utf-8'});

--- a/ai-platform/snippets/test/create-batch-prediction-job-text-classification.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-text-classification.test.js
@@ -16,18 +16,18 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+import { assert } from 'chai';
+import { after, describe, it } from 'mocha';
+import { v4 as uuid } from 'uuid';
+import { execSync as _execSync } from 'child_process';
+const execSync = cmd => _execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import { v1 } from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };
 
-const jobServiceClient = new aiplatform.v1.JobServiceClient(clientOptions);
+const jobServiceClient = new v1.JobServiceClient(clientOptions);
 
 const batchPredictionDisplayName = `temp_create_batch_prediction_text_classification_test${uuid()}`;
 const modelId = '7827432074230366208';

--- a/ai-platform/snippets/test/create-batch-prediction-job-text-classification.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-text-classification.test.js
@@ -19,7 +19,7 @@
 import { assert } from 'chai';
 import { after, describe, it } from 'mocha';
 import { v4 as uuid } from 'uuid';
-import { execSync as _execSync } from 'child_process';
+import { execSync as _execSync } from 'node:child_process';
 const execSync = cmd => _execSync(cmd, {encoding: 'utf-8'});
 
 import { v1 } from '@google-cloud/aiplatform';

--- a/ai-platform/snippets/test/create-batch-prediction-job-text-entity-extraction.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-text-entity-extraction.test.js
@@ -16,13 +16,13 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-batch-prediction-job-text-sentiment-analysis.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-text-sentiment-analysis.test.js
@@ -16,13 +16,13 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-batch-prediction-job-video-classification.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-video-classification.test.js
@@ -16,15 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-batch-prediction-job-video-object-tracking.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-video-object-tracking.test.js
@@ -16,15 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-custom-job.test.js
+++ b/ai-platform/snippets/test/create-custom-job.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-dataset-image.test.js
+++ b/ai-platform/snippets/test/create-dataset-image.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-dataset-tabular-bigquery.test.js
+++ b/ai-platform/snippets/test/create-dataset-tabular-bigquery.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-dataset-tabular-gcs.test.js
+++ b/ai-platform/snippets/test/create-dataset-tabular-gcs.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-dataset-text.test.js
+++ b/ai-platform/snippets/test/create-dataset-text.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-dataset-video.test.js
+++ b/ai-platform/snippets/test/create-dataset-video.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-dataset.test.js
+++ b/ai-platform/snippets/test/create-dataset.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-endpoint.test.js
+++ b/ai-platform/snippets/test/create-endpoint.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/create-featurestore-fixed-nodes-sample.test.js
+++ b/ai-platform/snippets/test/create-featurestore-fixed-nodes-sample.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const {assert} = require('chai');
+import {assert} from 'chai';
 const {FeaturestoreServiceClient} = require('@google-cloud/aiplatform').v1;
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const project = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/create-featurestore-sample.test.js
+++ b/ai-platform/snippets/test/create-featurestore-sample.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const {assert} = require('chai');
+import {assert} from 'chai';
 const {FeaturestoreServiceClient} = require('@google-cloud/aiplatform').v1;
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const project = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/create-hyperparameter-tuning-job.test.js
+++ b/ai-platform/snippets/test/create-hyperparameter-tuning-job.test.js
@@ -16,14 +16,13 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-image-classification.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-image-classification.test.js
@@ -16,14 +16,13 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-image-object-detection.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-image-object-detection.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-tabular-classification.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-tabular-classification.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-tabular-regression.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-tabular-regression.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-text-entity-extraction.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-text-entity-extraction.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-text-sentiment-analysis.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-text-sentiment-analysis.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-video-action-recognition.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-video-action-recognition.test.js
@@ -16,14 +16,13 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-video-classification.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-video-classification.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/create-training-pipeline-video-object-tracking.test.js
+++ b/ai-platform/snippets/test/create-training-pipeline-video-object-tracking.test.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
-const aiplatform = require('@google-cloud/aiplatform');
+import aiplatform from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };

--- a/ai-platform/snippets/test/deploy-model.test.js
+++ b/ai-platform/snippets/test/deploy-model.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const endpointDisplayName = `temp_create_endpoint_test_${uuid()}`;

--- a/ai-platform/snippets/test/embedding-model-tuning.test.js
+++ b/ai-platform/snippets/test/embedding-model-tuning.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-const aiplatform = require('@google-cloud/aiplatform');
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import aiplatform from '@google-cloud/aiplatform';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/entity-type-samples.test.js
+++ b/ai-platform/snippets/test/entity-type-samples.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const {assert} = require('chai');
+import {assert} from 'chai';
 const {FeaturestoreServiceClient} = require('@google-cloud/aiplatform').v1;
-const {after, before, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {after, before, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const project = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/export-model-tabular-classification.test.js
+++ b/ai-platform/snippets/test/export-model-tabular-classification.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/feature-samples.test.js
+++ b/ai-platform/snippets/test/feature-samples.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const {assert} = require('chai');
+import {assert} from 'chai';
 const {FeaturestoreServiceClient} = require('@google-cloud/aiplatform').v1;
-const {after, before, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {after, before, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const project = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/feature-values-samples.test.js
+++ b/ai-platform/snippets/test/feature-values-samples.test.js
@@ -16,12 +16,12 @@
 
 'use strict';
 
-const {BigQuery} = require('@google-cloud/bigquery');
+import {BigQuery} from '@google-cloud/bigquery';
 const {FeaturestoreServiceClient} = require('@google-cloud/aiplatform').v1;
-const {assert} = require('chai');
-const {after, before, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, before, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const project = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/featurestore-samples.test.js
+++ b/ai-platform/snippets/test/featurestore-samples.test.js
@@ -16,10 +16,10 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, before, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import {assert} from 'chai';
+import {after, before, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const project = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/gemma2Prediction.test.js
+++ b/ai-platform/snippets/test/gemma2Prediction.test.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const {expect} = require('chai');
-const {afterEach, describe, it} = require('mocha');
-const sinon = require('sinon');
-const gemma2PredictGpu = require('../gemma2PredictGpu.js');
-const gemma2PredictTpu = require('../gemma2PredictTpu.js');
+import {expect} from 'chai';
+import {afterEach, describe, it} from 'mocha';
+import sinon from 'sinon';
+import gemma2PredictGpu from '../gemma2PredictGpu.js';
+import gemma2PredictTpu from '../gemma2PredictTpu.js';
 
 const gpuResponse = `The sky appears blue due to a phenomenon called **Rayleigh scattering**.
 **Here's how it works:**

--- a/ai-platform/snippets/test/get-custom-job.test.js
+++ b/ai-platform/snippets/test/get-custom-job.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-hyperparameter-tuning-job.test.js
+++ b/ai-platform/snippets/test/get-hyperparameter-tuning-job.test.js
@@ -16,10 +16,9 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const tuningJobId = '2216298782247616512';

--- a/ai-platform/snippets/test/get-model-evaluation-slice.test.js
+++ b/ai-platform/snippets/test/get-model-evaluation-slice.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-model-evaluation-tabular-classification.test.js
+++ b/ai-platform/snippets/test/get-model-evaluation-tabular-classification.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-model-evaluation-tabular-regression.test.js
+++ b/ai-platform/snippets/test/get-model-evaluation-tabular-regression.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-model-evaluation-video-action-recognition.test.js
+++ b/ai-platform/snippets/test/get-model-evaluation-video-action-recognition.test.js
@@ -16,10 +16,9 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const modelId = '3530998029718913024';

--- a/ai-platform/snippets/test/get-model-evaluation-video-classification.test.js
+++ b/ai-platform/snippets/test/get-model-evaluation-video-classification.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-model-evaluation-video-object-tracking.test.js
+++ b/ai-platform/snippets/test/get-model-evaluation-video-object-tracking.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-model.test.js
+++ b/ai-platform/snippets/test/get-model.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/get-training-pipeline.test.js
+++ b/ai-platform/snippets/test/get-training-pipeline.test.js
@@ -16,10 +16,9 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const trainingPipelineId = '1419759782528548864';

--- a/ai-platform/snippets/test/imagen.test.js
+++ b/ai-platform/snippets/test/imagen.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/import-data-video-classification.test.js
+++ b/ai-platform/snippets/test/import-data-video-classification.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/list-endpoints.test.js
+++ b/ai-platform/snippets/test/list-endpoints.test.js
@@ -15,11 +15,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 

--- a/ai-platform/snippets/test/list-model-evaluation-slices.test.js
+++ b/ai-platform/snippets/test/list-model-evaluation-slices.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/predict-image-from-image-and-text.test.js
+++ b/ai-platform/snippets/test/predict-image-from-image-and-text.test.js
@@ -16,13 +16,10 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-const sinon = require('sinon');
-
-const {
-  predictImageFromImageAndText,
-} = require('../predict-image-from-image-and-text');
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import sinon from 'sinon';
+import {predictImageFromImageAndText} from '../predict-image-from-image-and-text.js';
 
 const project = process.env.CAIP_PROJECT_ID;
 const LOCATION = 'us-central1';

--- a/ai-platform/snippets/test/predict-image-object-detection.test.js
+++ b/ai-platform/snippets/test/predict-image-object-detection.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/predict-tabular-classification.test.js
+++ b/ai-platform/snippets/test/predict-tabular-classification.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/predict-tabular-regression.test.js
+++ b/ai-platform/snippets/test/predict-tabular-regression.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/predict-text-classification.test.js
+++ b/ai-platform/snippets/test/predict-text-classification.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/predict-text-embeddings.test.js
+++ b/ai-platform/snippets/test/predict-text-embeddings.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/predict-text-entity-extraction.test.js
+++ b/ai-platform/snippets/test/predict-text-entity-extraction.test.js
@@ -16,11 +16,10 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
-
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 

--- a/ai-platform/snippets/test/upload-model.test.js
+++ b/ai-platform/snippets/test/upload-model.test.js
@@ -16,12 +16,11 @@
 
 'use strict';
 
-const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-
-const uuid = require('uuid').v4;
-const cp = require('child_process');
+import path from 'node:path';
+import {assert} from 'chai';
+import {after, describe, it} from 'mocha';
+import {v4 as uuid} from 'uuid';
+import cp from 'node:child_process';
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 


### PR DESCRIPTION
Experiment to migrate CJS to ESM, adding `"type": "module"` to package.json.

```sh
cd ai-platform/snippets
npx eslint-cjs-to-esm "**/*.js" --fix
npx lebab --replace . --transform commonjs
```

- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
