### PR TITLE
test(secret-manager): fix ALREADY_EXISTS in delayed destroy tests by using unique UUIDs

### DIFF
--- a/secret-manager/test/secretmanager.test.js
+++ b/secret-manager/test/secretmanager.test.js
@@ -703,20 +703,23 @@ describe('Secret Manager samples', () => {
       },
     });
 
-    const output = execSync(
-      `node disableSecretDelayedDestroy.js ${fullSecretName}`
-    );
-    assert.match(output, new RegExp('Disabled delayed destroy'));
-
-    await client.deleteSecret({
-      name: fullSecretName,
-    });
+    try {
+      const output = execSync(
+        `node disableSecretDelayedDestroy.js ${fullSecretName}`
+      );
+      assert.match(output, new RegExp('Disabled delayed destroy'));
+    } finally {
+      await client.deleteSecret({
+        name: fullSecretName,
+      });
+    }
   });
 
   it('updates a secret delayed destroy', async () => {
     const customSecretId = `${secretId}-${v4()}`;
     const fullSecretName = `projects/${projectId}/secrets/${customSecretId}`;
     const updatedTimeToLive = 24 * 60 * 60 * 2;
+
     await client.createSecret({
       parent: `projects/${projectId}`,
       secretId: customSecretId,
@@ -730,13 +733,16 @@ describe('Secret Manager samples', () => {
       },
     });
 
-    const output = execSync(
-      `node updateSecretWithDelayedDestroy.js ${fullSecretName} ${updatedTimeToLive}`
-    );
-    assert.match(output, new RegExp('Updated secret'));
-    await client.deleteSecret({
-      name: fullSecretName,
-    });
+    try {
+      const output = execSync(
+        `node updateSecretWithDelayedDestroy.js ${fullSecretName} ${updatedTimeToLive}`
+      );
+      assert.match(output, new RegExp('Updated secret'));
+    } finally {
+      await client.deleteSecret({
+        name: fullSecretName,
+      });
+    }
   });
 
   it('creates a regional secret with delayed destroy', async () => {
@@ -761,14 +767,16 @@ describe('Secret Manager samples', () => {
       },
     });
 
-    const output = execSync(
-      `node regional_samples/disableRegionalSecretDelayedDestroy.js ${projectId} ${locationId} ${customSecretId}`
-    );
-    assert.match(output, new RegExp('Disabled delayed destroy'));
-
-    await regionalClient.deleteSecret({
-      name: fullSecretName,
-    });
+    try {
+      const output = execSync(
+        `node regional_samples/disableRegionalSecretDelayedDestroy.js ${projectId} ${locationId} ${customSecretId}`
+      );
+      assert.match(output, new RegExp('Disabled delayed destroy'));
+    } finally {
+      await regionalClient.deleteSecret({
+        name: fullSecretName,
+      });
+    }
   });
 
   it('updates a regional secret delayed destroy', async () => {
@@ -786,13 +794,16 @@ describe('Secret Manager samples', () => {
       },
     });
 
-    const output = execSync(
-      `node regional_samples/updateRegionalSecretWithDelayedDestroy.js ${projectId} ${locationId} ${customSecretId} ${updatedTimeToLive}`
-    );
-    assert.match(output, new RegExp('Updated regional secret'));
-    await regionalClient.deleteSecret({
-      name: fullSecretName,
-    });
+    try {
+      const output = execSync(
+        `node regional_samples/updateRegionalSecretWithDelayedDestroy.js ${projectId} ${locationId} ${customSecretId} ${updatedTimeToLive}`
+      );
+      assert.match(output, new RegExp('Updated regional secret'));
+    } finally {
+      await regionalClient.deleteSecret({
+        name: fullSecretName,
+      });
+    }
   });
 
   it('creates secret with tags', async () => {

--- a/secret-manager/test/secretmanager.test.js
+++ b/secret-manager/test/secretmanager.test.js
@@ -687,9 +687,12 @@ describe('Secret Manager samples', () => {
   });
 
   it('disables a secret delayed destroy', async () => {
+    const customSecretId = `${secretId}-${v4()}`;
+    const fullSecretName = `projects/${projectId}/secrets/${customSecretId}`;
+
     await client.createSecret({
       parent: `projects/${projectId}`,
-      secretId: `${secretId}-delayedDestroy`,
+      secretId: customSecretId,
       secret: {
         replication: {
           automatic: {},
@@ -701,20 +704,22 @@ describe('Secret Manager samples', () => {
     });
 
     const output = execSync(
-      `node disableSecretDelayedDestroy.js ${secret.name}-delayedDestroy`
+      `node disableSecretDelayedDestroy.js ${fullSecretName}`
     );
     assert.match(output, new RegExp('Disabled delayed destroy'));
 
     await client.deleteSecret({
-      name: `${secret.name}-delayedDestroy`,
+      name: fullSecretName,
     });
   });
 
   it('updates a secret delayed destroy', async () => {
+    const customSecretId = `${secretId}-${v4()}`;
+    const fullSecretName = `projects/${projectId}/secrets/${customSecretId}`;
     const updatedTimeToLive = 24 * 60 * 60 * 2;
     await client.createSecret({
       parent: `projects/${projectId}`,
-      secretId: `${secretId}-delayedDestroy`,
+      secretId: customSecretId,
       secret: {
         replication: {
           automatic: {},
@@ -726,11 +731,11 @@ describe('Secret Manager samples', () => {
     });
 
     const output = execSync(
-      `node updateSecretWithDelayedDestroy.js ${secret.name}-delayedDestroy ${updatedTimeToLive}`
+      `node updateSecretWithDelayedDestroy.js ${fullSecretName} ${updatedTimeToLive}`
     );
     assert.match(output, new RegExp('Updated secret'));
     await client.deleteSecret({
-      name: `${secret.name}-delayedDestroy`,
+      name: fullSecretName,
     });
   });
 
@@ -743,9 +748,12 @@ describe('Secret Manager samples', () => {
   });
 
   it('disables a regional secret delayed destroy', async () => {
+    const customSecretId = `${secretId}-${v4()}`;
+    const fullSecretName = `projects/${projectId}/locations/${locationId}/secrets/${customSecretId}`;
+
     await regionalClient.createSecret({
       parent: `projects/${projectId}/locations/${locationId}`,
-      secretId: `${secretId}-delayedDestroy`,
+      secretId: customSecretId,
       secret: {
         version_destroy_ttl: {
           seconds: 24 * 60 * 60,
@@ -754,20 +762,23 @@ describe('Secret Manager samples', () => {
     });
 
     const output = execSync(
-      `node regional_samples/disableRegionalSecretDelayedDestroy.js ${projectId} ${locationId} ${secretId}-delayedDestroy`
+      `node regional_samples/disableRegionalSecretDelayedDestroy.js ${projectId} ${locationId} ${customSecretId}`
     );
     assert.match(output, new RegExp('Disabled delayed destroy'));
 
     await regionalClient.deleteSecret({
-      name: `projects/${projectId}/locations/${locationId}/secrets/${secretId}-delayedDestroy`,
+      name: fullSecretName,
     });
   });
 
   it('updates a regional secret delayed destroy', async () => {
+    const customSecretId = `${secretId}-${v4()}`;
+    const fullSecretName = `projects/${projectId}/locations/${locationId}/secrets/${customSecretId}`;
+
     const updatedTimeToLive = 24 * 60 * 60 * 2;
     await regionalClient.createSecret({
       parent: `projects/${projectId}/locations/${locationId}`,
-      secretId: `${secretId}-delayedDestroy`,
+      secretId: customSecretId,
       secret: {
         version_destroy_ttl: {
           seconds: 24 * 60 * 60,
@@ -776,11 +787,11 @@ describe('Secret Manager samples', () => {
     });
 
     const output = execSync(
-      `node regional_samples/updateRegionalSecretWithDelayedDestroy.js ${projectId} ${locationId} ${secretId}-delayedDestroy ${updatedTimeToLive}`
+      `node regional_samples/updateRegionalSecretWithDelayedDestroy.js ${projectId} ${locationId} ${customSecretId} ${updatedTimeToLive}`
     );
     assert.match(output, new RegExp('Updated regional secret'));
     await regionalClient.deleteSecret({
-      name: `projects/${projectId}/locations/${locationId}/secrets/${secretId}-delayedDestroy`,
+      name: fullSecretName,
     });
   });
 


### PR DESCRIPTION


## Description

Fixes Internal: b/515137253

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

This PR fixes flakiness and `ALREADY_EXISTS` resource collision errors within the Secret Manager test suite.

* **Fixed Secret Name Collisions in Delayed Destroy Tests**
  * Updated the four `delayedDestroy` related tests to generate unique secret names at runtime using `uuid.v4()`.
  * Previously, these tests hardcoded the suffix `-delayedDestroy`. This caused race conditions and `6 ALREADY_EXISTS` errors during sequential executions if the backend took slightly longer to purge the deleted resource from the prior test.
  * Extracted `customSecretId` and `fullSecretName` to avoid repeating logic and ensure the exact same unique ID is used during creation, execution, and teardown.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
