### PR TITLE
ci: fix undefined CAIP_PROJECT_ID by exporting secrets to GITHUB_ENV

### DIFF
--- a/.github/workflows/ai-platform-snippets.yaml
+++ b/.github/workflows/ai-platform-snippets.yaml
@@ -55,6 +55,10 @@ jobs:
         secrets: |-
           caip_id:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-caip-project-id
           location:nodejs-docs-samples-tests/nodejs-docs-samples-ai-platform-location
+    - name: Set environment variables
+      run: |
+        echo "CAIP_PROJECT_ID=${{ steps.secrets.outputs.caip_id }}" >> $GITHUB_ENV
+        echo "LOCATION=${{ steps.secrets.outputs.location }}" >> $GITHUB_ENV
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
         node-version: 16
@@ -78,5 +82,3 @@ jobs:
       run: make test dir=ai-platform/snippets
       env:
         GOOGLE_SAMPLES_PROJECT: "long-door-651"
-        LOCATION: ${{ steps.secrets.outputs.location }}
-        CAIP_PROJECT_ID: ${{ steps.secrets.outputs.caip_id }}


### PR DESCRIPTION
## Description
This PR fixes an issue where the `CAIP_PROJECT_ID` and `LOCATION` environment variables were evaluating as `undefined` during test execution in the `ai-platform-snippets` workflow. 

Although these variables were retrieved from Secret Manager, they were scoped exclusively to the `Run Tests` step. Because the test suite initializes and executes through multi-layered scripts (`make test`), the dynamically fetched secrets were losing context. 

To resolve this, an intermediate step has been added to explicitly export `CAIP_PROJECT_ID` and `LOCATION` directly to `$GITHUB_ENV`, making them globally accessible to the entire runner session—emulating the injection behavior seen in the `Setup Custard` action.

Fixes Internal: b/532613004

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
