### PR TITLE
chore(retail): Correct region tag for consistency

### DIFF
--- a/retail/interactive-tutorials/search/search-with-ordering.js
+++ b/retail/interactive-tutorials/search/search-with-ordering.js
@@ -11,9 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// [START retail_search_products_with_ordering]
 
 'use strict';
+
+// [START retail_search_for_products_with_ordering]
 
 async function main() {
   // Call Retail API to search for a products in a catalog, order the results by different product fields.
@@ -82,4 +83,4 @@ process.on('unhandledRejection', err => {
 });
 
 main();
-// [END retail_search_products_with_ordering]
+// [END retail_search_for_products_with_ordering]


### PR DESCRIPTION
## Description

Addresses introduced in in #4131

Change in https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/4131#discussion_r2206094099 introduced a new region tag that doesn't make the same sample in other repos. 

This PR reverts that change for consistency with other samples: 

* https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/retail/interactive-tutorials/search/search_with_ordering.py#L17
* https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/retail/interactive-tutorials/src/main/java/search/SearchWithOrdering.java#L24
* https://github.com/GoogleCloudPlatform/dotnet-docs-samples/blob/main/retail/interactive-tutorial/RetailSearch.Samples/SearchWithOrderingSample.cs#L16


- [x] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
