### PR TITLE
fix(healthcare): set responseType to JSON instead of Buffer in deleteFhirResourcePurge.js

### DIFF
--- a/healthcare/fhir/deleteFhirResourcePurge.js
+++ b/healthcare/fhir/deleteFhirResourcePurge.js
@@ -29,6 +29,7 @@ const main = (
     auth: new google.auth.GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     }),
+    responseType: 'blob',
   });
 
   const deleteFhirResourcePurge = async () => {
@@ -42,10 +43,14 @@ const main = (
     const name = `projects/${projectId}/locations/${cloudRegion}/datasets/${datasetId}/fhirStores/${fhirStoreId}/fhir/${resourceType}/${resourceId}`;
     const request = {name};
 
-    await healthcare.projects.locations.datasets.fhirStores.fhir.ResourcePurge(
-      request
-    );
-    console.log('Deleted all historical versions of resource');
+    try {
+      await healthcare.projects.locations.datasets.fhirStores.fhir.ResourcePurge(
+        request
+      );
+      console.log(`Purged all historical versions of resource: ${resourceId}`);
+    } catch (error) {
+      console.error('Error purging FHIR resource:', error.message || error);
+    }
   };
 
   deleteFhirResourcePurge();

--- a/healthcare/fhir/deleteFhirResourcePurge.js
+++ b/healthcare/fhir/deleteFhirResourcePurge.js
@@ -29,7 +29,7 @@ const main = (
     auth: new google.auth.GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     }),
-    responseType: 'blob',
+    responseType: 'json',
   });
 
   const deleteFhirResourcePurge = async () => {

--- a/healthcare/fhir/system-test/fhir_resources.test.js
+++ b/healthcare/fhir/system-test/fhir_resources.test.js
@@ -163,7 +163,9 @@ it('should purge all historical versions of a FHIR resource', () => {
     {cwd}
   );
   assert.strictEqual(
-    new RegExp('Deleted all historical versions of resource').test(output),
+    new RegExp(
+      `Purged all historical versions of resource: ${resourceId}`
+    ).test(output),
     true
   );
 });


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
