### PR TITLE
chore(ci): migrate ai-platform/snippets via Node 16

### DIFF
--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -77,6 +77,7 @@
     "recaptcha_enterprise/demosite/app", // no tests exist
 
     // These tests are already passing in prod, so skip them in dev.
+    "ai-platform/snippets",
     "appengine/building-an-app/build",
     "appengine/building-an-app/update",
     "appengine/datastore",

--- a/.github/config/nodejs.jsonc
+++ b/.github/config/nodejs.jsonc
@@ -75,7 +75,6 @@
     "recaptcha_enterprise/demosite/app", // no tests exist
 
     // TODO: fix these
-    "ai-platform/snippets", // PERMISSION_DENIED: Permission denied: Consumer 'projects/undefined' has been suspended.
     "automl", // (untested) FAILED_PRECONDITION: Google Cloud AutoML Natural Language was retired on March 15, 2024. Please migrate to Vertex AI instead
     "cloud-sql/sqlserver/tedious", // (untested) TypeError: The "config.server" property is required and must be of type string.
     "compute", // GoogleError: The resource 'projects/long-door-651/zones/us-central1-a/disks/disk-from-pool-name' was not found

--- a/ai-platform/snippets/ci-setup.json
+++ b/ai-platform/snippets/ci-setup.json
@@ -1,4 +1,5 @@
 {
+  "timeout-minutes": 20,
   "secrets": {
     "CAIP_PROJECT_ID": "nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id"
   }

--- a/ai-platform/snippets/ci-setup.json
+++ b/ai-platform/snippets/ci-setup.json
@@ -1,0 +1,5 @@
+{
+  "secrets": {
+    "CAIP_PROJECT_ID": "nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id"
+  }
+}

--- a/ai-platform/snippets/ci-setup.json
+++ b/ai-platform/snippets/ci-setup.json
@@ -2,5 +2,6 @@
   "timeout-minutes": 20,
   "secrets": {
     "CAIP_PROJECT_ID": "nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id"
-  }
+  },
+  "node-version": "16"
 }

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -10,7 +10,7 @@
     "*.js"
   ],
   "scripts": {
-    "test": "c8 mocha -p -j 2 --timeout 2400000 test/*.js"
+    "test": "c8 mocha -p -j 2 --timeout 2400000 test/*.js --reporter list"
   },
   "dependencies": {
     "@google-cloud/aiplatform": "^3.0.0",

--- a/ai-platform/snippets/package.json
+++ b/ai-platform/snippets/package.json
@@ -13,16 +13,16 @@
     "test": "c8 mocha -p -j 2 --timeout 2400000 test/*.js --reporter list"
   },
   "dependencies": {
-    "@google-cloud/aiplatform": "^3.0.0",
-    "@google-cloud/bigquery": "^7.0.0",
+    "@google-cloud/aiplatform": "^4.0.0",
+    "@google-cloud/bigquery": "^8.0.0",
     "@google-cloud/storage": "^7.0.0"
   },
   "devDependencies": {
     "c8": "^10.0.0",
-    "chai": "^4.5.0",
-    "mocha": "^10.0.0",
-    "uuid": "^10.0.0",
-    "sinon": "^18.0.0"
+    "chai": "^5.0.0",
+    "mocha": "^11.0.0",
+    "uuid": "^11.0.0",
+    "sinon": "^20.0.0"
   }
 }
 

--- a/ai-platform/snippets/test/batch-prediction-gemini.test.js
+++ b/ai-platform/snippets/test/batch-prediction-gemini.test.js
@@ -16,12 +16,12 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const cp = require('child_process');
-const {JobServiceClient} = require('@google-cloud/aiplatform');
+import { assert } from 'chai';
+import { after, describe, it } from 'mocha';
+import { execSync as _execSync } from 'child_process';
+import { JobServiceClient } from '@google-cloud/aiplatform';
 
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => _execSync(cmd, {encoding: 'utf-8'});
 
 describe('Batch predict with Gemini', async () => {
   const projectId = process.env.CAIP_PROJECT_ID;

--- a/ai-platform/snippets/test/create-batch-prediction-job-text-classification.test.js
+++ b/ai-platform/snippets/test/create-batch-prediction-job-text-classification.test.js
@@ -16,18 +16,18 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
-const uuid = require('uuid').v4;
-const cp = require('child_process');
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+import { assert } from 'chai';
+import { after, describe, it } from 'mocha';
+import { v4 as uuid } from 'uuid';
+import { execSync as _execSync } from 'child_process';
+const execSync = cmd => _execSync(cmd, {encoding: 'utf-8'});
 
-const aiplatform = require('@google-cloud/aiplatform');
+import { v1 } from '@google-cloud/aiplatform';
 const clientOptions = {
   apiEndpoint: 'us-central1-aiplatform.googleapis.com',
 };
 
-const jobServiceClient = new aiplatform.v1.JobServiceClient(clientOptions);
+const jobServiceClient = new v1.JobServiceClient(clientOptions);
 
 const batchPredictionDisplayName = `temp_create_batch_prediction_text_classification_test${uuid()}`;
 const modelId = '7827432074230366208';


### PR DESCRIPTION
Based from https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/4100

Experiment to downgrade to Node 16 to avoid CJS errors.

- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
