### PR TITLE
fix(healthcare): correct typo 'occured' to 'occurred' in importDicomInstance.js

### DIFF
--- a/healthcare/dicom/importDicomInstance.js
+++ b/healthcare/dicom/importDicomInstance.js
@@ -73,7 +73,7 @@ const main = (
     } else {
       console.log('Encountered errors. Sample error:');
       console.log(
-        'Resource on which error occured:',
+        'Resource on which error occurred:',
         data.error.details[0]['sampleErrors'][0]['resource']
       );
       console.log(


### PR DESCRIPTION
## Description

Fixes a minor spelling typo (`occured` → `occurred`) in the console.log string emitted by the DICOM instance import sample when the returned Long-Running Operation contains errors.

## Location

`healthcare/dicom/importDicomInstance.js:76`

Before:
\`\`\`js
console.log(
  'Resource on which error occured:',
  data.error.details[0]['sampleErrors'][0]['resource']
);
\`\`\`

After:
\`\`\`js
console.log(
  'Resource on which error occurred:',
  data.error.details[0]['sampleErrors'][0]['resource']
);
\`\`\`

## Scope

- Pure spelling correction in user-visible console output.
- No behavior change.
- No tests affected (the string is not asserted against anywhere in this repo — verified via grep).
- Single package (`healthcare/dicom`); no other files touched.