### PR TITLE
fix(slack): replace deprecated @slack/events-api with native crypto validation

### DIFF
--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -112,13 +112,18 @@ const verifyWebhook = req => {
     throw err;
   }
 
-  const baseString = `v0:${requestTimestamp}:${requestBody}`;
-  const expectedSignature =
-    'v0=' +
-    crypto
-      .createHmac('sha256', signingSecret)
-      .update(baseString, 'utf8')
-      .digest('hex');
+  // Prevent replay attacks by verifying the timestamp is recent
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - Number(requestTimestamp)) > 60 * 5) {
+    const err = new Error('Slack request timestamp is too old.');
+    err.code = 401;
+    throw err;
+  }
+
+  const hmac = crypto.createHmac('sha256', signingSecret);
+  hmac.update('v0:' + requestTimestamp + ':', 'utf8');
+  hmac.update(requestBody || '');
+  const expectedSignature = 'v0=' + hmac.digest('hex');
 
   const sigBuffer = Buffer.from(requestSignature, 'utf8');
   const expBuffer = Buffer.from(expectedSignature, 'utf8');

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -17,7 +17,7 @@
 // [START functions_slack_setup]
 const functions = require('@google-cloud/functions-framework');
 const google = require('@googleapis/kgsearch');
-const {verifyRequestSignature} = require('@slack/events-api');
+const crypto = require('crypto');
 
 // Get a reference to the Knowledge Graph Search component
 const kgsearch = google.kgsearch('v1');
