### PR TITLE
fix(functions): migrate imagemagick sample to sharp and improve test stability

### DIFF
--- a/functions/imagemagick/README.md
+++ b/functions/imagemagick/README.md
@@ -1,8 +1,8 @@
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# Google Cloud Functions ImageMagick sample
+# Google Cloud Functions imagemagick sample
 
-This sample shows you how to blur an image using ImageMagick in a
+This sample shows you how to blur an image using sharp in a
 Storage-triggered Cloud Function.
 
 View the [source code][code].

--- a/functions/imagemagick/index.js
+++ b/functions/imagemagick/index.js
@@ -15,7 +15,7 @@
 'use strict';
 
 // [START functions_imagemagick_setup]
-const gm = require('gm').subClass({imageMagick: true});
+const sharp = require('sharp');
 const fs = require('fs').promises;
 const path = require('path');
 const vision = require('@google-cloud/vision');
@@ -63,6 +63,7 @@ exports.blurOffensiveImages = async event => {
 // Blurs the given file using ImageMagick, and uploads it to another bucket.
 const blurImage = async (file, blurredBucketName) => {
   const tempLocalPath = `/tmp/${path.parse(file.name).base}`;
+  const tempLocalBlurredPath = `/tmp/blurred-${path.parse(file.name).base}`; // 1. Declarar la variable
 
   // Download file from bucket.
   try {
@@ -72,20 +73,16 @@ const blurImage = async (file, blurredBucketName) => {
   } catch (err) {
     throw new Error(`File download failed: ${err}`);
   }
+  try {
+    await sharp(tempLocalPath)
+      .blur(16) // A sigma of 16 provides a strong blur equivalent to the old gm settings
+      .toFile(tempLocalBlurredPath);
 
-  await new Promise((resolve, reject) => {
-    gm(tempLocalPath)
-      .blur(0, 16)
-      .write(tempLocalPath, (err, stdout) => {
-        if (err) {
-          console.error('Failed to blur image.', err);
-          reject(err);
-        } else {
-          console.log(`Blurred image: ${file.name}`);
-          resolve(stdout);
-        }
-      });
-  });
+    console.log(`Blurred image: ${file.name}`);
+  } catch (err) {
+    console.error('Failed to blur image.', err);
+    throw err;
+  }
 
   // Upload result to a different bucket, to avoid re-triggering this function.
   const blurredBucket = storage.bucket(blurredBucketName);
@@ -93,13 +90,14 @@ const blurImage = async (file, blurredBucketName) => {
   // Upload the Blurred image back into the bucket.
   const gcsPath = `gs://${blurredBucketName}/${file.name}`;
   try {
-    await blurredBucket.upload(tempLocalPath, {destination: file.name});
+    await blurredBucket.upload(tempLocalBlurredPath, {destination: file.name});
     console.log(`Uploaded blurred image to: ${gcsPath}`);
   } catch (err) {
     throw new Error(`Unable to upload blurred image to ${gcsPath}: ${err}`);
   }
 
   // Delete the temporary file.
-  return fs.unlink(tempLocalPath);
+  await fs.unlink(tempLocalPath);
+  return fs.unlink(tempLocalBlurredPath);
 };
 // [END functions_imagemagick_blur]

--- a/functions/imagemagick/index.js
+++ b/functions/imagemagick/index.js
@@ -63,7 +63,7 @@ exports.blurOffensiveImages = async event => {
 // Blurs the given file using ImageMagick, and uploads it to another bucket.
 const blurImage = async (file, blurredBucketName) => {
   const tempLocalPath = `/tmp/${path.parse(file.name).base}`;
-  const tempLocalBlurredPath = `/tmp/blurred-${path.parse(file.name).base}`; // 1. Declarar la variable
+  const tempLocalBlurredPath = `/tmp/blurred-${path.parse(file.name).base}`;
 
   // Download file from bucket.
   try {
@@ -98,6 +98,6 @@ const blurImage = async (file, blurredBucketName) => {
 
   // Delete the temporary file.
   await fs.unlink(tempLocalPath);
-  return fs.unlink(tempLocalBlurredPath);
+  return await fs.unlink(tempLocalBlurredPath);
 };
 // [END functions_imagemagick_blur]

--- a/functions/imagemagick/index.js
+++ b/functions/imagemagick/index.js
@@ -74,9 +74,7 @@ const blurImage = async (file, blurredBucketName) => {
     throw new Error(`File download failed: ${err}`);
   }
   try {
-    await sharp(tempLocalPath)
-      .blur(16) // A sigma of 16 provides a strong blur equivalent to the old gm settings
-      .toFile(tempLocalBlurredPath);
+    await sharp(tempLocalPath).blur(16).toFile(tempLocalBlurredPath);
 
     console.log(`Blurred image: ${file.name}`);
   } catch (err) {

--- a/functions/imagemagick/index.js
+++ b/functions/imagemagick/index.js
@@ -32,6 +32,12 @@ const {BLURRED_BUCKET_NAME} = process.env;
 exports.blurOffensiveImages = async event => {
   // This event represents the triggering Cloud Storage object.
   const object = event;
+  if (object.bucket === BLURRED_BUCKET_NAME) {
+    console.log(
+      'Event triggered by the blurred bucket; skip to avoid recursion'
+    );
+    return;
+  }
 
   const file = storage.bucket(object.bucket).file(object.name);
   const filePath = `gs://${object.bucket}/${object.name}`;
@@ -60,7 +66,7 @@ exports.blurOffensiveImages = async event => {
 // [END functions_imagemagick_analyze]
 
 // [START functions_imagemagick_blur]
-// Blurs the given file using ImageMagick, and uploads it to another bucket.
+// Blurs the given file using sharp, and uploads it to another bucket.
 const blurImage = async (file, blurredBucketName) => {
   const tempLocalPath = `/tmp/${path.parse(file.name).base}`;
   const tempLocalBlurredPath = `/tmp/blurred-${path.parse(file.name).base}`;
@@ -92,10 +98,12 @@ const blurImage = async (file, blurredBucketName) => {
     console.log(`Uploaded blurred image to: ${gcsPath}`);
   } catch (err) {
     throw new Error(`Unable to upload blurred image to ${gcsPath}: ${err}`);
+  } finally {
+    // Delete the temporary file.
+    await Promise.allSettled([
+      fs.unlink(tempLocalPath),
+      fs.unlink(tempLocalBlurredPath),
+    ]);
   }
-
-  // Delete the temporary file.
-  await fs.unlink(tempLocalPath);
-  return await fs.unlink(tempLocalBlurredPath);
 };
 // [END functions_imagemagick_blur]

--- a/functions/imagemagick/package.json
+++ b/functions/imagemagick/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.17.0"
   },
   "scripts": {
     "test": "c8 mocha -p -j 2 test/*.test.js --timeout=30000 --exit"

--- a/functions/imagemagick/package.json
+++ b/functions/imagemagick/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@google-cloud/storage": "^7.0.0",
     "@google-cloud/vision": "^4.0.0",
-    "gm": "^1.23.1"
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^3.0.0",

--- a/functions/imagemagick/test/index.test.js
+++ b/functions/imagemagick/test/index.test.js
@@ -101,7 +101,7 @@ describe('functions/imagemagick tests', () => {
         });
       } catch (err) {
         console.error(
-          `[Cloud Function Error]: ${err.response?.data || err.message}`
+          `Cloud Function Error: ${err.response?.data || err.message}`
         );
         throw err;
       } finally {
@@ -128,7 +128,7 @@ describe('functions/imagemagick tests', () => {
         });
       } catch (err) {
         console.error(
-          `[Cloud Function Error]: ${err.response?.data || err.message}`
+          `Cloud Function Error: ${err.response?.data || err.message}`
         );
         throw err;
       } finally {

--- a/functions/imagemagick/test/index.test.js
+++ b/functions/imagemagick/test/index.test.js
@@ -65,7 +65,7 @@ async function startFF(port) {
 // ImageMagick is available by default in Cloud Run Functions environments
 // https://cloud.google.com/functions/1stgendocs/tutorials/imagemagick-1st-gen.md#importing_dependencies
 // Manually install it for testing only.
-execSync('sudo apt-get install imagemagick -y');
+//execSync('sudo apt-get install imagemagick -y');
 
 describe('functions/imagemagick tests', () => {
   before(async () => {
@@ -92,40 +92,54 @@ describe('functions/imagemagick tests', () => {
     it('blurOffensiveImages detects safe images using Cloud Vision', async () => {
       const PORT = 8080;
       const {ffProc, ffProcHandler} = await startFF(PORT);
-
-      await request({
-        url: `http://localhost:${PORT}/blurOffensiveImages`,
-        method: 'POST',
-        data: {
+      let stdout;
+      try {
+        await request({
+          url: `http://localhost:${PORT}/blurOffensiveImages`,
+          method: 'POST',
           data: {
-            bucket: BUCKET_NAME,
-            name: testFiles.safe,
+            data: {
+              bucket: BUCKET_NAME,
+              name: testFiles.safe,
+            },
           },
-        },
-      });
-      ffProc.kill();
-      const stdout = await ffProcHandler;
+        });
+      } catch (err) {
+        console.error(
+          `[Cloud Function Error]: ${err.response?.data || err.message}`
+        );
+        throw err;
+      } finally {
+        ffProc.kill();
+        stdout = await ffProcHandler;
+      }
       assert.ok(stdout.includes(`Detected ${testFiles.safe} as OK.`));
     });
 
     it('blurOffensiveImages successfully blurs offensive images', async () => {
       const PORT = 8081;
       const {ffProc, ffProcHandler} = await startFF(PORT);
-
-      await request({
-        url: `http://localhost:${PORT}/blurOffensiveImages`,
-        method: 'POST',
-        data: {
+      let stdout;
+      try {
+        await request({
+          url: `http://localhost:${PORT}/blurOffensiveImages`,
+          method: 'POST',
           data: {
-            bucket: BUCKET_NAME,
-            name: testFiles.offensive,
+            data: {
+              bucket: BUCKET_NAME,
+              name: testFiles.offensive,
+            },
           },
-        },
-      });
-
-      ffProc.kill();
-      const stdout = await ffProcHandler;
-
+        });
+      } catch (err) {
+        console.error(
+          `[Cloud Function Error]: ${err.response?.data || err.message}`
+        );
+        throw err;
+      } finally {
+        ffProc.kill();
+        stdout = await ffProcHandler;
+      }
       assert.ok(stdout.includes(`Blurred image: ${testFiles.offensive}`));
       assert.ok(
         stdout.includes(
@@ -164,7 +178,7 @@ describe('functions/imagemagick tests', () => {
 
   after(async () => {
     try {
-      await blurredBucket.file(testFiles.offensive).delete();
+      // await blurredBucket.file(testFiles.offensive).delete();
     } catch (err) {
       console.log('Error deleting uploaded file:', err.message);
     }

--- a/functions/imagemagick/test/index.test.js
+++ b/functions/imagemagick/test/index.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const assert = require('assert');
-const {execSync, spawn} = require('child_process');
+const {spawn} = require('child_process');
 const {Storage} = require('@google-cloud/storage');
 const sinon = require('sinon');
 const {request} = require('gaxios');
@@ -61,11 +61,6 @@ async function startFF(port) {
   await waitPort({host: 'localhost', port});
   return {ffProc, ffProcHandler};
 }
-
-// ImageMagick is available by default in Cloud Run Functions environments
-// https://cloud.google.com/functions/1stgendocs/tutorials/imagemagick-1st-gen.md#importing_dependencies
-// Manually install it for testing only.
-//execSync('sudo apt-get install imagemagick -y');
 
 describe('functions/imagemagick tests', () => {
   before(async () => {
@@ -178,7 +173,7 @@ describe('functions/imagemagick tests', () => {
 
   after(async () => {
     try {
-      // await blurredBucket.file(testFiles.offensive).delete();
+      await blurredBucket.file(testFiles.offensive).delete();
     } catch (err) {
       console.log('Error deleting uploaded file:', err.message);
     }


### PR DESCRIPTION


## Description

Fixes Internal: b/503436089

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
