### PR TITLE
fix(ci): restrict workflow_run test jobs to same-repo runs only

### DIFF
--- a/.github/workflows/custard-run-dev.yaml
+++ b/.github/workflows/custard-run-dev.yaml
@@ -56,7 +56,11 @@ jobs:
       create-check-if: ${{ !!github.event.workflow_run }}
 
   test:
-    if: needs.affected.outputs.paths != '[]'
+    # Guard: workflow_run fires for fork PRs but executes with repository secrets
+    # (id-token: write / GCP WIF). Restrict credential use to same-repo runs.
+    if: |
+      needs.affected.outputs.paths != '[]' &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.head_repository.full_name == github.repository)
     needs: affected
     runs-on: ubuntu-latest
     timeout-minutes: 120 # 2 hours hard limit

--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -102,7 +102,11 @@ jobs:
           status: failure
 
   test:
-    if: needs.affected.outputs.paths != '[]'
+    # Guard: workflow_run fires for fork PRs but executes with repository secrets
+    # (id-token: write / GCP WIF). Restrict credential use to same-repo runs.
+    if: |
+      needs.affected.outputs.paths != '[]' &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.head_repository.full_name == github.repository)
     needs: affected
     runs-on: ubuntu-latest
     timeout-minutes: 120 # 2 hours hard limit


### PR DESCRIPTION
## Summary

The `test` jobs in `custard-run.yaml` and `custard-run-dev.yaml` use `workflow_run` as a trigger, which fires whenever the `Custard CI` workflow runs — including when triggered by fork PRs.

**The vulnerability:** These `test` jobs have `id-token: write` permission and authenticate to GCP as `kokoro-system-test@long-door-651.iam.gserviceaccount.com` via Workload Identity Federation. They then check out code at `github.event.workflow_run.head_sha` (which can be a fork commit) and execute `make test dir=${{ matrix.path }}`.

**Attack path:**
1. Attacker forks the repo, submits a PR that modifies a `Makefile` or test file in any affected path
2. The `Custard CI` workflow runs on the fork, triggering `custard-run.yaml` via `workflow_run`  
3. The `test` job checks out the fork's commit and runs `make test` **with live GCP credentials**
4. Attacker's code executes with access to `kokoro-system-test@long-door-651.iam.gserviceaccount.com` (GCP WIF token)

**Fix:** Add a guard condition on the `test` job so credentials are only used when the triggering `workflow_run` originated from the same repository:

```yaml
if: |
  needs.affected.outputs.paths != '[]' &&
  (github.event_name != 'workflow_run' || github.event.workflow_run.head_repository.full_name == github.repository)
```

Push, `workflow_dispatch`, and same-repo PR triggers are completely unaffected.

## Changes

- `.github/workflows/custard-run.yaml`: Add fork guard to `test` job `if:` condition
- `.github/workflows/custard-run-dev.yaml`: Same fix

## Test Plan

- [ ] Same-repo PRs / push to main: `test` job runs normally (`event_name != 'workflow_run'` or same-repo check passes)
- [ ] Fork PRs via `workflow_run`: `test` job is skipped, no GCP credentials are issued
- [ ] `workflow_dispatch` runs: unaffected (condition short-circuits at `event_name != 'workflow_run'`)

---

*Reported to Google via OSS VRP. Fix PR submitted as part of responsible disclosure.*