### PR TITLE
fix: update repository URL

### DIFF
--- a/recaptcha_enterprise/demosite/app/package.json
+++ b/recaptcha_enterprise/demosite/app/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/googleapis/nodejs-recaptcha-enterprise.git"
+        "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
     },
     "dependencies": {
         "@google-cloud/recaptcha-enterprise": "^5.5.0",


### PR DESCRIPTION
The previous repo is deprecated. All of its content and history has been moved to google-cloud-node.