### PR TITLE
feat(storage): add deleteFolderRecursive sample

### DIFF
--- a/storage-control/deleteFolderRecursive.js
+++ b/storage-control/deleteFolderRecursive.js
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(bucketName, folderName) {
+  // [START storage_control_delete_folder_recursive]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+
+  // The name of your GCS bucket
+  // const bucketName = 'bucketName';
+
+  // The name of the folder to be deleted
+  // const folderName = 'folderName';
+
+  // Imports the Control library
+  const {StorageControlClient} = require('@google-cloud/storage-control').v2;
+
+  // Instantiates a client
+  const controlClient = new StorageControlClient();
+
+  async function callDeleteFolderRecursive() {
+    // Set project to "_" to signify globally scoped bucket
+    const folderPath = controlClient.folderPath('_', bucketName, folderName);
+
+    // Create the request
+    const request = {
+      name: folderPath,
+    };
+
+    // Run request
+    const [operation] = await controlClient.deleteFolderRecursive(request);
+    await operation.promise();
+    console.log(`Deleted folder: ${folderPath}`);
+  }
+
+  callDeleteFolderRecursive();
+  // [END storage_control_delete_folder_recursive]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/storage-control/package.json
+++ b/storage-control/package.json
@@ -13,10 +13,11 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@google-cloud/storage": "^7.17.0",
-    "@google-cloud/storage-control": "^0.5.0",
+    "@google-cloud/storage-control": "^0.10.0",
     "c8": "^10.0.0",
     "chai": "^4.5.0",
     "mocha": "^10.7.0",
     "uuid": "^10.0.0"
   }
 }
+

--- a/storage-control/system-test/folders.test.js
+++ b/storage-control/system-test/folders.test.js
@@ -80,6 +80,7 @@ describe('Folders', () => {
   it('should delete a folder recursively', async () => {
     const recursiveFolderName = uuid.v4();
     execSync(`node createFolder.js ${bucketName} ${recursiveFolderName}`);
+    await bucket.file(`${recursiveFolderName}/test.txt`).save('hello');
     const output = execSync(
       `node deleteFolderRecursive.js ${bucketName} ${recursiveFolderName}`
     );

--- a/storage-control/system-test/folders.test.js
+++ b/storage-control/system-test/folders.test.js
@@ -76,4 +76,14 @@ describe('Folders', () => {
     assert.match(output, /Deleted folder:/);
     assert.match(output, new RegExp(folderName));
   });
+
+  it('should delete a folder recursively', async () => {
+    const recursiveFolderName = uuid.v4();
+    execSync(`node createFolder.js ${bucketName} ${recursiveFolderName}`);
+    const output = execSync(
+      `node deleteFolderRecursive.js ${bucketName} ${recursiveFolderName}`
+    );
+    assert.match(output, /Deleted folder:/);
+    assert.match(output, new RegExp(recursiveFolderName));
+  });
 });


### PR DESCRIPTION
This adds a sample demonstrating how to recursively delete a folder in a hierarchical namespace bucket.

Fixes: b/521168740