### PR TITLE
fix(securitycenter): Update list findings to use the new Filter implementation

### DIFF
--- a/security-center/snippets/system-test/v1/findings.test.js
+++ b/security-center/snippets/system-test/v1/findings.test.js
@@ -163,9 +163,7 @@ describe('Client with SourcesAndFindings', async () => {
     const output = exec(`node v1/listFindingsAtTime.js ${data.sourceName}`);
     // Nothing was created for the source more then a few minutes ago, so
     // days ago should return nothing.
-    //commented below assert and added new assert as source is created in before block
-    // assert.equal(output, '');
-    assert.include(output, data.sourceName);
+    assert.equal(output, '');
   });
 
   it('client can add security marks to finding', () => {

--- a/security-center/snippets/v1/listFindingsAtTime.js
+++ b/security-center/snippets/v1/listFindingsAtTime.js
@@ -37,14 +37,8 @@ function main(sourceName = 'FULL RESOURCE PATH TO PARENT SOURCE') {
 
   async function listFindingsAtTime() {
     const [response] = await client.listFindings({
-      // List findings across all sources.
       parent: sourceName,
-      //commented readTime as it is not supported, refer below link
-      //https://cloud.google.com/security-command-center/docs/release-notes#April_15_2024
-      // readTime: {
-      //   seconds: Math.floor(fiveDaysAgo.getTime() / 1000),
-      //   nanos: (fiveDaysAgo.getTime() % 1000) * 1e6,
-      // },
+      filter: `event_time < "${fiveDaysAgo.toISOString()}"`,
     });
     let count = 0;
     Array.from(response).forEach(result =>


### PR DESCRIPTION
## Description
Replaces the deprecated `readTime` property with a `filter` on `event_time` in the `listFindingsAtTime` sample. This aligns the code with current API recommendations and the existing Go/Python reference implementations. Tests have also been restored and updated to validate the new filter logic.

Fixes Internal b/517940405

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
