### PR TITLE
test(cloud-tasks/tutorial-gcf/function): mock sendgrid package to prevent 401 errors in CI pipeline

### DIFF
--- a/cloud-tasks/tutorial-gcf/function/test/index.test.js
+++ b/cloud-tasks/tutorial-gcf/function/test/index.test.js
@@ -23,16 +23,17 @@ describe('tasks/function', () => {
   let key;
 
   const getSample = function () {
-    const requestPromise = sinon
-      .stub()
-      .returns(new Promise(resolve => resolve('test')));
+    const sendGridStub = {
+      setApiKey: sinon.stub(),
+      send: sinon.stub().resolves([{statusCode: 200}]),
+    };
 
     return {
       program: proxyquire('../', {
-        'request-promise': requestPromise,
+        '@sendgrid/mail': sendGridStub,
       }),
       mocks: {
-        requestPromise: requestPromise,
+        sendGridStub: sendGridStub,
       },
     };
   };

--- a/cloud-tasks/tutorial-gcf/function/test/index.test.js
+++ b/cloud-tasks/tutorial-gcf/function/test/index.test.js
@@ -17,7 +17,6 @@
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const assert = require('assert');
-const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
 
 describe('tasks/function', () => {
   let key;
@@ -55,14 +54,7 @@ describe('tasks/function', () => {
   };
 
   before(async () => {
-    const secrets = new SecretManagerServiceClient();
-    const projectId = await secrets.getProjectId();
-    const secretName = 'sendgrid-api-key';
-    const secretVersion = 1;
-    const [version] = await secrets.accessSecretVersion({
-      name: secrets.secretVersionPath(projectId, secretName, secretVersion),
-    });
-    key = version.payload.data.toString();
+    key = 'SG.dummy_key_for_testing';
     process.env.SENDGRID_API_KEY = key;
   });
 
@@ -168,5 +160,11 @@ describe('tasks/function', () => {
     assert.strictEqual(mocks.res.status.callCount, 1);
     assert.deepStrictEqual(mocks.res.status.firstCall.args, [200]);
     assert.strictEqual(mocks.res.send.callCount, 1);
+    sinon.assert.calledOnceWithExactly(sample.mocks.sendGridStub.send, {
+      to: 'to@gmail.com',
+      from: 'postcard@example.com',
+      subject: 'A Postcard Just for You!',
+      html: sinon.match.string,
+    });
   });
 });


### PR DESCRIPTION
## Description
This PR fixes a CI pipeline failure in the `cloud-tasks/tutorial-gcf/function` test suite. 

The test `send succeeds` was previously failing with a `401 Unauthorized` error (`API key does not start with "SG."`) because the `@sendgrid/mail` package was making actual HTTP requests to the SendGrid API during the test execution. Since the CI environment lacks a valid production API key, the SDK rejected the request.

## Changes
- Mocked the `@sendgrid/mail` package using `proxyquire` and `sinon.stub` inside `getSample()` to isolate the tests from external network calls.
- Removed the live Google Cloud Secret Manager API call from the `before` hook, replacing it with a local dummy key (`SG.dummy_key_for_testing`) to make the test suite 100% hermetic and offline-capable.
- Added a payload assertion using `sinon.assert.calledOnceWithExactly` in the `send succeeds` test case to verify that the correct recipient, sender, subject, and template structure are passed to SendGrid.
- Resolved the `401` validation error by bypassing the live SDK initialization during test runs, ensuring the test suite resolves locally with a mocked `200` status code.

Fixes Internal: b/516872192

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
