### PR TITLE
feat(secretmanager): Added samples for delete secret annotation

### DIFF
--- a/secret-manager/deleteSecretAnnotation.js
+++ b/secret-manager/deleteSecretAnnotation.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secret-manager/deleteSecretAnnotation.js
+++ b/secret-manager/deleteSecretAnnotation.js
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(name, annotationKey) {
+  // [START secretmanager_delete_secret_annotation]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const name = 'projects/my-project/secrets/my-secret';
+  // const annotationKey = 'secretmanager';
+
+  // Imports the Secret Manager library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient();
+
+  async function getSecret() {
+    const [secret] = await client.getSecret({
+      name: name,
+    });
+
+    return secret;
+  }
+
+  async function deleteSecretAnnotation() {
+    const oldSecret = await getSecret();
+    delete oldSecret.annotations[annotationKey];
+    const [secret] = await client.updateSecret({
+      secret: {
+        name: name,
+        annotations: oldSecret.annotations,
+      },
+      updateMask: {
+        paths: ['annotations'],
+      },
+    });
+
+    console.info(`Updated secret ${secret.name}`);
+  }
+
+  deleteSecretAnnotation();
+  // [END secretmanager_delete_secret_annotation]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/regional_samples/deleteRegionalSecretAnnotation.js
+++ b/secret-manager/regional_samples/deleteRegionalSecretAnnotation.js
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secret-manager/regional_samples/deleteRegionalSecretAnnotation.js
+++ b/secret-manager/regional_samples/deleteRegionalSecretAnnotation.js
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function main(projectId, locationId, secretId, annotationKey) {
+  // [START secretmanager_delete_regional_secret_annotation]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const projectId = 'my-project'
+  // const locationId = 'locationId';
+  // const secretId = 'my-secret';
+  // const annotationKey = 'secretmanager';
+  const name = `projects/${projectId}/locations/${locationId}/secrets/${secretId}`;
+
+  // Imports the Secret Manager library
+  const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
+
+  // Adding the endpoint to call the regional secret manager sever
+  const options = {};
+  options.apiEndpoint = `secretmanager.${locationId}.rep.googleapis.com`;
+
+  // Instantiates a client
+  const client = new SecretManagerServiceClient(options);
+
+  async function getSecret() {
+    const [secret] = await client.getSecret({
+      name: name,
+    });
+
+    return secret;
+  }
+
+  async function deleteRegionalSecretAnnotation() {
+    const oldSecret = await getSecret();
+    delete oldSecret.annotations[annotationKey];
+    const [secret] = await client.updateSecret({
+      secret: {
+        name: name,
+        annotations: oldSecret.annotations,
+      },
+      updateMask: {
+        paths: ['annotations'],
+      },
+    });
+
+    console.info(`Updated secret ${secret.name}`);
+  }
+
+  deleteRegionalSecretAnnotation();
+  // [END secretmanager_delete_regional_secret_annotation]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/secret-manager/test/secretmanager.test.js
+++ b/secret-manager/test/secretmanager.test.js
@@ -547,6 +547,20 @@ describe('Secret Manager samples', () => {
     assert.match(output, new RegExp(`Updated secret ${regionalSecret.name}`));
   });
 
+  it('deletes a secret annotation', async () => {
+    const output = execSync(
+      `node deleteSecretAnnotation.js ${secret.name} ${annotationKey}`
+    );
+    assert.match(output, new RegExp(`Updated secret ${secret.name}`));
+  });
+
+  it('deletes a regional secret annotation', async () => {
+    const output = execSync(
+      `node regional_samples/deleteRegionalSecretAnnotation.js ${projectId} ${locationId} ${secretId} ${annotationKey}`
+    );
+    assert.match(output, new RegExp(`Updated secret ${regionalSecret.name}`));
+  });
+
   it('deletes a regional secret', async () => {
     const output = execSync(
       `node regional_samples/deleteRegionalSecret.js ${projectId} ${locationId} ${secretId}-3`


### PR DESCRIPTION
## Description

Created samples for Global and Regional Secret Manager API

#### Samples

1. Delete Secret Annotation
2. Delete Regional Secret Annotation

## Checklist
- [X] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [X] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [X] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
