### PR TITLE
ci(storagetransfer): update Node.js version to 20

### DIFF
--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -53,7 +53,7 @@ jobs:
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@e5bb06c2ca53b244f978d33348d18317a7f263ce' # v2.0.0
+      uses: 'google-github-actions/get-secretmanager-secrets@e5bb06c2ca53b244f978d33348d18317a7f263ce' # v2.2.2
       with:
         secrets: |-
           sts_aws_secret:nodejs-docs-samples-tests/nodejs-docs-samples-storagetransfer-aws

--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -53,7 +53,7 @@ jobs:
         create_credentials_file: 'true'
         access_token_lifetime: 600s
     - id: secrets
-      uses: 'google-github-actions/get-secretmanager-secrets@e5bb06c2ca53b244f978d33348d18317a7f263ce' # v2
+      uses: 'google-github-actions/get-secretmanager-secrets@e5bb06c2ca53b244f978d33348d18317a7f263ce' # v2.0.0
       with:
         secrets: |-
           sts_aws_secret:nodejs-docs-samples-tests/nodejs-docs-samples-storagetransfer-aws
@@ -65,7 +65,7 @@ jobs:
       id: npm-cache-dir
       shell: bash
       run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflows/storagetransfer.yaml
+++ b/.github/workflows/storagetransfer.yaml
@@ -60,7 +60,7 @@ jobs:
           sts_azure_secret:nodejs-docs-samples-tests/nodejs-docs-samples-storagetransfer-azure
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
-        node-version: 16
+        node-version: 20
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash


### PR DESCRIPTION
## Description
Update the Node.js version from 16 to 20 in the `storagetransfer` GitHub Actions workflow.

## Context
This PR updates the `actions/setup-node` step in the `storagetransfer.yaml` workflow to use Node.js 20. This change aligns this workflow with the rest of the repository's CI pipelines to maintain consistency. Additionally, upgrading allows us to take advantage of the latest features, security updates, and performance improvements available in Node.js 20.

Fixes Internal: b/549796667

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [x] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
