### PR TITLE
fix(healthcare): set responseType to JSON instead of Buffer in deleteFhirResource.js

### DIFF
--- a/healthcare/fhir/deleteFhirResource.js
+++ b/healthcare/fhir/deleteFhirResource.js
@@ -29,6 +29,7 @@ const main = (
     auth: new google.auth.GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     }),
+    responseType: 'json',
   });
 
   const deleteFhirResource = async () => {
@@ -46,10 +47,14 @@ const main = (
     // fails, the server returns a 200 OK HTTP status code. To check that the
     // resource was successfully deleted, search for or get the resource and
     // see if it exists.
-    await healthcare.projects.locations.datasets.fhirStores.fhir.delete(
-      request
-    );
-    console.log('Deleted FHIR resource');
+    try {
+      await healthcare.projects.locations.datasets.fhirStores.fhir.delete(
+        request
+      );
+      console.log(`Deleted FHIR resource: ${resourceId}`);
+    } catch (error) {
+      console.error('Error deleting FHIR resource:', error.message || error);
+    }
   };
 
   deleteFhirResource();

--- a/healthcare/fhir/system-test/fhir_resources.test.js
+++ b/healthcare/fhir/system-test/fhir_resources.test.js
@@ -181,7 +181,10 @@ it('should delete a FHIR resource', () => {
     `node deleteFhirResource.js ${projectId} ${cloudRegion} ${datasetId} ${fhirStoreId} ${resourceType} ${resourceId}`,
     {cwd}
   );
-  assert.strictEqual(new RegExp('Deleted FHIR resource').test(output), true);
+  assert.strictEqual(
+    new RegExp(`Deleted FHIR resource: ${resourceId}`).test(output),
+    true
+  );
 
   // Clean up
   execSync(


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [ ] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
