### PR TITLE
chore(ci): upgrade Node.js version from 16 to 20 in workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
         access_token_lifetime: 600s
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
-        node-version: 16
+        node-version: 20
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
-    - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.2.4
+    - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
         node-version: 20
     - name: Get npm cache directory

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
       id: npm-cache-dir
       shell: bash
       run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -61,11 +61,11 @@ jobs:
       env:
         SUITE_NAME: ${{ inputs.name }}
       run: |
-        echo "MOCHA_REPORTER_SUITENAME=${{SUITE_NAME}}" >> $GITHUB_ENV
+        echo "MOCHA_REPORTER_SUITENAME=${SUITE_NAME}" >> $GITHUB_ENV
         echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
     - name: Run Tests
       env:
         GOOGLE_SAMPLES_PROJECT: "long-door-651"
         SAMPLE_PATH: ${{ inputs.path }}
-      run: make test dir=${{SAMPLE_PATH}}
+      run: make test dir="${SAMPLE_PATH}"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
         service_account: 'kokoro-system-test@long-door-651.iam.gserviceaccount.com'
         create_credentials_file: 'true'
         access_token_lifetime: 600s
-    - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+    - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.2.4
       with:
         node-version: 20
     - name: Get npm cache directory
@@ -58,10 +58,14 @@ jobs:
       run: echo "MOCHA_REPORTER_OUTPUT=${{github.run_id}}_sponge_log.xml" >> $GITHUB_ENV
     - name: set testing env vars for scheduled run
       if: github.event.action == 'schedule'
+      env:
+        SUITE_NAME: ${{ inputs.name }}
       run: |
-        echo "MOCHA_REPORTER_SUITENAME=${{ inputs.name }}" >> $GITHUB_ENV
+        echo "MOCHA_REPORTER_SUITENAME=${{SUITE_NAME}}" >> $GITHUB_ENV
         echo "MOCHA_REPORTER=xunit" >> $GITHUB_ENV
     - name: Run Tests
-      run: make test dir=${{ inputs.path }}
       env:
         GOOGLE_SAMPLES_PROJECT: "long-door-651"
+        SAMPLE_PATH: ${{ inputs.path }}
+      run: make test dir=${{SAMPLE_PATH}}
+


### PR DESCRIPTION
## Description
- Upgrades Node.js runtime target from 16 to 20 in CI test workflow configurations (`.github/workflows/test-sample.yml`).
- Fixes `zizmor/template-injection` security warnings by routing workflow `inputs` (`name` and `path`) through intermediate environment variables before executing shell commands.

Fixes Internal: b/553550396

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed guidelines from [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md) and [Samples Style Guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] **Tests** pass:   `npm test` (see [Testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#run-the-tests-for-a-single-sample))
- [x] **Lint** pass:   `npm run lint` (see [Style](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#style))
- [ ] **Required CI tests** pass (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This pull request is from a branch created directly off of `GoogleCloudPlatform/nodejs-docs-samples`. Not a fork.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new sample directory, and I created [GitHub Actions workflow](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#adding-new-samples) for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved

> **Note**: Any check with `(dev)`, `(experimental)`, or `(legacy)` can be ignored and should **not block** your PR from merging (see [CI testing](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/main/CONTRIBUTING.md#ci-testing)).
