### PR TITLE
feat(secretmanager): Added samples for tags field

### DIFF
--- a/secret-manager/bindTagsToSecret.js
+++ b/secret-manager/bindTagsToSecret.js
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, secretId, tagValue) {
+  // [START secretmanager_bind_tags_to_secret]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const secretId = 'my-secret';
+  // const tagValue = 'tagValues/281476592621530';
+  const parent = `projects/${projectId}`;
+
+  // Imports the library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+  const {TagBindingsClient} = require('@google-cloud/resource-manager').v3;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient();
+  const resourcemanagerClient = new TagBindingsClient();
+
+  async function bindTagsToSecret() {
+    const [secret] = await client.createSecret({
+      parent: parent,
+      secretId: secretId,
+      secret: {
+        replication: {
+          automatic: {},
+        },
+      },
+    });
+
+    console.log(`Created secret ${secret.name}`);
+
+    const [operation] = await resourcemanagerClient.createTagBinding({
+      tagBinding: {
+        parent: `//secretmanager.googleapis.com/${secret.name}`,
+        tagValue: tagValue,
+      },
+    });
+    const [response] = await operation.promise();
+    console.log('Created Tag Binding', response.name);
+  }
+
+  bindTagsToSecret();
+  // [END secretmanager_bind_tags_to_secret]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/createSecretWithTags.js
+++ b/secret-manager/createSecretWithTags.js
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, secretId, tagKey, tagValue) {
+  // [START secretmanager_create_secret_with_tags]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const secretId = 'my-secret';
+  // const tagKey = 'tagKeys/281475012216835';
+  // const tagValue = 'tagValues/281476592621530';
+  const parent = `projects/${projectId}`;
+
+  // Imports the library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient();
+
+  async function createSecretWithTags() {
+    const [secret] = await client.createSecret({
+      parent: parent,
+      secretId: secretId,
+      secret: {
+        replication: {
+          automatic: {},
+        },
+        tags: {
+          [tagKey]: tagValue,
+        },
+      },
+    });
+
+    console.log(`Created secret ${secret.name}`);
+  }
+
+  createSecretWithTags();
+  // [END secretmanager_create_secret_with_tags]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/package.json
+++ b/secret-manager/package.json
@@ -14,7 +14,8 @@
     "test": "c8 mocha -p -j 2 --recursive test/ --timeout=800000"
   },
   "dependencies": {
-    "@google-cloud/secret-manager": "^5.6.0"
+    "@google-cloud/secret-manager": "^6.1.0",
+    "@google-cloud/resource-manager": "^6.2.0"
   },
   "devDependencies": {
     "c8": "^10.0.0",

--- a/secret-manager/regional_samples/bindTagsToRegionalSecret.js
+++ b/secret-manager/regional_samples/bindTagsToRegionalSecret.js
@@ -1,0 +1,65 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, locationId, secretId, tagValue) {
+  // [START secretmanager_bind_tags_to_regional_secret]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'my-location';
+  // const secretId = 'my-secret';
+  // const tagValue = 'tagValues/281476592621530';
+  const parent = `projects/${projectId}/locations/${locationId}`;
+
+  // Imports the library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+  const {TagBindingsClient} = require('@google-cloud/resource-manager').v3;
+
+  // Adding the endpoint to call the regional
+  const options = {};
+  const bindingOptions = {};
+  options.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+  bindingOptions.apiEndpoint = `${locationId}-cloudresourcemanager.googleapis.com`;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient(options);
+  const resourcemanagerClient = new TagBindingsClient(bindingOptions);
+
+  async function bindTagsToRegionalSecret() {
+    const [secret] = await client.createSecret({
+      parent: parent,
+      secretId: secretId,
+    });
+
+    console.log(`Created secret ${secret.name}`);
+
+    const [operation] = await resourcemanagerClient.createTagBinding({
+      tagBinding: {
+        parent: `//secretmanager.googleapis.com/${secret.name}`,
+        tagValue: tagValue,
+      },
+    });
+    const [response] = await operation.promise();
+    console.log('Created Tag Binding', response.name);
+  }
+
+  bindTagsToRegionalSecret();
+  // [END secretmanager_bind_tags_to_regional_secret]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/regional_samples/createRegionalSecretWithTags.js
+++ b/secret-manager/regional_samples/createRegionalSecretWithTags.js
@@ -1,0 +1,58 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, locationId, secretId, tagKey, tagValue) {
+  // [START secretmanager_create_regional_secret_with_tags]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project';
+  // const locationId = 'my-location';
+  // const secretId = 'my-secret';
+  // const tagKey = 'tagKeys/281475012216835';
+  // const tagValue = 'tagValues/281476592621530';
+  const parent = `projects/${projectId}/locations/${locationId}`;
+
+  // Imports the library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Adding the endpoint to call the regional secret manager sever
+  const options = {};
+  options.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient(options);
+
+  async function createRegionalSecretWithTags() {
+    const [secret] = await client.createSecret({
+      parent: parent,
+      secretId: secretId,
+      secret: {
+        tags: {
+          [tagKey]: tagValue,
+        },
+      },
+    });
+
+    console.log(`Created secret ${secret.name}`);
+  }
+
+  createRegionalSecretWithTags();
+  // [END secretmanager_create_regional_secret_with_tags]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);


### PR DESCRIPTION
## Description

Created samples for Global and Regional Secret Manager API

#### Samples (Global, Regional)

1. Create Secret With Tags
2. Bind Tags to Secret

Ref: https://cloud.google.com/secret-manager/docs/create-and-manage-tags 

Additionally, in certain tests, some resources were not properly deleted; therefore, I have updated the tests accordingly.

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
