### PR TITLE
chore(secretmanager): add regional code samples for delayed destroy

### DIFF
--- a/secret-manager/regional_samples/createRegionalSecretWithDelayedDestroy.js
+++ b/secret-manager/regional_samples/createRegionalSecretWithDelayedDestroy.js
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, locationId, secretId, timeToLive) {
+  // [START secretmanager_create_regional_secret_with_delayed_destroy]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const project = 'my-project';
+  // const locationId = 'my-location';
+  // const secretId = 'my-secret';
+  // const timeToLive = 86400;
+  const parent = `projects/${projectId}/locations/${locationId}`;
+
+  // Imports the Secret Manager library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Adding the endpoint to call the regional secret manager sever
+  const options = {};
+  options.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient(options);
+
+  async function createRegionalSecretWithDelayedDestroy() {
+    const [secret] = await client.createSecret({
+      parent: parent,
+      secretId: secretId,
+      secret: {
+        version_destroy_ttl: {
+          seconds: timeToLive,
+        },
+      },
+    });
+
+    console.log(`Created regional secret ${secret.name}`);
+  }
+
+  createRegionalSecretWithDelayedDestroy();
+  // [END secretmanager_create_regional_secret_with_delayed_destroy]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/regional_samples/disableRegionalSecretDelayedDestroy.js
+++ b/secret-manager/regional_samples/disableRegionalSecretDelayedDestroy.js
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, locationId, secretId) {
+  // [START secretmanager_disable_regional_secret_delayed_destroy]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'my-location';
+  // const secretId = 'my-secret';
+  const name = `projects/${projectId}/locations/${locationId}/secrets/${secretId}`;
+
+  // Imports the Secret Manager library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Adding the endpoint to call the regional secret manager sever
+  const options = {};
+  options.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient(options);
+
+  async function disableRegionalSecretDelayedDestroy() {
+    const [secret] = await client.updateSecret({
+      secret: {
+        name: name,
+      },
+      updateMask: {
+        paths: ['version_destroy_ttl'],
+      },
+    });
+
+    console.info(`Disabled delayed destroy ${secret.name}`);
+  }
+
+  disableRegionalSecretDelayedDestroy();
+  // [END secretmanager_disable_regional_secret_delayed_destroy]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/regional_samples/updateRegionalSecretWithDelayedDestroy.js
+++ b/secret-manager/regional_samples/updateRegionalSecretWithDelayedDestroy.js
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(
+  projectId, locationId, secretId, updatedTimeToLive
+) {
+  // [START secretmanager_update_regional_secret_with_delayed_destroy]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'my-location';
+  // const secretId = 'my-secret';
+  // const updatedTimeToLive = 86400;
+  const name = `projects/${projectId}/locations/${locationId}/secrets/${secretId}`;
+
+  // Imports the Secret Manager library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Adding the endpoint to call the regional secret manager sever
+  const options = {};
+  options.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient(options);
+
+  async function updateRegionalSecret() {
+    const [secret] = await client.updateSecret({
+      secret: {
+        name: name,
+        version_destroy_ttl: {
+          seconds: updatedTimeToLive,
+        },
+      },
+      updateMask: {
+        paths: ['version_destroy_ttl'],
+      },
+    });
+
+    console.info(`Updated regional secret ${secret.name}`);
+  }
+
+  updateRegionalSecret();
+  // [END secretmanager_update_regional_secret_with_delayed_destroy]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/test/secretmanager.test.js
+++ b/secret-manager/test/secretmanager.test.js
@@ -599,4 +599,54 @@ describe('Secret Manager samples', () => {
       name: `${secret.name}-delayedDestroy`,
     });
   });
+
+  it('creates a regional secret with delayed destroy', async () => {
+    const timeToLive = 24 * 60 * 60;
+    const output = execSync(
+      `node regional_samples/createRegionalSecretWithDelayedDestroy.js ${projectId} ${locationId} ${secretId}-2-dd ${timeToLive}`
+    );
+    assert.match(output, new RegExp('Created regional secret'));
+  });
+
+  it('disables a regional secret delayed destroy', async () => {
+    await regionalClient.createSecret({
+      parent: `projects/${projectId}/locations/${locationId}`,
+      secretId: `${secretId}-delayedDestroy`,
+      secret: {
+        version_destroy_ttl: {
+          seconds: 24 * 60 * 60,
+        },
+      },
+    });
+
+    const output = execSync(
+      `node regional_samples/disableRegionalSecretDelayedDestroy.js ${projectId} ${locationId} ${secretId}-delayedDestroy`
+    );
+    assert.match(output, new RegExp('Disabled delayed destroy'));
+
+    await regionalClient.deleteSecret({
+      name: `projects/${projectId}/locations/${locationId}/secrets/${secretId}-delayedDestroy`,
+    });
+  });
+
+  it('updates a regional secret delayed destroy', async () => {
+    const updatedTimeToLive = 24 * 60 * 60 * 2;
+    await regionalClient.createSecret({
+      parent: `projects/${projectId}/locations/${locationId}`,
+      secretId: `${secretId}-delayedDestroy`,
+      secret: {
+        version_destroy_ttl: {
+          seconds: 24 * 60 * 60,
+        },
+      },
+    });
+
+    const output = execSync(
+      `node regional_samples/updateRegionalSecretWithDelayedDestroy.js ${projectId} ${locationId} ${secretId}-delayedDestroy ${updatedTimeToLive}`
+    );
+    assert.match(output, new RegExp('Updated regional secret'));
+    await regionalClient.deleteSecret({
+      name: `projects/${projectId}/locations/${locationId}/secrets/${secretId}-delayedDestroy`,
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes - N/A

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] These samples need a new **API enabled** in testing projects to pass - N/A
- [X] These samples need a new/updated **env vars** in testing projects set to pass - N/A
- [X] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [X] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample - N/A
- [X] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample - N/A
- [X] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample - N/A
- [X] Please **merge** this PR for me once it is approved
