### PR TITLE
ci: restrict credentialed Custard test job to trusted refs

### DIFF
--- a/.github/workflows/custard-run.yaml
+++ b/.github/workflows/custard-run.yaml
@@ -102,7 +102,19 @@ jobs:
           status: failure
 
   test:
-    if: needs.affected.outputs.paths != '[]'
+    # These tests authenticate to Google Cloud as the
+    # kokoro-system-test@long-door-651 service account and run repository code
+    # (make test -> npm install -> npm test), so they must only run on trusted
+    # refs. For workflow_run triggers, limit execution to same-repo branches.
+    # Pull requests from forks do not reach the service account credentials or
+    # execute their code in this privileged context; push (post-merge) and
+    # workflow_dispatch runs are unaffected. The legacy test job in
+    # custard-ci.yaml enforces the same boundary with
+    # `github.event.pull_request.head.repo.fork == false`.
+    if: >-
+      needs.affected.outputs.paths != '[]' &&
+      (github.event_name != 'workflow_run' ||
+      github.event.workflow_run.head_repository.full_name == github.repository)
     needs: affected
     runs-on: ubuntu-latest
     timeout-minutes: 120 # 2 hours hard limit


### PR DESCRIPTION
### What

Add a trust guard to the `test` job in `.github/workflows/custard-run.yaml` so it does not run repository code from forked pull requests while the `kokoro-system-test@long-door-651` service account credentials are configured.

### Why

`custard-run.yaml` is triggered by `workflow_run` (`Custard CI`, `types: [in_progress]`) and therefore runs in the base-repository context. The `test` job requests `id-token: write`, authenticates with `google-github-actions/auth`, and then runs `make test`, which runs `npm install` (repo root and the affected package) followed by `npm test`.

Its only condition today is `if: needs.affected.outputs.paths != '[]'`, with no check on where the triggering pull request came from. A pull request from a fork that adds a `package.json` marks a path as affected (`.github/config/nodejs.jsonc` sets `"package-file": ["package.json"]`), so the job runs, checks out the fork head commit (`ref: github.event.workflow_run.head_sha`), and executes the fork's npm lifecycle and test scripts. `google-github-actions/auth` defaults to `create_credentials_file: true` and `export_environment_variables: true`, so `GOOGLE_APPLICATION_CREDENTIALS` points at an impersonation credential for the service account before those scripts run. The result is fork-controlled code execution in the privileged context with access to the service account.

The legacy `test` job in `custard-ci.yaml` already refuses to run on forks (`github.event.pull_request.head.repo.fork == false`). This change applies the same trust boundary to the `workflow_run` job.

### Change

Run the credentialed `test` job only for trusted refs:

- `workflow_run` where the head repository equals this repository (same-repo branches)
- `push` (post-merge validation)
- `workflow_dispatch` (manual runs)

Fork pull requests continue to get lint and region-tag feedback from `custard-ci.yaml`, which runs in the unprivileged fork context without credentials. Integration tests that need the service account run once a maintainer lands the change on a branch in this repository or after merge.

### Alternative

If running integration tests on fork pull requests before merge is a requirement, the supported way to keep it is a GitHub Environment with required reviewers on this job, so every fork run pauses for an explicit per-run approval that is not skipped for returning contributors. That needs repository settings in addition to workflow changes, so it is out of scope for this PR. Happy to follow up if preferred.

### Related, not in this PR

The `lint` job in `custard-run.yaml` also checks out the head commit and runs `npm install` in the base context, though with only `statuses: write` and no service account. `custard-ci.yaml` already lints forked pull requests in the unprivileged context, so that job could later move out of the privileged workflow. Left out here to keep this change minimal.

Reported through the Google OSS VRP.