@@ -93,15 +93,36 @@ const formatSlackMessage = (query, response) => {
  * @param {string} req.rawBody Raw body of webhook request to check signature against.
  */
 const verifyWebhook = req => {
-  const signature = {
-    signingSecret: process.env.SLACK_SECRET,
-    requestSignature: req.headers['x-slack-signature'],
-    requestTimestamp: req.headers['x-slack-request-timestamp'],
-    body: req.rawBody,
-  };
+  const signingSecret = process.env.SLACK_SECRET;
+  const requestSignature = req.headers['x-slack-signature'];
+  const requestTimestamp = req.headers['x-slack-request-timestamp'];
+  const requestBody = req.rawBody;
 
-  // This method throws an exception if an incoming request is invalid.
-  verifyRequestSignature(signature);
+  if (!requestSignature || !requestTimestamp) {
+    const err = new Error('Missing Slack validation headers.');
+    err.code = 400;
+    throw err;
+  }
+
+  const baseString = `v0:${requestTimestamp}:${requestBody}`;
+  const expectedSignature =
+    'v0=' +
+    crypto
+      .createHmac('sha256', signingSecret)
+      .update(baseString, 'utf8')
+      .digest('hex');
+
+  const sigBuffer = Buffer.from(requestSignature, 'utf8');
+  const expBuffer = Buffer.from(expectedSignature, 'utf8');
+
+  if (
+    sigBuffer.length !== expBuffer.length ||
+    !crypto.timingSafeEqual(sigBuffer, expBuffer)
+  ) {
+    const err = new Error('Invalid Slack signature.');
+    err.code = 401;
+    throw err;
+  }
 };
 // [END functions_verify_webhook]
 

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -104,6 +104,14 @@ const verifyWebhook = req => {
     throw err;
   }
 
+  if (!signingSecret) {
+    const err = new Error(
+      'Server configuration error: SLACK_SECRET is missing.'
+    );
+    err.code = 500;
+    throw err;
+  }
+
   const baseString = `v0:${requestTimestamp}:${requestBody}`;
   const expectedSignature =
     'v0=' +

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -145,26 +145,13 @@ const verifyWebhook = req => {
  *
  * @param {string} query The user's search query.
  */
-const makeSearchRequest = query => {
-  return new Promise((resolve, reject) => {
-    kgsearch.entities.search(
-      {
-        auth: process.env.KG_API_KEY,
-        query: query,
-        limit: 1,
-      },
-      (err, response) => {
-        console.log(err);
-        if (err) {
-          reject(err);
-          return;
-        }
-
-        // Return a formatted message
-        resolve(formatSlackMessage(query, response));
-      }
-    );
+const makeSearchRequest = async query => {
+  const response = await kgsearch.entities.search({
+    auth: process.env.KG_API_KEY,
+    query,
+    limit: 1,
   });
+  return formatSlackMessage(query, response);
 };
 // [END functions_slack_request]
 
@@ -203,12 +190,9 @@ functions.http('kgSearch', async (req, res) => {
 
     // Send the formatted message back to Slack
     res.json(response);
-
-    return Promise.resolve();
   } catch (err) {
     console.error(err);
-    res.status(err.code || 500).send(err);
-    return Promise.reject(err);
+    res.status(err.code || 500).send(err.message || 'Internal Server Error');
   }
 });
 // [END functions_slack_search]

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.1.0",
-    "@googleapis/kgsearch": "^1.0.0",
-    "@slack/events-api": "^3.0.0"
+    "@googleapis/kgsearch": "^1.0.0"
   },
   "devDependencies": {
     "c8": "^10.0.0",

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "c8": "^10.0.0",
     "mocha": "^10.0.0",
-    "nock": "^14.0.15",
+    "nock": "^13.5.6",
     "proxyquire": "^2.1.0",
     "sinon": "^18.0.0",
     "supertest": "^7.0.0"

--- a/functions/slack/package.json
+++ b/functions/slack/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "c8": "^10.0.0",
     "mocha": "^10.0.0",
+    "nock": "^14.0.15",
     "proxyquire": "^2.1.0",
     "sinon": "^18.0.0",
     "supertest": "^7.0.0"

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -18,8 +18,8 @@ const assert = require('assert');
 const crypto = require('crypto');
 const supertest = require('supertest');
 const functionsFramework = require('@google-cloud/functions-framework/testing');
-
-const {SLACK_SECRET} = process.env;
+process.env.SLACK_SECRET = process.env.SLACK_SECRET || 'test-slack-secret';
+const SLACK_SECRET = process.env.SLACK_SECRET;
 const SLACK_TIMESTAMP = Math.floor(Date.now() / 1000).toString();
 
 require('../index');

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -18,6 +18,8 @@ const assert = require('assert');
 const crypto = require('crypto');
 const supertest = require('supertest');
 const functionsFramework = require('@google-cloud/functions-framework/testing');
+const nock = require('nock');
+
 process.env.SLACK_SECRET = process.env.SLACK_SECRET || 'test-slack-secret';
 const SLACK_SECRET = process.env.SLACK_SECRET;
 const SLACK_TIMESTAMP = Math.floor(Date.now() / 1000).toString();
@@ -38,8 +40,33 @@ const generateSignature = query => {
 };
 
 describe('functions_slack_format functions_slack_request functions_slack_search functions_verify_webhook', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   it('returns search results', async () => {
     const query = 'kolach';
+
+    // Mock: Intercept the Google API request and return the expected data
+    nock('https://kgsearch.googleapis.com')
+      .get('/v1/entities:search')
+      .query(true)
+      .reply(200, {
+        itemListElement: [
+          {
+            result: {
+              name: 'Kolach',
+              description: 'Pastry',
+              detailedDescription: {
+                articleBody:
+                  'A kolach is a pastry that holds a portion of fruit surrounded by puffy dough.',
+                url: 'http://domain.com/kolach',
+              },
+            },
+          },
+        ],
+      });
+
     const server = functionsFramework.getTestServer('kgSearch');
     const response = await supertest(server)
       .post('/')
@@ -63,6 +90,13 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
 
   it('handles non-existent query', async () => {
     const query = 'g1bb3r1shhhhhhh';
+
+    nock('https://kgsearch.googleapis.com')
+      .get('/v1/entities:search')
+      .query(true)
+      .reply(200, {
+        itemListElement: [],
+      });
 
     const server = functionsFramework.getTestServer('kgSearch');
     const response = await supertest(server)

--- a/functions/slack/test/integration.test.js
+++ b/functions/slack/test/integration.test.js
@@ -20,7 +20,7 @@ const supertest = require('supertest');
 const functionsFramework = require('@google-cloud/functions-framework/testing');
 
 const {SLACK_SECRET} = process.env;
-const SLACK_TIMESTAMP = Date.now();
+const SLACK_TIMESTAMP = Math.floor(Date.now() / 1000).toString();
 
 require('../index');
 
@@ -101,6 +101,6 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     const query = 'kolach';
 
     const server = functionsFramework.getTestServer('kgSearch');
-    await supertest(server).post('/').send({text: query}).expect(500);
+    await supertest(server).post('/').send({text: query}).expect(400);
   });
 });

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -58,7 +58,7 @@ const getSample = () => {
   };
   const kgsearch = {
     entities: {
-      search: sinon.stub().yields(),
+      search: sinon.stub().resolves(),
     },
   };
   const googleapis = {
@@ -134,17 +134,11 @@ describe('functions_slack_search', () => {
 
     const kgSearch = getFunction('kgSearch');
 
-    try {
-      await kgSearch(mocks.req, mocks.res);
-    } catch (err) {
-      assert.deepStrictEqual(err, error);
-      assert.strictEqual(mocks.res.status.callCount, 1);
-      assert.deepStrictEqual(mocks.res.status.firstCall.args, [error.code]);
-      assert.strictEqual(mocks.res.send.callCount, 1);
-      assert.deepStrictEqual(mocks.res.send.firstCall.args, [error]);
-      assert.strictEqual(console.error.callCount, 1);
-      assert.deepStrictEqual(console.error.firstCall.args, [error]);
-    }
+    await kgSearch(mocks.req, mocks.res);
+    assert.strictEqual(mocks.res.status.callCount, 1);
+    assert.deepStrictEqual(mocks.res.status.firstCall.args, [error.code]);
+    assert.strictEqual(mocks.res.send.callCount, 1);
+    assert.deepStrictEqual(mocks.res.send.firstCall.args, [error.message]);
   });
 });
 
@@ -157,20 +151,13 @@ describe('functions_slack_search functions_verify_webhook', () => {
 
     mocks.req.method = method;
     signMockRequest(mocks.req, 'not empty', false);
-
     const kgSearch = getFunction('kgSearch');
+    await kgSearch(mocks.req, mocks.res);
 
-    try {
-      await kgSearch(mocks.req, mocks.res);
-    } catch (err) {
-      assert.deepStrictEqual(err, error);
-      assert.strictEqual(mocks.res.status.callCount, 1);
-      assert.deepStrictEqual(mocks.res.status.firstCall.args, [error.code]);
-      assert.strictEqual(mocks.res.send.callCount, 1);
-      assert.deepStrictEqual(mocks.res.send.firstCall.args, [error]);
-      assert.strictEqual(console.error.callCount, 1);
-      assert.deepStrictEqual(console.error.firstCall.args, [error]);
-    }
+    assert.strictEqual(mocks.res.status.callCount, 1);
+    assert.deepStrictEqual(mocks.res.status.firstCall.args, [error.code]);
+    assert.strictEqual(mocks.res.send.callCount, 1);
+    assert.deepStrictEqual(mocks.res.send.firstCall.args, [error.message]);
   });
 });
 
@@ -182,21 +169,15 @@ describe('functions_slack_request functions_slack_search functions_verify_webhoo
 
     mocks.req.method = method;
     signMockRequest(mocks.req, query, true);
-    sample.mocks.kgsearch.entities.search.yields(error);
+    sample.mocks.kgsearch.entities.search.rejects(error);
 
     const kgSearch = getFunction('kgSearch');
+    await kgSearch(mocks.req, mocks.res);
 
-    try {
-      await kgSearch(mocks.req, mocks.res);
-    } catch (err) {
-      assert.deepStrictEqual(err, error);
-      assert.strictEqual(mocks.res.status.callCount, 1);
-      assert.deepStrictEqual(mocks.res.status.firstCall.args, [500]);
-      assert.strictEqual(mocks.res.send.callCount, 1);
-      assert.deepStrictEqual(mocks.res.send.firstCall.args, [error]);
-      assert.strictEqual(console.error.callCount, 1);
-      assert.deepStrictEqual(console.error.firstCall.args, [error]);
-    }
+    assert.strictEqual(mocks.res.status.callCount, 1);
+    assert.deepStrictEqual(mocks.res.status.firstCall.args, [500]);
+    assert.strictEqual(mocks.res.send.callCount, 1);
+    assert.deepStrictEqual(mocks.res.send.firstCall.args, [error.message]);
   });
 });
 
