### PR TITLE
fix: standardize getSecret sample

### DIFF
--- a/secret-manager/getSecret.js
+++ b/secret-manager/getSecret.js
@@ -26,7 +26,6 @@ const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
 async function getSecret(projectId, secretId) {
   const client = new SecretManagerServiceClient();
   const name = `projects/${projectId}/secrets/${secretId}`;
-  
   try {
     const [secret] = await client.getSecret({
       name: name,
@@ -37,7 +36,6 @@ async function getSecret(projectId, secretId) {
       console.info(
         `Found secret ${secret.name} with replication policy ${policy}`
       );
-
     } else {
       console.info(`Found secret ${secret.name} with no replication policy.`);
     }
@@ -60,7 +58,6 @@ async function main() {
 if (require.main === module) {
   main().catch(err => {
     console.error(err.message);
-    process.exit(1);
   });
 }
 

--- a/secret-manager/getSecret.js
+++ b/secret-manager/getSecret.js
@@ -41,7 +41,7 @@ async function getSecret(projectId, secretId) {
     }
     return secret;
   } catch (err) {
-    console.error('Failed to retrieve secret ${name}:', err);
+    console.error(`Failed to retrieve secret ${name}:`, err);
   } finally {
     await client.close();
   }

--- a/secret-manager/test/secretmanager.test.js
+++ b/secret-manager/test/secretmanager.test.js
@@ -316,8 +316,8 @@ describe('Secret Manager samples', () => {
     assert.match(output, new RegExp(`${regionalSecret.name}`));
   });
 
-  it('gets a secret', async () => {
-    const output = execSync(`node getSecret.js ${secret.name}`);
+  it('gets metadata about a secret', async () => {
+    const output = execSync(`node getSecret.js ${projectId} ${secretId}`);
     assert.match(output, new RegExp(`Found secret ${secret.name}`));
   });
 


### PR DESCRIPTION
## Description

Adds consistency; try/catch; 

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
