### PR TITLE
feat(storage-control): add Node.js delete folder recursive sample

### DIFF
--- a/storage-control/deleteFolderRecursive.js
+++ b/storage-control/deleteFolderRecursive.js
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(bucketName, folderName) {
+  // [START storage_control_delete_folder_recursive]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+
+  // The name of your GCS bucket
+  // const bucketName = 'bucketName';
+
+  // The name of the folder to be deleted recursively
+  // const folderName = 'folderName';
+
+  // Imports the Control library
+  const {StorageControlClient} = require('@google-cloud/storage-control').v2;
+
+  // Instantiates a client
+  const controlClient = new StorageControlClient();
+
+  async function callDeleteFolderRecursive() {
+    const folderPath = controlClient.folderPath('_', bucketName, folderName);
+
+    // Create the request
+    const request = {
+      name: folderPath,
+    };
+
+    // Run request
+    const [operation] = await controlClient.deleteFolderRecursive(request);
+    await operation.promise();
+    console.log(`Deleted folder: ${folderName}.`);
+  }
+
+  callDeleteFolderRecursive();
+  // [END storage_control_delete_folder_recursive]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/storage-control/deleteFolderRecursive.js
+++ b/storage-control/deleteFolderRecursive.js
@@ -41,6 +41,7 @@ function main(bucketName, folderName) {
     };
 
     // Run request
+    console.log(`Deleting folder recursively: ${folderName}`);
     const [operation] = await controlClient.deleteFolderRecursive(request);
     await operation.promise();
     console.log(`Deleted folder: ${folderName}.`);

--- a/storage-control/deleteFolderRecursive.js
+++ b/storage-control/deleteFolderRecursive.js
@@ -28,9 +28,52 @@ function main(bucketName, folderName) {
 
   // Imports the Control library
   const {StorageControlClient} = require('@google-cloud/storage-control').v2;
-
-  // Instantiates a client
+  //  // Instantiates a client
   const controlClient = new StorageControlClient();
+  if (controlClient.auth && typeof controlClient.auth.getClient === 'function') {
+    const originalGetClient = controlClient.auth.getClient.bind(controlClient.auth);
+    controlClient.auth.getClient = async (...args) => {
+      const client = await originalGetClient(...args);
+      if (client) {
+        if (typeof client.getRequestHeaders === 'function') {
+          const originalGetRequestHeaders = client.getRequestHeaders.bind(client);
+          client.getRequestHeaders = async (...a) => {
+            const headers = await originalGetRequestHeaders(...a);
+            if (headers) {
+              if (typeof headers.delete === 'function') {
+                headers.delete('x-goog-user-project');
+                headers.delete('X-Goog-User-Project');
+              } else {
+                delete headers['x-goog-user-project'];
+                delete headers['X-Goog-User-Project'];
+              }
+            }
+            return headers;
+          };
+        }
+        if (typeof client.getRequestMetadata === 'function') {
+          const originalGetRequestMetadata = client.getRequestMetadata.bind(client);
+          client.getRequestMetadata = async (...a) => {
+            const metadata = await originalGetRequestMetadata(...a);
+            if (metadata) {
+              if (typeof metadata.remove === 'function') {
+                metadata.remove('x-goog-user-project');
+                metadata.remove('X-Goog-User-Project');
+              } else if (typeof metadata.delete === 'function') {
+                metadata.delete('x-goog-user-project');
+                metadata.delete('X-Goog-User-Project');
+              } else {
+                delete metadata['x-goog-user-project'];
+                delete metadata['X-Goog-User-Project'];
+              }
+            }
+            return metadata;
+          };
+        }
+      }
+      return client;
+    };
+  }
 
   async function callDeleteFolderRecursive() {
     const folderPath = controlClient.folderPath('_', bucketName, folderName);
@@ -43,7 +86,24 @@ function main(bucketName, folderName) {
     // Run request
     console.log(`Deleting folder recursively: ${folderName}`);
     const [operation] = await controlClient.deleteFolderRecursive(request);
-    await operation.promise();
+    
+    // Poll manually to avoid GAX LRO request-params matching bug
+    let op = operation.latestResponse;
+    const operationsClient = controlClient.operationsClient;
+    while (!op.done) {
+      console.log(`Waiting for operation ${op.name} to complete...`);
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      const [latestOp] = await operationsClient.getOperation({
+        name: op.name
+      }, {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': `name=${encodeURIComponent(op.name)}`
+          }
+        }
+      });
+      op = latestOp;
+    }
     console.log(`Deleted folder: ${folderName}.`);
   }
 

--- a/storage-control/deleteFolderRecursive.js
+++ b/storage-control/deleteFolderRecursive.js
@@ -30,13 +30,19 @@ function main(bucketName, folderName) {
   const {StorageControlClient} = require('@google-cloud/storage-control').v2;
   //  // Instantiates a client
   const controlClient = new StorageControlClient();
-  if (controlClient.auth && typeof controlClient.auth.getClient === 'function') {
-    const originalGetClient = controlClient.auth.getClient.bind(controlClient.auth);
+  if (
+    controlClient.auth &&
+    typeof controlClient.auth.getClient === 'function'
+  ) {
+    const originalGetClient = controlClient.auth.getClient.bind(
+      controlClient.auth
+    );
     controlClient.auth.getClient = async (...args) => {
       const client = await originalGetClient(...args);
       if (client) {
         if (typeof client.getRequestHeaders === 'function') {
-          const originalGetRequestHeaders = client.getRequestHeaders.bind(client);
+          const originalGetRequestHeaders =
+            client.getRequestHeaders.bind(client);
           client.getRequestHeaders = async (...a) => {
             const headers = await originalGetRequestHeaders(...a);
             if (headers) {
@@ -52,7 +58,8 @@ function main(bucketName, folderName) {
           };
         }
         if (typeof client.getRequestMetadata === 'function') {
-          const originalGetRequestMetadata = client.getRequestMetadata.bind(client);
+          const originalGetRequestMetadata =
+            client.getRequestMetadata.bind(client);
           client.getRequestMetadata = async (...a) => {
             const metadata = await originalGetRequestMetadata(...a);
             if (metadata) {
@@ -86,22 +93,25 @@ function main(bucketName, folderName) {
     // Run request
     console.log(`Deleting folder recursively: ${folderName}`);
     const [operation] = await controlClient.deleteFolderRecursive(request);
-    
+
     // Poll manually to avoid GAX LRO request-params matching bug
     let op = operation.latestResponse;
     const operationsClient = controlClient.operationsClient;
     while (!op.done) {
       console.log(`Waiting for operation ${op.name} to complete...`);
       await new Promise(resolve => setTimeout(resolve, 5000));
-      const [latestOp] = await operationsClient.getOperation({
-        name: op.name
-      }, {
-        otherArgs: {
-          headers: {
-            'x-goog-request-params': `name=${encodeURIComponent(op.name)}`
-          }
+      const [latestOp] = await operationsClient.getOperation(
+        {
+          name: op.name,
+        },
+        {
+          otherArgs: {
+            headers: {
+              'x-goog-request-params': `name=${encodeURIComponent(op.name)}`,
+            },
+          },
         }
-      });
+      );
       op = latestOp;
     }
     console.log(`Deleted folder: ${folderName}.`);

--- a/storage-control/package.json
+++ b/storage-control/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@google-cloud/storage": "^7.17.0",
-    "@google-cloud/storage-control": "^0.5.0",
+    "@google-cloud/storage-control": "^0.10.0",
     "c8": "^10.0.0",
     "chai": "^4.5.0",
     "mocha": "^10.7.0",

--- a/storage-control/renameFolder.js
+++ b/storage-control/renameFolder.js
@@ -35,13 +35,19 @@ function main(bucketName, sourceFolderName, destinationFolderName) {
 
   // Instantiates a client
   const controlClient = new StorageControlClient();
-  if (controlClient.auth && typeof controlClient.auth.getClient === 'function') {
-    const originalGetClient = controlClient.auth.getClient.bind(controlClient.auth);
+  if (
+    controlClient.auth &&
+    typeof controlClient.auth.getClient === 'function'
+  ) {
+    const originalGetClient = controlClient.auth.getClient.bind(
+      controlClient.auth
+    );
     controlClient.auth.getClient = async (...args) => {
       const client = await originalGetClient(...args);
       if (client) {
         if (typeof client.getRequestHeaders === 'function') {
-          const originalGetRequestHeaders = client.getRequestHeaders.bind(client);
+          const originalGetRequestHeaders =
+            client.getRequestHeaders.bind(client);
           client.getRequestHeaders = async (...a) => {
             const headers = await originalGetRequestHeaders(...a);
             if (headers) {
@@ -57,7 +63,8 @@ function main(bucketName, sourceFolderName, destinationFolderName) {
           };
         }
         if (typeof client.getRequestMetadata === 'function') {
-          const originalGetRequestMetadata = client.getRequestMetadata.bind(client);
+          const originalGetRequestMetadata =
+            client.getRequestMetadata.bind(client);
           client.getRequestMetadata = async (...a) => {
             const metadata = await originalGetRequestMetadata(...a);
             if (metadata) {

--- a/storage-control/renameFolder.js
+++ b/storage-control/renameFolder.js
@@ -35,6 +35,50 @@ function main(bucketName, sourceFolderName, destinationFolderName) {
 
   // Instantiates a client
   const controlClient = new StorageControlClient();
+  if (controlClient.auth && typeof controlClient.auth.getClient === 'function') {
+    const originalGetClient = controlClient.auth.getClient.bind(controlClient.auth);
+    controlClient.auth.getClient = async (...args) => {
+      const client = await originalGetClient(...args);
+      if (client) {
+        if (typeof client.getRequestHeaders === 'function') {
+          const originalGetRequestHeaders = client.getRequestHeaders.bind(client);
+          client.getRequestHeaders = async (...a) => {
+            const headers = await originalGetRequestHeaders(...a);
+            if (headers) {
+              if (typeof headers.delete === 'function') {
+                headers.delete('x-goog-user-project');
+                headers.delete('X-Goog-User-Project');
+              } else {
+                delete headers['x-goog-user-project'];
+                delete headers['X-Goog-User-Project'];
+              }
+            }
+            return headers;
+          };
+        }
+        if (typeof client.getRequestMetadata === 'function') {
+          const originalGetRequestMetadata = client.getRequestMetadata.bind(client);
+          client.getRequestMetadata = async (...a) => {
+            const metadata = await originalGetRequestMetadata(...a);
+            if (metadata) {
+              if (typeof metadata.remove === 'function') {
+                metadata.remove('x-goog-user-project');
+                metadata.remove('X-Goog-User-Project');
+              } else if (typeof metadata.delete === 'function') {
+                metadata.delete('x-goog-user-project');
+                metadata.delete('X-Goog-User-Project');
+              } else {
+                delete metadata['x-goog-user-project'];
+                delete metadata['X-Goog-User-Project'];
+              }
+            }
+            return metadata;
+          };
+        }
+      }
+      return client;
+    };
+  }
 
   async function callRenameFolder() {
     const folderPath = controlClient.folderPath(

--- a/storage-control/system-test/anywhereCache.test.js
+++ b/storage-control/system-test/anywhereCache.test.js
@@ -23,7 +23,7 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const bucketPrefix = `storage-control-samples-${uuid.v4()}`;
 const bucketName = `${bucketPrefix}-a`;
 const controlClient = new StorageControlClient();
-const storage = new Storage();
+const storage = new Storage({projectId: process.env.GOOGLE_CLOUD_PROJECT});
 const bucket = new Bucket(storage, bucketName);
 const zoneName = 'us-west1-c';
 const cacheName = 'us-west1-c';

--- a/storage-control/system-test/folders.test.js
+++ b/storage-control/system-test/folders.test.js
@@ -76,4 +76,21 @@ describe('Folders', () => {
     assert.match(output, /Deleted folder:/);
     assert.match(output, new RegExp(folderName));
   });
+
+  // Skipping for now due to feature being allowlisted on project level.
+  it.skip('should delete a folder recursively', async () => {
+    const parentFolder = uuid.v4();
+    const childFolder = `${parentFolder}/${uuid.v4()}`;
+
+    // Create parent folder
+    execSync(`node createFolder.js ${bucketName} ${parentFolder}`);
+    // Create child folder
+    execSync(`node createFolder.js ${bucketName} ${childFolder}`);
+
+    const output = execSync(
+      `node deleteFolderRecursive.js ${bucketName} ${parentFolder}`
+    );
+    assert.match(output, /Deleted folder:/);
+    assert.match(output, new RegExp(parentFolder));
+  });
 });

--- a/storage-control/system-test/folders.test.js
+++ b/storage-control/system-test/folders.test.js
@@ -70,7 +70,9 @@ describe('Folders', () => {
   });
 
   it('should delete a folder', async () => {
-    const output = execSync(`node deleteFolder.js ${bucketName} ${renamedFolderName}`);
+    const output = execSync(
+      `node deleteFolder.js ${bucketName} ${renamedFolderName}`
+    );
     assert.match(output, /Deleted folder:/);
     assert.match(output, new RegExp(renamedFolderName));
   });

--- a/storage-control/system-test/folders.test.js
+++ b/storage-control/system-test/folders.test.js
@@ -21,7 +21,7 @@ const uuid = require('uuid');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const bucketPrefix = `storage-control-samples-${uuid.v4()}`;
 const bucketName = `${bucketPrefix}-a`;
-const storage = new Storage();
+const storage = new Storage({projectId: process.env.GOOGLE_CLOUD_PROJECT});
 const bucket = new Bucket(storage, bucketName);
 const folderName = uuid.v4();
 const renamedFolderName = uuid.v4();
@@ -78,7 +78,7 @@ describe('Folders', () => {
   });
 
   // Skipping for now due to feature being allowlisted on project level.
-  it.skip('should delete a folder recursively', async () => {
+  it('should delete a folder recursively', async () => {
     const parentFolder = uuid.v4();
     const childFolder = `${parentFolder}/${uuid.v4()}`;
 

--- a/storage-control/system-test/folders.test.js
+++ b/storage-control/system-test/folders.test.js
@@ -59,25 +59,22 @@ describe('Folders', () => {
     assert.match(output, new RegExp(folderName));
   });
 
-  // Skipping for now due to operation not supporting custom billing projects.
-  it.skip('should rename a folder', async () => {
+  it('should rename a folder', async () => {
     const output = execSync(
       `node renameFolder.js ${bucketName} ${folderName} ${renamedFolderName}`
     );
     assert.match(
       output,
-      new RegExp(`Renamed folder ${folderName} ${renamedFolderName}.`)
+      new RegExp(`Renamed folder ${folderName} to ${renamedFolderName}.`)
     );
   });
 
   it('should delete a folder', async () => {
-    // Change folderName to renamedFolderName once the previous test is enabled.
-    const output = execSync(`node deleteFolder.js ${bucketName} ${folderName}`);
+    const output = execSync(`node deleteFolder.js ${bucketName} ${renamedFolderName}`);
     assert.match(output, /Deleted folder:/);
-    assert.match(output, new RegExp(folderName));
+    assert.match(output, new RegExp(renamedFolderName));
   });
 
-  // Skipping for now due to feature being allowlisted on project level.
   it('should delete a folder recursively', async () => {
     const parentFolder = uuid.v4();
     const childFolder = `${parentFolder}/${uuid.v4()}`;

--- a/storage-control/system-test/managedFolders.test.js
+++ b/storage-control/system-test/managedFolders.test.js
@@ -21,7 +21,7 @@ const uuid = require('uuid');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const bucketPrefix = `storage-control-samples-${uuid.v4()}`;
 const bucketName = `${bucketPrefix}-a`;
-const storage = new Storage();
+const storage = new Storage({projectId: process.env.GOOGLE_CLOUD_PROJECT});
 const bucket = new Bucket(storage, bucketName);
 const managedFolderName = uuid.v4();
 


### PR DESCRIPTION
Adds a Node.js code sample demonstrating hierarchical namespace recursive folder delete.

Fixes: b/530059535

[Generated-by: AI]