### PR TITLE
fix(healthcare): set responseType to JSON instead of Buffer in exportFhirResources.js

### DIFF
--- a/healthcare/fhir/exportFhirResources.js
+++ b/healthcare/fhir/exportFhirResources.js
@@ -28,6 +28,7 @@ const main = (
     auth: new google.auth.GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     }),
+    responseType: 'json',
   });
   const sleep = ms => {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -51,23 +52,29 @@ const main = (
       },
     };
 
-    const operation =
-      await healthcare.projects.locations.datasets.fhirStores.export(request);
-    const operationName = operation.data.name;
+    try {
+      const operation =
+        await healthcare.projects.locations.datasets.fhirStores.export(request);
+      const operationName = operation.data.name;
 
-    // Wait ten seconds for the LRO to finish
-    await sleep(10000);
+      // Wait ten seconds for the LRO to finish
+      await sleep(10000);
 
-    // Check the LRO's status
-    const operationStatus =
-      await healthcare.projects.locations.datasets.operations.get({
-        name: operationName,
-      });
+      // Check the LRO's status
+      const operationStatus =
+        await healthcare.projects.locations.datasets.operations.get({
+          name: operationName,
+        });
 
-    if (typeof operationStatus.data.metadata.counter !== 'undefined') {
-      console.log('Exported FHIR resources successfully');
-    } else {
-      console.log('Export failed');
+      if (operationStatus.data.done && !operationStatus.data.error) {
+        console.log('Exported FHIR resources successfully');
+      } else if (operationStatus.data.error) {
+        console.log('Export failed with error:', operationStatus.data.error);
+      } else {
+        console.log('Export operation is still in progress.');
+      }
+    } catch (error) {
+      console.error('Error exporting FHIR resources:', error.message || error);
     }
   };
 

--- a/healthcare/fhir/exportFhirResources.js
+++ b/healthcare/fhir/exportFhirResources.js
@@ -57,21 +57,25 @@ const main = (
         await healthcare.projects.locations.datasets.fhirStores.export(request);
       const operationName = operation.data.name;
 
-      // Wait ten seconds for the LRO to finish
-      await sleep(10000);
+      let done = false;
+      let operationStatus;
 
-      // Check the LRO's status
-      const operationStatus =
-        await healthcare.projects.locations.datasets.operations.get({
-          name: operationName,
-        });
+      while (!done) {
+        console.log('Waiting for operation to complete...');
+        await sleep(5000);
 
-      if (operationStatus.data.done && !operationStatus.data.error) {
-        console.log('Exported FHIR resources successfully');
-      } else if (operationStatus.data.error) {
+        operationStatus =
+          await healthcare.projects.locations.datasets.operations.get({
+            name: operationName,
+          });
+
+        done = operationStatus.data.done;
+      }
+
+      if (operationStatus.data.error) {
         console.log('Export failed with error:', operationStatus.data.error);
       } else {
-        console.log('Export operation is still in progress.');
+        console.log('Exported FHIR resources successfully');
       }
     } catch (error) {
       console.error('Error exporting FHIR resources:', error.message || error);


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
