### PR TITLE
fix(healthcare): set responseType to JSON instead of Buffer in patchFhirResource.js

### DIFF
--- a/healthcare/fhir/patchFhirResource.js
+++ b/healthcare/fhir/patchFhirResource.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Google, LLC
+ * Copyright 2020 Google LLC
  * Licensed under the Apache License, Version 2.0 (the `License`);
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/healthcare/fhir/patchFhirResource.js
+++ b/healthcare/fhir/patchFhirResource.js
@@ -31,6 +31,7 @@ function main(
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     }),
     headers: {'Content-Type': 'application/json-patch+json'},
+    responseType: 'json',
   });
 
   async function patchFhirResource() {
@@ -50,8 +51,19 @@ function main(
       requestBody: patchOptions,
     };
 
-    await healthcare.projects.locations.datasets.fhirStores.fhir.patch(request);
-    console.log(`Patched ${resourceType} resource`);
+    try {
+      const resource =
+        await healthcare.projects.locations.datasets.fhirStores.fhir.patch(
+          request
+        );
+      console.log(`Patched ${resourceType} resource`);
+      console.log(JSON.stringify(resource.data, null, 2));
+    } catch (error) {
+      console.error(
+        `Error patching ${resourceType} resource:`,
+        error.message || error
+      );
+    }
   }
 
   patchFhirResource();


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
