### PR TITLE
fix(healthcare): set responseType to JSON instead of Buffer in executeFhirBundle.js

### DIFF
--- a/healthcare/fhir/executeFhirBundle.js
+++ b/healthcare/fhir/executeFhirBundle.js
@@ -30,6 +30,7 @@ function main(
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     }),
     headers: {'Content-Type': 'application/fhir+json'},
+    responseType: 'json',
   });
   const fs = require('fs');
 
@@ -50,7 +51,7 @@ function main(
         request
       );
     console.log('FHIR bundle executed');
-    console.log(resource.data);
+    console.log(JSON.stringify(resource.data, null, 2));
   }
 
   executeFhirBundle();

--- a/healthcare/fhir/executeFhirBundle.js
+++ b/healthcare/fhir/executeFhirBundle.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Google, LLC
+ * Copyright 2020 Google LLC
  * Licensed under the Apache License, Version 2.0 (the `License`);
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -43,15 +43,19 @@ function main(
     // const bundleFile = 'bundle.json';
     const parent = `projects/${projectId}/locations/${cloudRegion}/datasets/${datasetId}/fhirStores/${fhirStoreId}`;
 
-    const bundle = JSON.parse(fs.readFileSync(bundleFile));
+    try {
+      const bundle = JSON.parse(fs.readFileSync(bundleFile));
 
-    const request = {parent, requestBody: bundle};
-    const resource =
-      await healthcare.projects.locations.datasets.fhirStores.fhir.executeBundle(
-        request
-      );
-    console.log('FHIR bundle executed');
-    console.log(JSON.stringify(resource.data, null, 2));
+      const request = {parent, requestBody: bundle};
+      const resource =
+        await healthcare.projects.locations.datasets.fhirStores.fhir.executeBundle(
+          request
+        );
+      console.log('FHIR bundle executed');
+      console.log(JSON.stringify(resource.data, null, 2));
+    } catch (error) {
+      console.error('Error executing FHIR bundle:', error.message || error);
+    }
   }
 
   executeFhirBundle();


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
