### PR TITLE
fix(livestream): stop all channels before pool update to avoid FAILED_PRECONDITION

### DIFF
--- a/media/livestream/test/livestream.test.js
+++ b/media/livestream/test/livestream.test.js
@@ -53,32 +53,36 @@ before(async () => {
     parent: livestreamServiceClient.locationPath(projectId, location),
   });
   for (const channel of channels) {
-    const request = {
-      name: channel.name,
-    };
-
-    try {
-      const [operation] = await livestreamServiceClient.stopChannel(request);
-      await operation.promise();
-    } catch (err) {
-      //Ignore error when channel is not started.
-      console.log(
-        'Existing channel already stopped. Ignore the following error.'
-      );
-      console.log(err);
-    }
-
-    if (channel.createTime.seconds < DATE_NOW_SEC - THREE_HOURS_IN_SEC) {
-      const [events] = await livestreamServiceClient.listEvents({
-        parent: channel.name,
-      });
-
-      for (const event of events) {
-        await livestreamServiceClient.deleteEvent({
-          name: event.name,
-        });
+    const isTestChannel = channel.name.includes(
+      'nodejs-test-livestream-channel'
+    );
+    if (isTestChannel) {
+      const request = {
+        name: channel.name,
+      };
+      try {
+        const [operation] = await livestreamServiceClient.stopChannel(request);
+        await operation.promise();
+      } catch (err) {
+        //Ignore error when channel is not started.
+        console.log(
+          'Existing channel already stopped. Ignore the following error.'
+        );
+        console.log(err);
       }
-      await livestreamServiceClient.deleteChannel(request);
+
+      if (channel.createTime.seconds < DATE_NOW_SEC - THREE_HOURS_IN_SEC) {
+        const [events] = await livestreamServiceClient.listEvents({
+          parent: channel.name,
+        });
+
+        for (const event of events) {
+          await livestreamServiceClient.deleteEvent({
+            name: event.name,
+          });
+        }
+        await livestreamServiceClient.deleteChannel(request);
+      }
     }
   }
 

--- a/media/livestream/test/livestream.test.js
+++ b/media/livestream/test/livestream.test.js
@@ -53,21 +53,22 @@ before(async () => {
     parent: livestreamServiceClient.locationPath(projectId, location),
   });
   for (const channel of channels) {
-    if (channel.createTime.seconds < DATE_NOW_SEC - THREE_HOURS_IN_SEC) {
-      const request = {
-        name: channel.name,
-      };
-      try {
-        const [operation] = await livestreamServiceClient.stopChannel(request);
-        await operation.promise();
-      } catch (err) {
-        //Ignore error when channel is not started.
-        console.log(
-          'Existing channel already stopped. Ignore the following error.'
-        );
-        console.log(err);
-      }
+    const request = {
+      name: channel.name,
+    };
 
+    try {
+      const [operation] = await livestreamServiceClient.stopChannel(request);
+      await operation.promise();
+    } catch (err) {
+      //Ignore error when channel is not started.
+      console.log(
+        'Existing channel already stopped. Ignore the following error.'
+      );
+      console.log(err);
+    }
+
+    if (channel.createTime.seconds < DATE_NOW_SEC - THREE_HOURS_IN_SEC) {
       const [events] = await livestreamServiceClient.listEvents({
         parent: channel.name,
       });


### PR DESCRIPTION
## Description

Fixes Internal: b/511248282

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
