### PR TITLE
fix(genai): ensure resource cleanup and fix async execution in content-cache tests

### DIFF
--- a/genai/content-cache/test/content-cache-create-use-update-delete.test.js
+++ b/genai/content-cache/test/content-cache-create-use-update-delete.test.js
@@ -30,8 +30,8 @@ describe('content-cache-create-use-update-delete', function () {
   this.retries(5);
   let contentCacheName;
 
-  before(async function () {
-    await delay(this.test);
+  beforeEach(async function () {
+    await delay(this.currentTest);
   });
 
   after(async () => {

--- a/genai/content-cache/test/content-cache-create-use-update-delete.test.js
+++ b/genai/content-cache/test/content-cache-create-use-update-delete.test.js
@@ -25,12 +25,31 @@ const updateSample = require('../content-cache-update.js');
 const deleteSample = require('../content-cache-delete.js');
 const {delay} = require('../../test/util');
 
-describe('content-cache-create-use-update-delete', async function () {
+describe('content-cache-create-use-update-delete', function () {
   this.timeout(600000);
   this.retries(5);
-  await delay(this.test);
-
   let contentCacheName;
+
+  before(async function () {
+    await delay(this.test);
+  });
+
+  after(async () => {
+    if (contentCacheName) {
+      try {
+        await deleteSample.deleteContentCache(
+          projectId,
+          undefined,
+          contentCacheName
+        );
+      } catch (err) {
+        console.error(
+          `Failed to delete content cache ${contentCacheName}:`,
+          err
+        );
+      }
+    }
+  });
 
   it('should create content cache', async () => {
     contentCacheName = await createSample.generateContentCache(projectId);
@@ -61,5 +80,6 @@ describe('content-cache-create-use-update-delete', async function () {
       undefined,
       contentCacheName
     );
+    contentCacheName = undefined;
   });
 });


### PR DESCRIPTION

## Description
This PR fixes several execution and lifecycle issues in the `genai/content-cache` tests. 

Previously, the tests had the following issues:
1. **Skipped executions:** The `describe` block was marked as `async`, which is not supported by Mocha and caused the suite to exit early or register `0 passing` tests.
2. **Broken retry delays:** The retry delay function was placed inside a `before` hook. Since `before` only runs once per suite, test retries were not getting the intended backoff delay.
3. **Orphaned resources:** If a test failed in the middle of the suite (e.g., during update or use), the delete test was never reached, leaving orphaned caches in the GCP project.

Fixes Internal: b/548501421

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
