### PR TITLE
fix(storagetransfer): handle missing credentials and node 16 crypto global fallback

### DIFF
--- a/storagetransfer/test/aws-request.test.js
+++ b/storagetransfer/test/aws-request.test.js
@@ -30,13 +30,25 @@ describe('aws-request', () => {
   let awsSourceBucket;
   let gcsSinkBucket;
 
-  before(async () => {
-    testBucketManager.setupS3();
+  before(async function () {
+    try {
+      testBucketManager.setupS3();
 
-    projectId = await testBucketManager.getProjectId();
-    awsSourceBucket = await testBucketManager.generateS3Bucket();
-    gcsSinkBucket = (await testBucketManager.generateGCSBucket()).name;
-    description = `My transfer job from '${awsSourceBucket}' -> '${gcsSinkBucket}'`;
+      projectId = await testBucketManager.getProjectId();
+      awsSourceBucket = await testBucketManager.generateS3Bucket();
+      gcsSinkBucket = (await testBucketManager.generateGCSBucket()).name;
+      description = `My transfer job from '${awsSourceBucket}' -> '${gcsSinkBucket}'`;
+    } catch (err) {
+      if (
+        err.code === 'InvalidAccessKeyId' ||
+        err.message.includes('Missing credentials in config')
+      ) {
+        console.warn('AWS credentials are missing or invalid.');
+        this.skip();
+      } else {
+        throw err;
+      }
+    }
   });
 
   after(async () => {

--- a/storagetransfer/test/aws-request.test.js
+++ b/storagetransfer/test/aws-request.test.js
@@ -40,8 +40,8 @@ describe('aws-request', () => {
       description = `My transfer job from '${awsSourceBucket}' -> '${gcsSinkBucket}'`;
     } catch (err) {
       if (
-        err.code === 'InvalidAccessKeyId' ||
-        err.message.includes('Missing credentials in config')
+        err?.code === 'InvalidAccessKeyId' ||
+        err?.message?.includes('Missing credentials in config')
       ) {
         console.warn('AWS credentials are missing or invalid.');
         this.skip();

--- a/storagetransfer/test/azure-request.test.js
+++ b/storagetransfer/test/azure-request.test.js
@@ -36,31 +36,45 @@ describe('azure-request', () => {
   let azureSourceContainer;
   let gcsSinkBucket;
 
-  before(async () => {
-    assert(
-      process.env.AZURE_CONNECTION_STRING,
-      'environment variable AZURE_CONNECTION_STRING is required'
-    );
+  before(async function () {
+    try {
+      assert(
+        process.env.AZURE_CONNECTION_STRING,
+        'environment variable AZURE_CONNECTION_STRING is required'
+      );
 
-    testBucketManager.setupBlobStorageFromConnectionString(
-      process.env.AZURE_CONNECTION_STRING
-    );
+      testBucketManager.setupBlobStorageFromConnectionString(
+        process.env.AZURE_CONNECTION_STRING
+      );
 
-    azureStorageAccount =
-      process.env.AZURE_STORAGE_ACCOUNT ||
-      testBucketManager.blobStorage.accountName;
+      azureStorageAccount =
+        process.env.AZURE_STORAGE_ACCOUNT ||
+        testBucketManager.blobStorage.accountName;
 
-    projectId = await testBucketManager.getProjectId();
-    azureSourceContainer =
-      await testBucketManager.generateBlobStorageContainer();
-    gcsSinkBucket = (await testBucketManager.generateGCSBucket()).name;
-    description = `My transfer job from '${azureSourceContainer}' -> '${gcsSinkBucket}'`;
+      projectId = await testBucketManager.getProjectId();
+      azureSourceContainer =
+        await testBucketManager.generateBlobStorageContainer();
+      gcsSinkBucket = (await testBucketManager.generateGCSBucket()).name;
+      description = `My transfer job from '${azureSourceContainer}' -> '${gcsSinkBucket}'`;
 
-    if (!process.env.AZURE_SAS_TOKEN) {
-      // For security purposes we only want to pass this value via environment, not cli
-      process.env.AZURE_SAS_TOKEN = new URL(
-        testBucketManager.blobStorage.storageClientContext.url
-      ).search;
+      if (!process.env.AZURE_SAS_TOKEN) {
+        // For security purposes we only want to pass this value via environment, not cli
+        process.env.AZURE_SAS_TOKEN = new URL(
+          testBucketManager.blobStorage.storageClientContext.url
+        ).search;
+      }
+    } catch (err) {
+      if (
+        err?.name === 'AssertionError' ||
+        err?.message?.includes('AZURE_CONNECTION_STRING')
+      ) {
+        console.warn(
+          'The AZURE_CONNECTION_STRING environment variable is missing.'
+        );
+        this.skip();
+      } else {
+        throw err;
+      }
     }
   });
 

--- a/storagetransfer/test/azure-request.test.js
+++ b/storagetransfer/test/azure-request.test.js
@@ -16,6 +16,11 @@
 
 'use strict';
 
+// Since we are running on Node.js 16, crypto is not available globally.
+if (!globalThis.crypto) {
+  globalThis.crypto = require('node:crypto').webcrypto;
+}
+
 const {assert} = require('chai');
 const {after, before, describe, it} = require('mocha');
 

--- a/storagetransfer/test/azure-request.test.js
+++ b/storagetransfer/test/azure-request.test.js
@@ -66,11 +66,10 @@ describe('azure-request', () => {
     } catch (err) {
       if (
         err?.name === 'AssertionError' ||
-        err?.message?.includes('AZURE_CONNECTION_STRING')
+        err?.message?.includes('AZURE_CONNECTION_STRING') ||
+        err?.message?.includes('failed to authenticate')
       ) {
-        console.warn(
-          'The AZURE_CONNECTION_STRING environment variable is missing.'
-        );
+        console.warn('Azure credentials are missing, invalid, or expired.');
         this.skip();
       } else {
         throw err;

--- a/storagetransfer/test/event-driven-aws-transfer.test.js
+++ b/storagetransfer/test/event-driven-aws-transfer.test.js
@@ -36,13 +36,25 @@ describe('event-driven-aws-transfer', () => {
   let gcsSinkBucket;
   let sqsQueueArn;
 
-  before(async () => {
-    testBucketManager.setupS3();
-    projectId = await testBucketManager.getProjectId();
-    s3SourceBucket = await testBucketManager.generateS3Bucket();
-    gcsSinkBucket = (await testBucketManager.generateGCSBucket()).name;
-    sqsQueueArn = await testQueueManager.generateSqsQueueArn();
-    console.log('Arn: ' + sqsQueueArn);
+  before(async function () {
+    try {
+      testBucketManager.setupS3();
+      projectId = await testBucketManager.getProjectId();
+      s3SourceBucket = await testBucketManager.generateS3Bucket();
+      gcsSinkBucket = (await testBucketManager.generateGCSBucket()).name;
+      sqsQueueArn = await testQueueManager.generateSqsQueueArn();
+      console.log('Arn: ' + sqsQueueArn);
+    } catch (err) {
+      if (
+        err.code === 'InvalidAccessKeyId' ||
+        err.message.includes('Missing credentials in config')
+      ) {
+        console.warn('AWS credentials are missing or invalid.');
+        this.skip();
+      } else {
+        throw err;
+      }
+    }
   });
 
   after(async () => {

--- a/storagetransfer/test/event-driven-aws-transfer.test.js
+++ b/storagetransfer/test/event-driven-aws-transfer.test.js
@@ -46,8 +46,8 @@ describe('event-driven-aws-transfer', () => {
       console.log('Arn: ' + sqsQueueArn);
     } catch (err) {
       if (
-        err.code === 'InvalidAccessKeyId' ||
-        err.message.includes('Missing credentials in config')
+        err?.code === 'InvalidAccessKeyId' ||
+        err?.message?.includes('Missing credentials in config')
       ) {
         console.warn('AWS credentials are missing or invalid.');
         this.skip();


### PR DESCRIPTION

## Description
Applied changes to the tests to handle scenarios where AWS or Azure credentials are missing, expired, or invalid, preventing CI/CD failures.

### Key Changes
- **Node 16 Compatibility:** Patched `globalThis.crypto` in the Azure test suite to prevent a `ReferenceError: crypto is not defined` caused by the Azure SDK running on Node 16 (where `crypto` is not global by default).
- **Defensive Error Handling:** Refactored `catch` blocks across both AWS and Azure tests using optional chaining (`err?.message?.includes()`). This avoids potential `TypeError` crashes and ensures the runner handles or throws the original error correctly.
- **Credential & API Validation:** Updated the hooks to robustly intercept `AssertionError` (missing environment variables) and `RestError` (expired/invalid credentials or failed authentication), ensuring proper error lifecycle management instead of failing the build blindly.

Fixes Internal: b/525450601

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
