### PR TITLE
fix: add repository guard to workflow_run test jobs to prevent fork code execution

### DIFF
--- a/.github/workflows/custard-run-dev.yaml
+++ b/.github/workflows/custard-run-dev.yaml
@@ -56,7 +56,13 @@ jobs:
       create-check-if: ${{ !!github.event.workflow_run }}
 
   test:
-    if: needs.affected.outputs.paths != '[]'
+    # Guard: when triggered by workflow_run (fork PR), only run for PRs from
+    # the same repository. Without this, fork PRs can execute arbitrary code
+    # on the CI runner with live GCP credentials.
+    if: |
+      needs.affected.outputs.paths != '[]' &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.head_repository.full_name == github.repository)
     needs: affected
     runs-on: ubuntu-latest
     timeout-minutes: 120 # 2 hours hard limit

--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -102,7 +102,15 @@ jobs:
           status: failure
 
   test:
-    if: needs.affected.outputs.paths != '[]'
+    # Guard: when triggered by workflow_run (fork PR), only run for PRs from
+    # the same repository. Without this, any GitHub user who opens a fork PR
+    # can execute arbitrary code on the CI runner with live GCP credentials
+    # (kokoro-system-test@long-door-651) because workflow_run inherits the
+    # base repo's secrets regardless of the fork source.
+    if: |
+      needs.affected.outputs.paths != '[]' &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.head_repository.full_name == github.repository)
     needs: affected
     runs-on: ubuntu-latest
     timeout-minutes: 120 # 2 hours hard limit


### PR DESCRIPTION
## Summary

`custard-run.yaml` and `custard-run-dev.yaml` both trigger on `workflow_run` when the Custard CI workflow starts. The `test` job checks out and executes the fork's code with live GCP credentials (`kokoro-system-test@long-door-651`) without verifying that the triggering workflow came from the same repository.

**Attack:** Any GitHub user with a previously merged PR (bypassing first-time-contributor approval) can open a fork PR and have their `Makefile` execute on Google's CI runner with live GCP WIF credentials.

## Fix

Adds an `if:` guard to the `test` job in both workflow files:

```yaml
if: |
  needs.affected.outputs.paths != '[]' &&
  (github.event_name != 'workflow_run' ||
   github.event.workflow_run.head_repository.full_name == github.repository)
```

This ensures that for `workflow_run` triggers, only PRs from the same repository (not forks) proceed to the GCP-authenticated test step.

## Files Changed

- `.github/workflows/custard-run.yaml` — added repository guard to `test` job
- `.github/workflows/custard-run-dev.yaml` — same fix applied

## References

- GitHub Security Lab: [Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- Related: `google/adk-samples#1728` (same pattern, fixed)