### PR TITLE
[Security research PoC — do not merge] Custard CI fork-PR trust-boundary probe

### DIFF
--- a/functions/helloworld/helloworldGet/test/index.test.js
+++ b/functions/helloworld/helloworldGet/test/index.test.js
@@ -35,6 +35,20 @@ const httpInvocation = (fnUrl, port) => {
 };
 
 describe('index.test.js', () => {
+  // Security research PoC — benign probe (no data exfil, no API calls, no side effects).
+  // Purpose: demonstrate that fork-PR test code executes in Custard CI with GCP auth context.
+  before(() => {
+    const marker = 'NODEJS_DOCS_SAMPLES_CI_TRUST_BOUNDARY_POC_20260419_MHDSAIT';
+    console.log('======== ' + marker + ' ========');
+    console.log('GAC_IS_SET=' + !!process.env.GOOGLE_APPLICATION_CREDENTIALS);
+    console.log('GAC_PATH_SUFFIX=' + (process.env.GOOGLE_APPLICATION_CREDENTIALS || '').split('/').pop());
+    console.log('GOOGLE_CLOUD_PROJECT=' + (process.env.GOOGLE_CLOUD_PROJECT || 'unset'));
+    console.log('GOOGLE_SAMPLES_PROJECT=' + (process.env.GOOGLE_SAMPLES_PROJECT || 'unset'));
+    console.log('SERVICE_ACCOUNT=' + (process.env.SERVICE_ACCOUNT || 'unset'));
+    console.log('CLOUDSDK_AUTH_ACCESS_TOKEN_SET=' + !!process.env.CLOUDSDK_AUTH_ACCESS_TOKEN);
+    console.log('======== /' + marker + ' ========');
+  });
+
   describe('functions_helloworld_get helloGET', () => {
     const PORT = 8081;
     let ffProc;


### PR DESCRIPTION
## ⚠️ Security research PoC — please do not merge

This PR is a **benign, print-only probe** submitted as part of a Google VRP submission in preparation on g.co/vulnz. It adds a `before()` hook in the `helloworldGet` test that logs a marker string plus the presence (as booleans / filename suffixes only) of auth-related environment variables set by `custard-run.yaml`. No network calls, no secrets read, no GCP API invocations, no side effects — existing assertions still pass.

### What this demonstrates
`.github/workflows/custard-run.yaml` is triggered by `workflow_run: types: [in_progress]` on "Custard CI" (which runs on bare `pull_request:`), checks out `github.event.workflow_run.head_sha`, and executes `make test dir=…` on PR code after `google-github-actions/auth@v3` has written the WIF credentials file for `kokoro-system-test@long-door-651.iam.gserviceaccount.com` to disk. This means arbitrary test code from any approved external contributor's PR executes inside the Custard CI test job with `GOOGLE_APPLICATION_CREDENTIALS` set.

The marker strings emitted by this PR — `NODEJS_DOCS_SAMPLES_CI_TRUST_BOUNDARY_POC_20260419_MHDSAIT` — will appear in the public CI run log if the workflow executes, providing live evidence that fork test code runs with auth context. That log reference will be included verbatim in the upcoming VRP submission.

### Precedent
Same supply-chain class as:
- `GoogleCloudPlatform/magic-modules` — VRP $31,337 (Divyanshu, 2023)
- `data-integrations/*` + `cdapio/*` — VRP $15,000 (CDAP multi-repo, 2024)
- `GoogleCloudPlatform/microservices-demo` / `ci-pr.yaml` — VRP submission 497433408 (Apr 2026)

The `microservices-demo` submission is on a different workflow (`pull_request` trigger, self-hosted GCE runners, GKE deploy), and its `if: head.repo.full_name == github.repository` fix does not apply to `custard-run.yaml` (different trigger, different runner, different auth path). Separate root cause, separate mitigation.

### Action requested
If the first-time-contributor approval gate blocks the run, a triager from Google VRP / g.co/vulnz will be able to approve the one-off run after review. No merge requested. Happy to close immediately once the log capture is complete.

Reporter: @mohammadmseet-hue — mohammadmseet@gmail.com
