### PR TITLE
chore: remove Custard config references to flakybot.yaml

### DIFF
--- a/.github/config/nodejs-dev.jsonc
+++ b/.github/config/nodejs-dev.jsonc
@@ -37,7 +37,6 @@
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/auto-label.yaml",
     ".github/blunderbuss.yml",
-    ".github/flakybot.yaml",
     ".github/header-checker-lint.yml",
     ".github/scripts/",
     ".github/snippet-bot.yml",

--- a/.github/config/nodejs.jsonc
+++ b/.github/config/nodejs.jsonc
@@ -37,7 +37,6 @@
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/auto-label.yaml",
     ".github/blunderbuss.yml",
-    ".github/flakybot.yaml",
     ".github/header-checker-lint.yml",
     ".github/scripts/",
     ".github/snippet-bot.yml",


### PR DESCRIPTION
## Description

Follow up to #4145, removing Custard config references to flakybot.yaml, which is no longer in the repository.

Addresses b/434770885 (Complete flakybot deprecation) for this repo.


## Checklist

- [x] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