@@ -207,13 +188,13 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
 
     mocks.req.method = method;
     signMockRequest(mocks.req, query, true);
-    sample.mocks.kgsearch.entities.search.yields(null, {
+    sample.mocks.kgsearch.entities.search.resolves({
       data: {itemListElement: []},
     });
 
     const kgSearch = getFunction('kgSearch');
-
     await kgSearch(mocks.req, mocks.res);
+
     assert.strictEqual(mocks.res.json.callCount, 1);
     assert.deepStrictEqual(mocks.res.json.firstCall.args, [
       {
@@ -234,7 +215,7 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
 
     mocks.req.method = method;
     signMockRequest(mocks.req, query, true);
-    sample.mocks.kgsearch.entities.search.yields(null, {
+    sample.mocks.kgsearch.entities.search.resolves({
       data: {
         itemListElement: [
           {
@@ -281,7 +262,7 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
 
     mocks.req.method = method;
     signMockRequest(mocks.req, query, true);
-    sample.mocks.kgsearch.entities.search.yields(null, {
+    sample.mocks.kgsearch.entities.search.resolves({
       data: {
         itemListElement: [
           {

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -23,8 +23,11 @@ const {getFunction} = require('@google-cloud/functions-framework/testing');
 
 const method = 'POST';
 const query = 'giraffe';
-const SLACK_SECRET = process.env.SLACK_SECRET || 'slack-token';
-const KG_API_KEY = 'kg-api-key';
+process.env.SLACK_SECRET = process.env.SLACK_SECRET || 'slack-token';
+process.env.KG_API_KEY = process.env.KG_API_KEY || 'test-kg-api-key';
+
+const SLACK_SECRET = process.env.SLACK_SECRET;
+const KG_API_KEY = process.env.KG_API_KEY;
 
 const signMockRequest = (req, bodyText, isValid = true) => {
   req.body = {text: bodyText};

--- a/functions/slack/test/unit.test.js
+++ b/functions/slack/test/unit.test.js
@@ -17,17 +17,40 @@
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const assert = require('assert');
+const crypto = require('crypto');
 
 const {getFunction} = require('@google-cloud/functions-framework/testing');
 
 const method = 'POST';
 const query = 'giraffe';
-const SLACK_TOKEN = 'slack-token';
+const SLACK_SECRET = process.env.SLACK_SECRET || 'slack-token';
 const KG_API_KEY = 'kg-api-key';
+
+const signMockRequest = (req, bodyText, isValid = true) => {
+  req.body = {text: bodyText};
+  req.rawBody = JSON.stringify(req.body);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+
+  let signature;
+  if (!isValid) {
+    signature = 'v0=invalid_signature_hash_for_testing';
+  } else {
+    const baseString = `v0:${timestamp}:${req.rawBody}`;
+    signature =
+      'v0=' +
+      crypto
+        .createHmac('sha256', SLACK_SECRET)
+        .update(baseString, 'utf8')
+        .digest('hex');
+  }
+
+  req.headers['x-slack-request-timestamp'] = timestamp;
+  req.headers['x-slack-signature'] = signature;
+};
 
 const getSample = () => {
   const config = {
-    SLACK_TOKEN: SLACK_TOKEN,
+    SLACK_SECRET: SLACK_SECRET,
     KG_API_KEY: KG_API_KEY,
   };
   const kgsearch = {
@@ -38,21 +61,16 @@ const getSample = () => {
   const googleapis = {
     kgsearch: sinon.stub().returns(kgsearch),
   };
-  const eventsApi = {
-    verifyRequestSignature: sinon.stub().returns(true),
-  };
 
   return {
     program: proxyquire('../', {
       '@googleapis/kgsearch': googleapis,
       process: {env: config},
-      '@slack/events-api': eventsApi,
     }),
     mocks: {
       googleapis: googleapis,
       kgsearch: kgsearch,
       config: config,
-      eventsApi: eventsApi,
     },
   };
 };
@@ -129,14 +147,13 @@ describe('functions_slack_search', () => {
 
 describe('functions_slack_search functions_verify_webhook', () => {
   it('Throws if invalid slack token', async () => {
-    const error = new Error('Invalid credentials');
+    const error = new Error('Invalid Slack signature.');
     error.code = 401;
     const mocks = getMocks();
-    const sample = getSample();
+    getSample();
 
     mocks.req.method = method;
-    mocks.req.body.text = 'not empty';
-    sample.mocks.eventsApi.verifyRequestSignature = sinon.stub().returns(false);
+    signMockRequest(mocks.req, 'not empty', false);
 
     const kgSearch = getFunction('kgSearch');
 
@@ -161,8 +178,7 @@ describe('functions_slack_request functions_slack_search functions_verify_webhoo
     const sample = getSample();
 
     mocks.req.method = method;
-    mocks.req.body.token = SLACK_TOKEN;
-    mocks.req.body.text = query;
+    signMockRequest(mocks.req, query, true);
     sample.mocks.kgsearch.entities.search.yields(error);
 
     const kgSearch = getFunction('kgSearch');
@@ -187,8 +203,7 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     const sample = getSample();
 
     mocks.req.method = method;
-    mocks.req.body.token = SLACK_TOKEN;
-    mocks.req.body.text = query;
+    signMockRequest(mocks.req, query, true);
     sample.mocks.kgsearch.entities.search.yields(null, {
       data: {itemListElement: []},
     });
@@ -215,8 +230,7 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     const sample = getSample();
 
     mocks.req.method = method;
-    mocks.req.body.token = SLACK_TOKEN;
-    mocks.req.body.text = query;
+    signMockRequest(mocks.req, query, true);
     sample.mocks.kgsearch.entities.search.yields(null, {
       data: {
         itemListElement: [
@@ -263,8 +277,7 @@ describe('functions_slack_format functions_slack_request functions_slack_search 
     const sample = getSample();
 
     mocks.req.method = method;
-    mocks.req.body.token = SLACK_TOKEN;
-    mocks.req.body.text = query;
+    signMockRequest(mocks.req, query, true);
     sample.mocks.kgsearch.entities.search.yields(null, {
       data: {
         itemListElement: [


### PR DESCRIPTION

## Description
This PR refactors the Slack function sample to remove the deprecated `@slack/events-api` library. The request validation has been rewritten to use manual signature verification with the native Node.js `crypto` module. 

Additionally, the test suite has been updated to reflect these changes and ensure stability in the CI pipeline.

**Changes included:**
* **Security & Webhook Verification:** Removed the deprecated `@slack/events-api` dependency. Implemented native webhook verification using the `crypto` module. This includes protection against replay attacks (by enforcing a 5-minute request timestamp window) and timing attacks (using `crypto.timingSafeEqual`).
* **Async/Await Modernization:** Refactored the `@googleapis/kgsearch` client calls to use native `async/await` instead of outdated callback patterns (`new Promise` wrappers).
* **Code Cleanup:** Removed dangling/unnecessary promise returns at the end of the Cloud Function HTTP handler.
* **Test Suite Updates:** Updated Sinon mocks in `test/unit.test.js` to correctly use `.resolves()` and `.rejects()` to match the new Promise-based API calls, replacing the old `.yields()` callback stubs.

Fixes Internal: b/414440396

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
